### PR TITLE
made gevent.corecffi buildable under 32 bit systems

### DIFF
--- a/gevent/corecffi.py
+++ b/gevent/corecffi.py
@@ -3,6 +3,7 @@ import sys
 import os
 import traceback
 import signal as signalmodule
+import struct
 
 
 __all__ = ['get_version',
@@ -14,9 +15,15 @@ __all__ = ['get_version',
            'loop']
 
 
+def system_bits():
+    return struct.calcsize('P') * 8
+
+
 def st_nlink_type():
     if sys.platform == "darwin":
         return "short"
+    elif system_bits() == 32:
+        return "unsigned long"
     return "long long"
 
 


### PR DESCRIPTION
Under 32 bits systems gevent.corecffi build fails because type size of `nlink_t` on CFFI side is fixed to 64 bits width.
According to `bits/typesizes.h`, type of `nlink_t` is defined as unsigned word, which can be variable by architecture bits.
