### PR TITLE
Ignore sys.exc_clear() for PY3.

### DIFF
--- a/gevent/backdoor.py
+++ b/gevent/backdoor.py
@@ -30,6 +30,7 @@ from code import InteractiveConsole
 
 from gevent import socket
 from gevent.greenlet import Greenlet
+from gevent.hub import PY3
 from gevent.server import StreamServer
 
 __all__ = ['BackdoorServer']
@@ -79,7 +80,8 @@ class SocketConsole(Greenlet):
                     console.locals["builtins"] = builtins
                 console.interact(banner=self.banner)
             except SystemExit:  # raised by quit()
-                sys.exc_clear()
+                if not PY3:
+                    sys.exc_clear()
         finally:
             self.switch_out()
             self.finalize()

--- a/gevent/os.py
+++ b/gevent/os.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 import os
 import sys
-from gevent.hub import get_hub, reinit
+from gevent.hub import get_hub, reinit, PY3
 import errno
 
 EAGAIN = getattr(errno, 'EAGAIN', 11)
@@ -52,7 +52,8 @@ if fcntl:
             except OSError as e:
                 if e.errno not in ignored_errors:
                     raise
-                sys.exc_clear()
+                if not PY3:
+                    sys.exc_clear()
             if hub is None:
                 hub = get_hub()
                 event = hub.loop.io(fd, 1)
@@ -71,7 +72,8 @@ if fcntl:
             except OSError as e:
                 if e.errno not in ignored_errors:
                     raise
-                sys.exc_clear()
+                if not PY3:
+                    sys.exc_clear()
             if hub is None:
                 hub = get_hub()
                 event = hub.loop.io(fd, 2)

--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -13,6 +13,7 @@ from gevent import socket
 import gevent
 from gevent.server import StreamServer
 from gevent.hub import GreenletExit
+from gevent.hub import PY3
 
 
 __all__ = ['WSGIHandler', 'WSGIServer']
@@ -321,7 +322,8 @@ class WSGIHandler(object):
         except socket.error as ex:
             # Broken pipe, connection reset by peer
             if ex.args[0] in (errno.EPIPE, errno.ECONNRESET):
-                sys.exc_clear()
+                if not PY3:
+                    sys.exc_clear()
                 return
             else:
                 raise

--- a/greentest/test__exc_info.py
+++ b/greentest/test__exc_info.py
@@ -1,8 +1,10 @@
 import gevent
 import sys
 import greentest
+import six
 
-sys.exc_clear()
+if not six.PY3:
+    sys.exc_clear()
 
 
 class ExpectedError(Exception):


### PR DESCRIPTION
This PR excluded the changes to socket/ssl/fileobject which will be fixed a bit differently (code after Python-2-style exc_clear must be executed outside the "except" block in order for Python 3 to clear up correctly)
