### PR TITLE
allow to silence error reporting for certain 'expected exceptions'

### DIFF
--- a/gevent/greenlet.py
+++ b/gevent/greenlet.py
@@ -71,6 +71,11 @@ class FailureSpawnedLink(SpawnedLink):
 class Greenlet(greenlet):
     """A light-weight cooperatively-scheduled execution unit."""
 
+    # set this to a tuple of exception classes to prevent a traceback
+    # from being printed when the greenlet exits with by raising one
+    # of these exceptions
+    expected_exceptions = (GreenletExit, SystemExit)
+
     def __init__(self, run=None, *args, **kwargs):
         hub = get_hub()
         greenlet.__init__(self, parent=hub)

--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -289,7 +289,8 @@ class Hub(greenlet):
         return result + '>'
 
     def handle_error(self, context, type, value, tb):
-        if not issubclass(type, self.NOT_ERROR):
+        expected_exceptions = getattr(context, "expected_exceptions", self.NOT_ERROR)
+        if not issubclass(type, expected_exceptions):
             self.print_exception(context, type, value, tb)
         if context is None or issubclass(type, self.SYSTEM_ERROR):
             self.handle_system_error(type, value)


### PR DESCRIPTION
gevent prints a error report including a traceback for each failed
greenlet. this is at times useful, but you're currently forced to
either handle exceptions in those greenlets or live with the traceback
on stderr.

this change introduces a class variable 'expected_exceptions' to
gevent's greenlet class. This is a tuple of exceptions for which no
error report should be printed to stderr.

This can be set in a custom greenlet subclass, or even at runtime like
in:

,----
| from gevent import spawn, getcurrent
|
| def divide():
|     getcurrent().expected_exceptions += (ZeroDivisionError,)
|     1/0
|
| spawn(divide).join()
`----
