### PR TITLE
Re-use gevent.core.loop instance after hub destruction without loop destruction.

### DIFF
--- a/greentest/test__destroy.py
+++ b/greentest/test__destroy.py
@@ -1,22 +1,40 @@
 import gevent
+
 # Loop of initial Hub is default loop.
 hub = gevent.get_hub()
 assert hub.loop.default, hub
 
-# Destroy hub. Does not destroy default loop if not explicitly told to.
+# Save `gevent.core.loop` object for later comparison.
+initloop = hub.loop
+
+# Increase test complexity via threadpool creation.
+# Implicitly creates fork watcher connected to the current event loop.
+tp = hub.threadpool
+
+# Destroy hub. Does not destroy libev default loop if not explicitly told to.
 hub.destroy()
+
+# Create new hub. Must re-use existing libev default loop.
 hub = gevent.get_hub()
 assert hub.loop.default, hub
 
+# Ensure that loop object is identical to the initial one.
+assert hub.loop is initloop
+
 # Destroy hub including default loop.
 hub.destroy(destroy_loop=True)
+
 # Create new hub and explicitly request creation of a new default loop.
 hub = gevent.get_hub(default=True)
 assert hub.loop.default, hub
 
-# Destroy hub including default loop.
+# `gevent.core.loop` objects as well as libev loop pointers must differ.
+assert hub.loop is not initloop
+assert hub.loop.ptr != initloop.ptr
+
+# Destroy hub including default loop, create new hub with non-default loop.
 hub.destroy(destroy_loop=True)
-# Create new non-default loop in new hub.
 hub = gevent.get_hub()
 assert not hub.loop.default, hub
+
 hub.destroy()


### PR DESCRIPTION
This pull request solves issue #237. 

Currently, gevent may create multiple `gevent.core.loop` instances representing the same libev event loop. This can provoke a segmentation fault during garbage collection or during manual destruction of these loop instances: after the first of these instances has destroyed the event loop via libev's `ev_loop_destroy()`, the loop pointers of the other instances representing the same libev loop are invalid. The next API call referring to the already destroyed loop (which occurs latest during program exit) will result in segfault.

I believe the most straight-forward solution to this problem is to not allow the creation of multiple `gevent.core.loop` instances representing the same libev event loop via gevent API. The most important (only?) place to ensure this is the `gevent.core.loop` creation in hub.py. This pull request

- makes gevent temporarily store  `hub.loop` during hub destruction and re-use it upon the next hub creation (only if the loop isn't requested to be destroyed, too).
- consolidates the tests in `test__destroy.py` (more detail and complexity, more explanation)

Note that the new unit test will fail as long as `hub.py` erroneously calls `ThreadPool.close()` during `Hub.destroy()` (tackled in pull request #235).






