### PR TITLE
Added fix for issue #312. Encountering Windows error [183] when installi...

### DIFF
--- a/util/cythonpp.py
+++ b/util/cythonpp.py
@@ -516,6 +516,8 @@ def atomic_write(filename, data):
     f.flush()
     os.fsync(f.fileno())
     f.close()
+    if os.path.exists(filename):
+        os.unlink(filename)
     os.rename(tmpname, filename)
     dbg('Wrote %s bytes to %s', len(data), filename)
 


### PR DESCRIPTION
Hi @msiemens,

I encountered an issue in your fix (and edge case actually).
When running a fresh pip install of 1.0rc2 and above (or even python setup.py install from a tarball), line 519 of your fix gives the error: file not found.

This is because, when the atomic_write() tries to create the file for the first time, the original code would have simply created the file. But your changes only work, if the file already exists.

I've made a commit to fix that issue. Please let me know if its acceptable.

Best regards,
Jeryn
