### PR TITLE
`os.tp_write()` returns None instead of raising OSError. 

### DIFF
--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -248,7 +248,7 @@ class Hub(greenlet):
     It is created automatically by :func:`get_hub`.
     """
 
-    SYSTEM_ERROR = (KeyboardInterrupt, SystemExit, SystemError)
+    SYSTEM_ERROR = (KeyboardInterrupt, SystemExit, SystemError, OSError)
     NOT_ERROR = (GreenletExit, SystemExit)
     loop_class = config('gevent.core.loop', 'GEVENT_LOOP')
     resolver_class = ['gevent.resolver_thread.Resolver',


### PR DESCRIPTION
The `gevent.os.tp_write()` function currently does not behave like the native `os.write()` in the sense that it can return `None` and that it swallows exceptions.

Example code:

``` python
import os
import sys
import gevent.os


r, w = os.pipe()
os.close(r)
try:
    r = os.write(w, "a")
except OSError:
    print "Huh, catched!"


r, w = os.pipe()
os.close(r)
try:
    r = gevent.os.tp_write(w, "a")
except OSError:
    sys.exit()
print "not catched :( -- r: %s" % r
```

In the latter case, an exception is raised in the thread executing the actual write. However, it is not re-raised in the parent. Can we do that? Looking into the source of the threadpool, it looks like the infrastructure for propagating exception information between threads is available.

`gevent.os.tp_write()` should only return integers or raise an exception. I do not like to work around the current behavior by checking for return value  `None`.
