### PR TITLE
small fixups for gevent_call

### DIFF
--- a/gevent/callbacks.c
+++ b/gevent/callbacks.c
@@ -49,6 +49,7 @@ static CYTHON_INLINE void gevent_check_signals(struct PyGeventLoopObject* loop) 
 #define GIL_ENSURE  ___save = PyGILState_Ensure();
 #define GIL_RELEASE  PyGILState_Release(___save);
 #else
+#define GIL_DECLARE
 #define GIL_ENSURE
 #define GIL_RELEASE
 #endif


### PR DESCRIPTION
Here are a few simple fixes to the GIL locking.

I'm a bit rusty with my python C, let me know if I'm just misunderstanding anything.
