### PR TITLE
Fix segfault upon calling __repr__() of destroyed loop.

### DIFF
--- a/gevent/core.ppyx
+++ b/gevent/core.ppyx
@@ -461,6 +461,8 @@ cdef public class loop [object PyGeventLoopObject, type PyGeventLoop_Type]:
         return cb
 
     def _format(self):
+        if self._ptr == NULL:
+            return 'destroyed'    
         cdef object msg = self.backend
         if self.default:
             msg += ' default'


### PR DESCRIPTION
Currently, 

``` python
import gevent
h = gevent.get_hub()
loop = h.loop
print loop
h.destroy(destroy_loop=True)
print loop
```

makes the program crash with segmentation fault upon the last `print loop` statement. This is because the `__repr__()` method of a destroyed loop makes libev API calls with a previously invalidated event loop pointer.

When the loop object is still bound to a name, then  `_ptr == NULL` means that the loop has been destroyed (`_ptr` is only set to `NULL` upon destruction and deallocation). This relation is used by the patch. It makes the above code print

```
<loop at 0x7fd689f135f0 epoll default pending=0 ref=0 fileno=3>
<loop at 0x7fd689f135f0 destroyed>
```

I see that the repro code is quite an edge case. Nevertheless, I hit this issue when playing with loop creation/destruction and printing debug information. When a Python object is in the namespace, the program definitely should not crash when trying to `print` this object.
