### PR TITLE
Fix request logging for AF_UNIX sockets

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -467,7 +467,7 @@ class WSGIHandler(object):
         else:
             delta = '-'
         return '%s - - [%s] "%s" %s %s %s' % (
-            self.client_address[0],
+            self.client_address[0] if isinstance(self.client_address, tuple) else self.client_address,
             now,
             self.requestline,
             (getattr(self, 'status', None) or '000').split()[0],


### PR DESCRIPTION
This takes non-tuple `client_address` into account in `format_request()` (fixes #299)
