### PR TITLE
Properly handle HTTP versions in pywsgi

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -381,7 +381,7 @@ class WSGIHandler(object):
             self.headers_sent = True
             self.finalize_headers()
 
-            towrite.extend('%s %s\r\n' % (self.request_version, self.status))
+            towrite.extend('HTTP/1.1 %s\r\n' % self.status)
             for header in self.response_headers:
                 towrite.extend('%s: %s\r\n' % header)
 


### PR DESCRIPTION
There's no way for a WSGI application to discover the HTTP version used in the request, since the WSGIHandler is setting environ["SERVER_PROTOCOL"] to an hard-coded "HTTP/1.0". This patch fixes it, and also makes the server declare support for HTTP/1.1 in its responses, as the specification requires.

Issue https://github.com/surfly/gevent/issues/79 is related, but this patch seems a better fix than the one proposed there.

See also:
http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.1
http://www.ietf.org/rfc/rfc2145.txt (section 2.3, fourth paragraph)
