### PR TITLE
Remove redundant assignment of sys.exc_clear

### DIFF
--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -190,13 +190,6 @@ def set_hub(hub):
     _threadlocal.hub = hub
 
 
-if sys.version_info[0] >= 3:
-    def exc_clear():
-        pass
-else:
-    exc_clear = sys.exc_clear
-
-
 def _import(path):
     if isinstance(path, list):
         if not path:


### PR DESCRIPTION
Since the use of it was [removed](https://github.com/SiteSupport/gevent/commit/554ed446db75ed6b15f277ccc0094140d2b03e88)
