### PR TITLE
[Python 3] fix syntax error when running setup.py install

### DIFF
--- a/gevent/_util_py2.py
+++ b/gevent/_util_py2.py
@@ -1,4 +1,4 @@
-eval("""
+exec("""
 __all__ = ['reraise']
 
 


### PR DESCRIPTION
setup.py attempts to byte-compile all .py's, so it will fail on python 3.
