### PR TITLE
Fix parallel build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gevent/gevent.core.c: gevent/core.ppyx gevent/libev.pxd
 	echo '#include "callbacks.c"' >> gevent.core.c
 	mv gevent.core.* gevent/
 
-gevent/gevent.ares.c: gevent/ares.pyx gevent/core.pyx gevent/*.pxd
+gevent/gevent.ares.c: gevent/ares.pyx gevent/*.pxd
 	$(CYTHON) -o gevent.ares.c gevent/ares.pyx
 	mv gevent.ares.* gevent/
 


### PR DESCRIPTION
Fix #193.
Cython only check for .pxd files when compiling .pyx files AFAIK.
The dependency between targets is still not perfect (i.e. if you remove gevent/gevent.*.h, they will not be re-generated), which require some extra dirty hacks in Makefile to fix. Since the problem exists before this change and it doesn't matter that much (unless someone manually remove some files) that you probably don't care, this fix should be enough now for parallel build.
