### PR TITLE
Fix Hub.destroy(): replace self._threadpool.close() with self._threadpool.kill()

### DIFF
--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -405,7 +405,7 @@ class Hub(greenlet):
             self._resolver.close()
             del self._resolver
         if self._threadpool is not None:
-            self._threadpool.close()
+            self._threadpool.kill()
             del self._threadpool
         if destroy_loop is None:
             destroy_loop = not self.loop.default


### PR DESCRIPTION
Hello,

[Ken Chatfield](http://www.robots.ox.ac.uk/~ken/) found a bug in `gevent/hub.py` when using gevent's WSGIServer together with [gipc](http://pypi.python.org/pypi/gipc). I have created a repro:

```
import gevent
h = gevent.get_hub()
tp = h.threadpool
h.destroy()
```

resulting in

```
Traceback (most recent call last):
  File "repro.py", line 5, in <module>
    h.destroy()
  File "gevent/hub.py", line 408, in destroy
    self._threadpool.close()
AttributeError: 'ThreadPool' object has no attribute 'close'
```

I grepped through gevent's repo and it looks like `Hub.destroy()` is the only place in gevent where `ThreadPool.close()` is erroneously called.

In this pull request, I have
- replaced `self._threadpool.close()` in `Hub.destroy()` with `self._threadpool.kill()`. Looks like this is the first time `ThreadPool.kill()` is applied. This change does not have a negative impact on current gevent unit tests.
- added a new unit test for the repro above.
