### PR TITLE
Patches WSGI unicode responses

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -387,6 +387,8 @@ class WSGIHandler(object):
 
             towrite.extend('\r\n')
             if data:
+                if isinstance(data, unicode):
+                    data = data.encode('utf-8')
                 if self.response_use_chunked:
                     ## Write the chunked encoding
                     towrite.extend("%x\r\n%s\r\n" % (len(data), data))


### PR DESCRIPTION
Python `bytearray`s cannot extend unicode objects; a type error is raised. 

This patch coerces the data into utf-8 in the case where the application
returns a unicode string. There may be other areas that should be addressed to ensure the proper encoding is used.
