### PR TITLE
Update pywsgi.py

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -195,7 +195,8 @@ class WSGIHandler(object):
         finally:
             if self.socket is not None:
                 try:
-                    self.socket._sock.close()  # do not rely on garbage collection
+#                    self.socket._sock.close()  # do not rely on garbage collection
+#     for SSL connections, with _sock wrapped by OpenSSL, must not close FD till ready
                     self.socket.close()
                 except socket.error:
                     pass


### PR DESCRIPTION
Was getting SSL3 errors from clients with PyOpenSSL wrapping sockets.  Commenting out this line (which shouldn't be needed in CPython anyways) fixes it - the SSL library needs to send and receive shutdown segments.  