### PR TITLE
- bugfix for error: ISO C90 forbids mixed declarations and code in libev...

### DIFF
--- a/gevent/libev.h
+++ b/gevent/libev.h
@@ -16,10 +16,12 @@ static int sigchld_state = 0;
 
 static struct ev_loop* gevent_ev_default_loop(unsigned int flags)
 {
-    if (sigchld_state)
-        return ev_default_loop(flags);
     struct ev_loop* result;
     struct sigaction tmp;
+
+    if (sigchld_state)
+        return ev_default_loop(flags);
+
     sigaction(SIGCHLD, NULL, &tmp);
     result = ev_default_loop(flags);
     // XXX what if SIGCHLD received there?


### PR DESCRIPTION
this fixes an ISO C90 error I've encountered under a few different RHEL 6 & libevent 2.

"error: ISO C90 forbids mixed declarations and code" against libev.h
