### PR TITLE
Ignore generated egg-info directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 *.so
 gevent.*.[ch]
 gevent/core.pyx
+*.egg-info
+


### PR DESCRIPTION
I'm using gevent as a submodule in git and git always reports it as having modified content so I added the egg-info directory to .gitignore.
