### PR TITLE
Fix pep8

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,4 @@
 [pep8]
-ignore=E702
+ignore=E702,E265
 max_line_length=160
 exclude=.git,build,2.6,2.7,3.3,test_support.py,test_queue.py,patched_tests_setup.py,test_threading_2.py,lock_tests.py

--- a/greentest/test__subprocess.py
+++ b/greentest/test__subprocess.py
@@ -47,9 +47,9 @@ class Test(greentest.TestCase):
 
     def test_communicate(self):
         p = subprocess.Popen([sys.executable, "-c",
-                             'import sys,os;'
-                             'sys.stderr.write("pineapple");'
-                             'sys.stdout.write(sys.stdin.read())'],
+                              'import sys,os;'
+                              'sys.stderr.write("pineapple");'
+                              'sys.stdout.write(sys.stdin.read())'],
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
@@ -62,18 +62,18 @@ class Test(greentest.TestCase):
 
     def test_universal1(self):
         p = subprocess.Popen([sys.executable, "-c",
-                             'import sys,os;' + SETBINARY +
-                             'sys.stdout.write("line1\\n");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line2\\r");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line3\\r\\n");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line4\\r");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("\\nline5");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("\\nline6");'],
+                              'import sys,os;' + SETBINARY +
+                              'sys.stdout.write("line1\\n");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line2\\r");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line3\\r\\n");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line4\\r");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("\\nline5");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("\\nline6");'],
                              stdout=subprocess.PIPE,
                              universal_newlines=1)
         try:
@@ -91,16 +91,16 @@ class Test(greentest.TestCase):
 
     def test_universal2(self):
         p = subprocess.Popen([sys.executable, "-c",
-                             'import sys,os;' + SETBINARY +
-                             'sys.stdout.write("line1\\n");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line2\\r");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line3\\r\\n");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("line4\\r\\nline5");'
-                             'sys.stdout.flush();'
-                             'sys.stdout.write("\\nline6");'],
+                              'import sys,os;' + SETBINARY +
+                              'sys.stdout.write("line1\\n");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line2\\r");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line3\\r\\n");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("line4\\r\\nline5");'
+                              'sys.stdout.flush();'
+                              'sys.stdout.write("\\nline6");'],
                              stdout=subprocess.PIPE,
                              universal_newlines=1)
         try:


### PR DESCRIPTION
With new version of pep8:

```
./doc/conf.py:34:1: E265 block comment should start with '# '
./doc/conf.py:51:1: E265 block comment should start with '# '
./doc/conf.py:72:1: E265 block comment should start with '# '
./doc/conf.py:76:1: E265 block comment should start with '# '
./doc/conf.py:78:1: E265 block comment should start with '# '
./doc/conf.py:81:1: E265 block comment should start with '# '
./doc/conf.py:88:1: E265 block comment should start with '# '
./doc/conf.py:99:1: E265 block comment should start with '# '
./doc/conf.py:118:1: E265 block comment should start with '# '
./doc/conf.py:122:1: E265 block comment should start with '# '
./doc/conf.py:126:1: E265 block comment should start with '# '
./doc/conf.py:133:1: E265 block comment should start with '# '
./doc/conf.py:138:1: E265 block comment should start with '# '
./doc/conf.py:143:1: E265 block comment should start with '# '
./doc/conf.py:147:1: E265 block comment should start with '# '
./doc/conf.py:158:1: E265 block comment should start with '# '
./doc/conf.py:167:1: E265 block comment should start with '# '
./doc/conf.py:175:1: E265 block comment should start with '# '
./doc/conf.py:178:1: E265 block comment should start with '# '
./doc/conf.py:187:1: E265 block comment should start with '# '
./doc/conf.py:190:1: E265 block comment should start with '# '
./doc/conf.py:201:1: E265 block comment should start with '# '
./doc/conf.py:205:1: E265 block comment should start with '# '
./doc/conf.py:208:1: E265 block comment should start with '# '
./doc/conf.py:211:1: E265 block comment should start with '# '
./doc/conf.py:214:1: E265 block comment should start with '# '
./examples/geventsendfile.py:15:13: E265 block comment should start with '# '
./examples/webproxy.py:106:9: E265 block comment should start with '# '
./gevent/greenlet.py:175:21: E265 block comment should start with '# '
./gevent/pywsgi.py:401:13: E265 block comment should start with '# '
./gevent/pywsgi.py:428:17: E265 block comment should start with '# '
./greentest/greentest.py:194:17: E265 block comment should start with '# '
./greentest/test___example_servers.py:2:1: E265 block comment should start with '# '
./greentest/test__backdoor.py:40:9: E265 block comment should start with '# '
./greentest/test__execmodules.py:13:9: E265 block comment should start with '# '
./greentest/test__pool.py:137:9: E265 block comment should start with '# '
./greentest/test__refcount.py:70:5: E265 block comment should start with '# '
./greentest/test__refcount.py:73:5: E265 block comment should start with '# '
./greentest/test__refcount.py:75:5: E265 block comment should start with '# '
./greentest/test__refcount.py:76:5: E265 block comment should start with '# '
./greentest/test__refcount.py:77:5: E265 block comment should start with '# '
./greentest/test__refcount.py:81:5: E265 block comment should start with '# '
./greentest/test__refcount.py:84:5: E265 block comment should start with '# '
./greentest/test__refcount.py:86:5: E265 block comment should start with '# '
./greentest/test__refcount.py:89:5: E265 block comment should start with '# '
./greentest/test__refcount.py:90:5: E265 block comment should start with '# '
./greentest/test__refcount.py:100:5: E265 block comment should start with '# '
./greentest/test__refcount.py:101:5: E265 block comment should start with '# '
./greentest/test__socket_dns.py:246:5: E265 block comment should start with '# '
./greentest/test__subprocess.py:51:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:52:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:66:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:67:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:68:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:69:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:70:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:71:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:72:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:73:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:74:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:75:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:76:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:95:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:96:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:97:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:98:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:99:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:100:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:101:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:102:30: E128 continuation line under-indented for visual indent
./greentest/test__subprocess.py:103:30: E128 continuation line under-indented for visual indent
./greentest/xtest__server_close.py:48:9: E265 block comment should start with '# '
./greentest/xtest__server_close.py:55:9: E265 block comment should start with '# '
./util/pyflakes.py:66:9: E265 block comment should start with '# '
```
