### PR TITLE
fix version number

### DIFF
--- a/gevent/__init__.py
+++ b/gevent/__init__.py
@@ -8,8 +8,8 @@ See http://www.gevent.org/ for the documentation.
 
 from __future__ import absolute_import
 
-version_info = (1, 0, 0, 'rc2', None)
-__version__ = '1.0rc2'
+version_info = (1, 0, 0, 'rc3', None)
+__version__ = '1.0rc3'
 
 
 __all__ = ['get_hub',


### PR DESCRIPTION
some packages, e.g. [pyramid_sockjs](https://pypi.python.org/pypi/pyramid_sockjs/0.3.9), already [depend](https://github.com/fafhrd91/pyramid_sockjs/blob/3db3071ed7e4e4e9013f82fb3cabff6756a3bf68/setup.py#L11) on `gevent >= 1.0rc2`, but according to `pkg_resources` version `1.0dev` doesn't meet that requirement:

``` python
>>> from pkg_resources import parse_version
>>> parse_version('1.0dev') >= parse_version('1.0rc2')
False
```
