### PR TITLE
Fix absolute import issue in core.ppyx in PY3, refs #38

### DIFF
--- a/gevent/core.ppyx
+++ b/gevent/core.ppyx
@@ -2,11 +2,12 @@
 cimport cython
 cimport libev
 from python cimport *
-import sys
 # Work around lack of absolute_import in Cython
+# Note for PY3: not doing so will leave reference to locals() on import
+sys = __import__('sys', level=0)
 os = __import__('os', level=0)
-import traceback
-import signal as signalmodule
+traceback = __import__('traceback', level=0)
+signalmodule = __import__('signal', level=0)
 
 
 __all__ = ['get_version',

--- a/greentest/test__refcount_core.py
+++ b/greentest/test__refcount_core.py
@@ -1,0 +1,13 @@
+import weakref
+
+
+class Dummy:
+    def __init__(self):
+        __import__('gevent.core')
+
+
+assert weakref.ref(Dummy())() is None
+
+from gevent import socket
+
+assert weakref.ref(socket.socket())() is None

--- a/known_failures.py
+++ b/known_failures.py
@@ -53,6 +53,12 @@ if CPYTHON_DBG:
 
 if PYPY:
     FAILING_TESTS += [
+        # Different in PyPy:
+
+        # PyPy has no refcount
+        # http://pypy.readthedocs.org/en/latest/cpython_differences.html#differences-related-to-garbage-collection-strategies
+        'test__refcount_core.py',
+
         # Not implemented:
 
         # stat watchers are not implemented on pypy


### PR DESCRIPTION
Without this change, the test fails in PY3 which breaks the refcount thing of sockets.