### PR TITLE
start_response: Coerce response headers to list

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -431,7 +431,7 @@ class WSGIHandler(object):
                 exc_info = None
         self.code = int(status.split(' ', 1)[0])
         self.status = status
-        self.response_headers = headers
+        self.response_headers = list(headers)
 
         provided_connection = None
         self.provided_date = None


### PR DESCRIPTION
Since finalize_headers appends values to self.response_headers, it
needs to be a list, but the caller could have passed in another type
of iterable. Therefore, it should be coerced into a list when savede
in self.response_headers.
