### PR TITLE
Fix for issue #148: 'OSError: [Errno 22] Invalid argument' when gevent.subprocess.Popen() fails repeatedly

### DIFF
--- a/gevent/subprocess.py
+++ b/gevent/subprocess.py
@@ -689,6 +689,8 @@ class Popen(object):
                                                                    tb)
                             exc_value.child_traceback = ''.join(exc_lines)
                             os.write(errpipe_write, pickle.dumps(exc_value))
+                        finally:
+                            os._exit(255)
 
                         # This exitcode won't be reported to applications, so it
                         # really doesn't matter what we return.
@@ -714,7 +716,7 @@ class Popen(object):
                 # Wait for exec to fail or succeed; possibly raising exception
                 # Exception limited to 1M
                 errpipe_read = FileObject(errpipe_read, 'rb')
-                data = errpipe_read.read(1048576)
+                data = errpipe_read.read()
             finally:
                 if hasattr(errpipe_read, 'close'):
                     errpipe_read.close()


### PR DESCRIPTION
Here is my second attempt for this pull request with all changes in a single commit:

Add a "finally" clause with os._exit(255) in the "Child" block to make sure that the child exits without executing any unintended code if t

Fixed issue #148: 'OSError: [Errno 22] Invalid argument' when gevent.subprocess.Popen() fails repeatedly.
