### PR TITLE
Pass copy of error list instead of direct reference

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -524,7 +524,7 @@ class WSGIHandler(object):
         if self.response_length:
             self.close_connection = True
         else:
-            self.start_response(_INTERNAL_ERROR_STATUS, _INTERNAL_ERROR_HEADERS)
+            self.start_response(_INTERNAL_ERROR_STATUS, _INTERNAL_ERROR_HEADERS[:])
             self.write(_INTERNAL_ERROR_BODY)
 
     def _headers(self):


### PR DESCRIPTION
At least partially fixes #324

The wsgi server is allowed to modify header list passed in as it chooses, and we do not wish the internal global header error list to be modified, so a copy should be passed in instead.
