### PR TITLE
Fixes for issues #147 and #146

### DIFF
--- a/greentest/test__fileobject.py
+++ b/greentest/test__fileobject.py
@@ -3,6 +3,16 @@ import greentest
 import gevent
 from gevent.fileobject import FileObject, FileObjectThread
 
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    
+try:
+    import errno
+except ImportError:
+    errno = None
+
 
 class Test(greentest.TestCase):
 
@@ -36,6 +46,110 @@ class Test(greentest.TestCase):
             del s
             os.close(w)
             self.assertEqual(FileObject(r).read(), 'x')
+        
+        def test_EBADF_from_read_with_fd_closed(self):
+            if fcntl is None or errno is None:
+                return
+            
+            r, w = os.pipe()
+            rfile = FileObject(r, 'r', close=False)
+            os.close(r)
+            try:
+                data = rfile.read()
+            except OSError, e:
+                if e.errno != errno.EBADF:
+                    raise
+            else:
+                raise AssertionError('FileObject.read with closed fd must fail with EBADF')
+            
+            os.close(w)
+            del rfile
+            
+            # Test when fd is closed during hub switch in read
+            r, w = os.pipe()
+            rfile = FileObject(r, 'r', close=False)
+            # set nbytes such that for sure it is > maximum pipe buffer
+            def close_fd(fd):
+                os.close(fd)
+            
+            g = gevent.spawn(close_fd, fd=r)
+            try:
+                data = rfile.read()
+            except OSError, e:
+                if e.errno != errno.EBADF:
+                    raise
+            else:
+                raise AssertionError('FileObject.read with closed fd must fail with EBADF')
+            g.get()
+            
+                
+        def test_fcntl_flags_preserved(self):
+            if fcntl is None:
+                return
+            r, w = os.pipe()
+            # duplicate fd's share the original's flags
+            rdup = os.dup(r)
+            wdup = os.dup(w)
+            
+            # Test that flags are preserved after read/write return
+            rflags = fcntl.fcntl(r, fcntl.F_GETFL, 0)
+            rdupflags = fcntl.fcntl(rdup, fcntl.F_GETFL, 0)
+            self.assertEqual(rflags, rdupflags)
+            
+            wflags = fcntl.fcntl(w, fcntl.F_GETFL, 0)
+            wdupflags = fcntl.fcntl(wdup, fcntl.F_GETFL, 0)
+            self.assertEqual(wflags, wdupflags)
+            
+            rfile = FileObject(r, 'r', restore_flags=True)
+            self.assertEqual(fcntl.fcntl(r, fcntl.F_GETFL, 0), rflags)
+            wfile = FileObject(w, 'w', restore_flags=True)
+            self.assertEqual(fcntl.fcntl(w, fcntl.F_GETFL, 0), wflags)
+            
+            wfile.write("foo")
+            wfile.flush()
+            self.assertEqual(fcntl.fcntl(w, fcntl.F_GETFL, 0), wflags)
+            data = rfile.read(3)
+            self.assertEqual(data, "foo")
+            self.assertEqual(fcntl.fcntl(r, fcntl.F_GETFL, 0), rflags)
+            
+            # Test that write-end flags are preserved during hub switch in write
+            # set nbytes such that for sure it is > maximum pipe buffer
+            nbytes = 1000000
+            def consume(f):
+                wflags_at_start = fcntl.fcntl(w, fcntl.F_GETFL, 0)
+                data = f.read(nbytes)
+                self.assertEqual(len(data), nbytes)
+                self.assertEqual(wflags_at_start, wflags)
+                self.assertEqual(fcntl.fcntl(w, fcntl.F_GETFL, 0), wflags)
+                self.assertEqual(fcntl.fcntl(r, fcntl.F_GETFL, 0), rflags)
+            
+            g = gevent.spawn(consume, f=rfile)
+            wfile.write("d" * nbytes)
+            wfile.flush()
+            g.get()
+            del g
+            
+            # Test that read-end flags are preserved during hub switch in read
+            def produce(f):
+                rflags_at_start = fcntl.fcntl(r, fcntl.F_GETFL, 0)
+                f.write("d" * nbytes)
+                f.flush()
+                self.assertEqual(rflags_at_start, rflags)
+                self.assertEqual(fcntl.fcntl(r, fcntl.F_GETFL, 0), rflags)
+                self.assertEqual(fcntl.fcntl(w, fcntl.F_GETFL, 0), wflags)
+            
+            g = gevent.spawn(produce, f=wfile)
+            data = rfile.read(nbytes)
+            self.assertEqual(len(data), nbytes)
+            g.get()
+            del g
+            
+            # Test that flags are preserved after destruction of FileObjects
+            del rfile
+            self.assertEqual(fcntl.fcntl(rdup, fcntl.F_GETFL, 0), rdupflags)
+            del wfile
+            self.assertEqual(fcntl.fcntl(wdup, fcntl.F_GETFL, 0), wdupflags)
+            
 
     def test_newlines(self):
         r, w = os.pipe()
@@ -46,6 +160,41 @@ class Test(greentest.TestCase):
             self.assertEqual('line1\nline2\nline3\nline4\nline5\nline6', result)
         finally:
             g.kill()
+    
+    def test_newlines_only_in_small_read_chunks(self):
+        r, w = os.pipe()
+        r = FileObject(r, "rbU", bufsize=1)
+        w = FileObject(w, "wb")
+      
+        def read(r):
+          all_received_data = ""
+          
+          while True:
+            data = r.read(1)
+            if not data:
+              break
+            all_received_data += data
+            
+          return all_received_data
+        
+        reader_greenlet = gevent.spawn(read, r)
+        
+        data = "\n\r" * 2
+        w.write(data)
+        w.close()
+        
+        all_received_data = reader_greenlet.get()
+        
+        total_bytes_read = len(all_received_data)
+        total_bytes_expected = (len(data)/2) + data.startswith("\n")
+        
+        self.assertEqual(total_bytes_read, total_bytes_expected,
+                         msg="read %d bytes, expected=%d bytes" % (
+                            total_bytes_read, total_bytes_expected))
+        
+        self.assertTrue(all((c == "\n") for c in all_received_data),
+                        msg=("Expected only newlines, but got a combination of "
+                             "these chars: %r") % (set(all_received_data),))
 
 
 def writer(fobj, line):


### PR DESCRIPTION
Fixed issue #147 ("FileObject(stdin) causes os.write on stdout to fail with OSError: [Errno 35]
Resource temporarily unavailable") by adding an optional arg restore_flags to FileObjectPosix
constructor.  This enables an efficient default case (restore_flags=False, such as FileObject's
use in gevent.subprocess.Popen), while enabling FileObjectPosix to also be used for stdin, etc.
without causing unexpected failures in stdout I/O. Implemented test_fcntl_flags_preserved() in
test__fileobject.py.

Fixed issue #146 ("FileObject incorrectly reports end of file when file descriptor is closed
prematurely"). NOTE: this was fixed in teh same commit as #147 due to rewrite in the same block
of code. Implemented test_EBADF_from_read_with_fd_closed() in test__fileobject.py.

Implemented additional fileobject test: test_newlines_only_in_small_read_chunks()

Fixed lost data in my pull request changes when self.recv is called recursively.
Removed my TODO from the pull request about possibly deep recursion and need for yield -- I was wrong about that.
