### PR TITLE
	 update pywsig.py, allow http get request has body

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -247,7 +247,7 @@ class WSGIHandler(object):
             if content_length < 0:
                 self.log_error('Invalid Content-Length: %r', content_length)
                 return
-            if content_length and self.command in ('HEAD'):
+            if content_length and self.command in ('HEAD', ):
                 self.log_error('Unexpected Content-Length')
                 return
 


### PR DESCRIPTION
Allow request message-body in GET.
I Don't found some description in RFC (http://www.w3.org/Protocols/rfc2616/rfc2616.html)
In theory, GET request has body should not return error 400
Thanks.
