### PR TITLE
Keep traceback when a greenlet raise an Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[co]
 build/
+dist/
 *.so
 gevent.*.[ch]
 gevent/core.pyx


### PR DESCRIPTION
Using exc_info to raise the exception, the stack trace are preserved. This allows apps like Sentry keep the data from the original request.

This can be tested with this code:
```
def a():
    b()

def b():
    c()

def c():
    raise Exception("oops")

import gevent
g = gevent.spawn(a)

gevent.joinall([g], raise_error=True)
```

Before this change, the stack trace are like:
```
Traceback (most recent call last):
  File "/home/rodolfo/.virtualenvs/learn/local/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "<ipython-input-9-68c02506ab89>", line 2, in a
    b()
  File "<ipython-input-10-95346865739c>", line 2, in b
    c()
  File "<ipython-input-11-dac247e82805>", line 2, in c
    raise Exception("oops")
Exception: oops
<Greenlet at 0x7f11aba28910: a> failed with Exception

---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-14-4cc8a7e34316> in <module>()
----> 1 gevent.joinall([g], raise_error=True)

/home/rodolfo/.virtualenvs/learn/local/lib/python2.7/site-packages/gevent/greenlet.pyc in joinall(greenlets, timeout, raise_error, count)
    402         for obj in iwait(greenlets, timeout=timeout):
    403             if getattr(obj, 'exception', None) is not None:
--> 404                 raise obj.exception
    405             if count is not None:
    406                 count -= 1

Exception: oops
```

After this, we get the original stack:
```
Traceback (most recent call last):
  File "/home/rodolfo/.virtualenvs/learn/local/lib/python2.7/site-packages/gevent/greenlet.py", line 328, in run
    result = self._run(*self.args, **self.kwargs)
  File "<ipython-input-1-68c02506ab89>", line 2, in a
    b()
  File "<ipython-input-2-95346865739c>", line 2, in b
    c()
  File "<ipython-input-3-dac247e82805>", line 2, in c
    raise Exception("oops")
Exception: oops
<Greenlet at 0x7f02bf0e9550: a> failed with Exception

---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-6-4cc8a7e34316> in <module>()
----> 1 gevent.joinall([g], raise_error=True)

/home/rodolfo/.virtualenvs/learn/local/lib/python2.7/site-packages/gevent/greenlet.py in run(self)
    326                 self._start_event.stop()
    327             try:
--> 328                 result = self._run(*self.args, **self.kwargs)
    329             except:
    330                 self._report_error(sys.exc_info())

<ipython-input-1-68c02506ab89> in a()
      1 def a():
----> 2         b()
      3

<ipython-input-2-95346865739c> in b()
      1 def b():
----> 2         c()
      3

<ipython-input-3-dac247e82805> in c()
      1 def c():
----> 2         raise Exception("oops")
      3

Exception: oops
```