### PR TITLE
Fixed WindowsError 183 when installing on Windows

### DIFF
--- a/util/cythonpp.py
+++ b/util/cythonpp.py
@@ -516,7 +516,9 @@ def atomic_write(filename, data):
     f.flush()
     os.fsync(f.fileno())
     f.close()
+    os.rename(filename, filename + '.bak')
     os.rename(tmpname, filename)
+    os.unlink(filename + '.bak')
     dbg('Wrote %s bytes to %s', len(data), filename)
 
 


### PR DESCRIPTION
When trying to install gevent on Windows, a `WindowsError [183]`
occured:

```
Traceback (most recent call last):
  File "util/cythonpp.py", line 801, in <module>
      process_filename(filename, options.output_file)
  File "util/cythonpp.py", line 82, in process_filename
      atomic_write(pyx_filename, py_banner + value)
  File "util/cythonpp.py", line 519, in atomic_write
      os.rename(tmpname, filename)
```

The reason is, that `atomic_write` writes a `filename.tmp` file first and then tries to rename the `filename.tmp` file to the real filename. That fails on Windows, because filename already exists (see [Windows System Error Code #183](http://msdn.microsoft.com/en-us/library/windows/desktop/ms681382%28v=vs.85%29.aspx)).
Now `atomic_write` writes the `filename.tmp`, then moves `filename` to `filename.bak` and then renames  `filename.tmp` to `filename` and finally removes `filename.bak`.
