### PR TITLE
Fix for Issue #155 -- gevent.os.posix_read/posix_write don't honor non-blocking FD's

### DIFF
--- a/gevent/os.py
+++ b/gevent/os.py
@@ -48,12 +48,15 @@ def posix_read(fd, n):
     hub, event = None, None
     while True:
         flags = _map_errors(fcntl.fcntl, fd, fcntl.F_GETFL, 0)
-        if not flags & os.O_NONBLOCK:
+        already_nonblock = bool(flags & os.O_NONBLOCK)
+        if not already_nonblock:
             _map_errors(fcntl.fcntl, fd, fcntl.F_SETFL, flags|os.O_NONBLOCK)
         try:
             return _read(fd, n)
         except OSError, e:
             if e.errno not in ignored_errors:
+                raise
+            if e.errno == EAGAIN and already_nonblock:
                 raise
             sys.exc_clear()
         finally:
@@ -62,7 +65,7 @@ def posix_read(fd, n):
             # (e.g. when using ttys/ptys). Those other file descriptors are
             # impacted by our change of flags, so we should restore them
             # before any other code can possibly run.
-            if not flags & os.O_NONBLOCK:
+            if not already_nonblock:
                 _map_errors(fcntl.fcntl, fd, fcntl.F_SETFL, flags)
         if hub is None:
             hub = get_hub()
@@ -76,17 +79,20 @@ def posix_write(fd, buf):
     hub, event = None, None
     while True:
         flags = _map_errors(fcntl.fcntl, fd, fcntl.F_GETFL, 0)
-        if not flags & os.O_NONBLOCK:
+        already_nonblock = bool(flags & os.O_NONBLOCK)
+        if not already_nonblock:
             _map_errors(fcntl.fcntl, fd, fcntl.F_SETFL, flags|os.O_NONBLOCK)
         try:
             return _write(fd, buf)
         except OSError, e:
             if e.errno not in ignored_errors:
                 raise
+            if e.errno == EAGAIN and already_nonblock:
+                raise
             sys.exc_clear()
         finally:
             # See note in posix_read().
-            if not flags & os.O_NONBLOCK:
+            if not already_nonblock:
                 _map_errors(fcntl.fcntl, fd, fcntl.F_SETFL, flags)
         if hub is None:
             hub = get_hub()


### PR DESCRIPTION
Here is my second attempt to submit a fix for issue #155, this time all in a single commit:

Fixed Issue #155 -- gevent.os.posix_read/posix_write don't honor non-blocking FD's.
Implemented unit tests in test__os.py: test_o_nonblock_read() and test_o_nonblock_write().
