### PR TITLE
fix local unix socket logging failure to get requestor hostname/ip

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -467,7 +467,7 @@ class WSGIHandler(object):
         else:
             delta = '-'
         return '%s - - [%s] "%s" %s %s %s' % (
-            self.client_address[0],
+			"UNIX_SOCKET" if self.client_address is None or len(self.client_address) == 0 else self.client_address[0],
             now,
             self.requestline,
             (getattr(self, 'status', None) or '000').split()[0],


### PR DESCRIPTION
## Problem

Receive error when logging a request. This is due to the backing IPC being a UNIX socket passed in via wsgi.WSGIServer(sock, wsgi_application, spawn=None).serve_forever()

The attached pull request substitutes the requestor ip address with UNIX_SOCKET when the above case is encountered. It might nicer to substitute the unix socket path, if possible.
## Recreate
- django (can modify the gevent python script to do without)
- nginx proxy_pass
  
  <pre>
  location / {
      proxy_pass_header Server;
      proxy_set_header Host $http_host;
      proxy_redirect off;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Scheme $scheme;
      proxy_connect_timeout 10;
      proxy_read_timeout 10;
      #proxy_pass http://localhost:8000/;
      proxy_pass http://unix:/tmp/server.sock;
  }
  </pre>
- gevent

``` python
#!/usr/bin/python

import sys, os

from gevent import wsgi
from gevent import socket
from gevent import monkey
#from pong import application

sys.stdout = sys.stderr

# Just in case
monkey.patch_all()

import pwd

# Get this so we can chown/chgrp the socket and let nginx read it
pe = pwd.getpwnam('www-data')

SOCK = '/var/www/django_pestermypet/server.sock'

sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
try:
    os.remove(SOCK)
except OSError:
    pass
sock.bind(SOCK)
os.chown(SOCK, pe.pw_uid, pe.pw_gid)
os.chmod(SOCK,0770)
sock.listen(256)

import django.core.handlers.wsgi
application = django.core.handlers.wsgi.WSGIHandler()

# Set up for Django
sys.path.insert(0,'/var/www/django_pestermypet/')
os.environ['DJANGO_SETTINGS_MODULE'] = 'django_pestermypet.settings'

wsgi.WSGIServer(sock, application, spawn=None).serve_forever()
```
## Trace

<pre>
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/baseserver.py", line 159, in _do_read
    self.do_handle(*args)
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/baseserver.py", line 130, in do_handle
    self._handle(*args)
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 654, in handle
    handler.handle()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 184, in handle
    result = self.handle_one_request()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 316, in handle_one_request
    self.handle_one_response()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 514, in handle_one_response
    self.log_request()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 460, in log_request
    log.write(self.format_request() + '\n')
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0dev-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 472, in format_request
    self.client_address[0] if self.client_address is not None else "",
IndexError: string index out of range
(('',),
 <WSGIServer at 0x2d63390 fileno=5 address=/var/www/django_pestermypet/server.sock>) failed with IndexError
</pre>
