### PR TITLE
Use only family in getaddrinfo hints when socket.connect

### DIFF
--- a/gevent/_socket3.py
+++ b/gevent/_socket3.py
@@ -209,7 +209,7 @@ class socket(_socket.socket):
         if self.timeout == 0.0:
             return _socket.socket.connect(self, address)
         if isinstance(address, tuple):
-            r = getaddrinfo(address[0], address[1], self.family, self.type, self.proto)
+            r = getaddrinfo(address[0], address[1], self.family)
             address = r[0][-1]
         if self.timeout is not None:
             timer = Timeout.start_new(self.timeout, timeout('timed out'))


### PR DESCRIPTION
being consistent with stdlib
