### PR TITLE
Port gevent vfd to win64

### DIFF
--- a/gevent/core.ppyx
+++ b/gevent/core.ppyx
@@ -453,8 +453,13 @@ cdef public class loop [object PyGeventLoopObject, type PyGeventLoop_Type]:
             CHECK_LOOP3(self)
             return libev.ev_pending_count(self._ptr)
 
+#ifdef _WIN32
+    def io(self, libev.vfd_socket_t fd, int events, ref=True, priority=None):
+        return io(self, fd, events, ref, priority)
+#else
     def io(self, int fd, int events, ref=True, priority=None):
         return io(self, fd, events, ref, priority)
+#endif
 
     def timer(self, double after, double repeat=0.0, ref=True, priority=None):
         return timer(self, after, repeat, ref, priority)
@@ -785,7 +790,7 @@ cdef public class io(watcher) [object PyGeventIOObject, type PyGeventIO_Type]:
 
 #ifdef _WIN32
 
-    def __init__(self, loop loop, long fd, int events, ref=True, priority=None):
+    def __init__(self, loop loop, libev.vfd_socket_t fd, int events, ref=True, priority=None):
         if events & ~(libev.EV__IOFDSET | libev.EV_READ | libev.EV_WRITE):
             raise ValueError('illegal event mask: %r' % events)
         cdef int vfd = libev.vfd_open(fd)

--- a/gevent/libev.pxd
+++ b/gevent/libev.pxd
@@ -1,4 +1,13 @@
 cdef extern from "libev_vfd.h":
+#ifdef _WIN32
+#ifdef _WIN64
+    ctypedef long long vfd_socket_t
+#else
+    ctypedef long vfd_socket_t
+#endif
+#else
+    ctypedef int vfd_socket_t
+#endif
     long vfd_get(int)
     int vfd_open(long) except -1
     void vfd_free(int)


### PR DESCRIPTION
Since long on win64 is 32-bit it cannot hold all possible
SOCKET handle values, making it theoretically possible to
get an exception "OverflowError: Python int too large to
convert to C long" if socket handles become too big. Now
on win64 it properly uses PY_LONG_LONG.
