### PR TITLE
Fix various problems in current PY3 WSGI implementation (Currently Non-operational)

### DIFF
--- a/gevent/__init__.py
+++ b/gevent/__init__.py
@@ -8,8 +8,8 @@ See http://www.gevent.org/ for the documentation.
 
 from __future__ import absolute_import
 
-version_info = (1, 1, 0, 'dev', None)
-__version__ = '1.1'
+version_info = (1, 1, 1, 'dev', None)
+__version__ = '1.1.1'
 
 
 __all__ = ['get_hub',

--- a/gevent/_socket3.py
+++ b/gevent/_socket3.py
@@ -5,6 +5,8 @@ import time
 from gevent import _socketcommon
 import _socket
 from io import BlockingIOError
+from os import dup
+from gevent.hub import string_types, to_wire
 
 for key in _socketcommon.__dict__:
     if key.startswith('__'):
@@ -22,7 +24,7 @@ SocketIO = __socket__.SocketIO
 
 
 def _get_memory(string, offset):
-    return memoryview(string)[offset:]
+    return memoryview(to_wire(string))[offset:]
 
 
 timeout_default = object()

--- a/gevent/_ssl3.py
+++ b/gevent/_ssl3.py
@@ -9,6 +9,7 @@ This module implements cooperative SSL socket wrappers.
 
 from __future__ import absolute_import
 import ssl as __ssl__
+from gevent.hub import to_wire
 
 _ssl = __ssl__._ssl
 
@@ -232,7 +233,7 @@ class SSLSocket(socket):
                     self.__class__)
             while True:
                 try:
-                    return self._sslobj.write(data)
+                    return self._sslobj.write(to_wire(data))             
                 except SSLWantReadError:
                     if self.timeout == 0.0:
                         return 0

--- a/gevent/_util_py2.py
+++ b/gevent/_util_py2.py
@@ -1,8 +1,4 @@
-# this produces syntax error on Python3
-
-
 __all__ = ['reraise']
 
-
-def reraise(type, value, tb):
-    raise type, value, tb
+def reraise(tp, value, tb=None):
+    raise type, value, tb     # please ignore syntax error here for Python3

--- a/gevent/_util_py3.py
+++ b/gevent/_util_py3.py
@@ -1,0 +1,6 @@
+__all__ = ['reraise']
+
+def reraise(tp, value, tb=None):
+    if value.__traceback__ is not tb:
+        raise value.with_traceback(tb)
+    raise value

--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -36,21 +36,24 @@ if PY3:
     integer_types = int,
     text_type = str
     xrange = range
-
-    def reraise(tp, value, tb=None):
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-
+    from gevent._util_py3 import reraise
 else:
     import __builtin__
     string_types = __builtin__.basestring,
     text_type = __builtin__.unicode
     integer_types = (int, __builtin__.long)
     xrange = __builtin__.xrange
-
     from gevent._util_py2 import reraise
 
+def to_wire(text):
+    if not text == None and isinstance(text, string_types):
+        text = text if not PY3 else bytes(text, 'iso-8859-1')
+    return text
+
+def to_local(text):
+    if not text == None and not isinstance(text, string_types): 
+        text = text.decode('iso-8859-1')
+    return text
 
 if sys.version_info[0] <= 2:
     import thread

--- a/greentest/test__pywsgi.py
+++ b/greentest/test__pywsgi.py
@@ -19,9 +19,12 @@
 # THE SOFTWARE.
 from __future__ import print_function
 from gevent import monkey
+from gevent.hub import PY3, string_types, to_wire, to_local
+from urllib.parse import unquote, unquote_to_bytes
 monkey.patch_all(thread=False)
 
 import cgi
+import io
 import os
 import sys
 try:
@@ -58,6 +61,15 @@ except ImportError:
 REASONS = {200: 'OK',
            500: 'Internal Server Error'}
 
+def asHex(text):
+    import binascii
+    newString=''
+    for character in text:
+        x=to_wire(character)
+        x=binascii.hexlify(x)
+        y=str(x,'ascii')
+        newString += y
+    return newString
 
 class ConnectionClosed(Exception):
     pass
@@ -81,10 +93,18 @@ def read_headers(fd):
         headers[key] = value
     return response_line, headers
 
+def detect_end(fd):
+    for _ in range(2):
+        crlf = to_local(fd.read(1))
+        if crlf == '\n':
+            return
+        assert crlf == '\r', '\\r != '+ repr(crlf)
+    assert crlf == '\n', '\\n != '+ repr(crlf)
+        
 
 def iread_chunks(fd):
     while True:
-        line = fd.readline()
+        line = to_local(fd.readline())
         chunk_size = line.strip()
         try:
             chunk_size = int(chunk_size, 16)
@@ -92,13 +112,11 @@ def iread_chunks(fd):
             print('Failed to parse chunk size: %r' % line)
             raise
         if chunk_size == 0:
-            crlf = fd.read(2)
-            assert crlf == '\r\n', repr(crlf)
+            detect_end(fd)
             break
-        data = fd.read(chunk_size)
+        data = to_local(fd.read(chunk_size))
         yield data
-        crlf = fd.read(2)
-        assert crlf == '\r\n', repr(crlf)
+        detect_end(fd)
 
 
 class Response(object):
@@ -109,7 +127,8 @@ class Response(object):
         self.body = None
         self.chunks = False
         try:
-            version, code, self.reason = status_line[:-2].split(' ', 2)
+            last_char_location = -2 if self.status_line[-2] == '\r' else -1
+            version, code, self.reason = status_line[:last_char_location].split(' ', 2)
         except Exception:
             print('Error: %r' % status_line)
             raise
@@ -204,14 +223,64 @@ class DebugFileObject(object):
         if DEBUG:
             print(repr(result))
         return result
+    
+    def write(self, *args):
+        return self.obj.write(*args)
 
     def __getattr__(self, item):
         assert item != 'obj'
         return getattr(self.obj, item)
 
+if not PY3:
+    def makefile(self, mode='r', bufsize=-1):
+        return DebugFileObject(socket._fileobject(self.dup(), mode, bufsize))
+else:
+    import socket as __socket__
+    SocketIO = __socket__.SocketIO
+    def special_makefile(sock, mode="r", buffering=None, *,
+                 encoding=None, errors=None, newline=None):
+        """makefile(...) -> an I/O stream connected to the socket
 
-def makefile(self, mode='r', bufsize=-1):
-    return DebugFileObject(socket._fileobject(self.dup(), mode, bufsize))
+        The arguments are as for io.open() after the filename,
+        except the only mode characters supported are 'r', 'w' and 'b'.
+        The semantics are similar too.  (XXX refactor to share code?)
+        """
+        for c in mode:
+            if c not in {"r", "w", "b"}:
+                raise ValueError("invalid mode %r (only r, w, b allowed)")
+        writing = "w" in mode
+        reading = "r" in mode or not writing
+        assert reading or writing
+        binary = "b" in mode
+        rawmode = ""
+        if reading:
+            rawmode += "r"
+        if writing:
+            rawmode += "w"
+        raw = SocketIO(sock, rawmode)
+        if buffering is None:
+            buffering = -1
+        if buffering < 0:
+            buffering = io.DEFAULT_BUFFER_SIZE
+        if buffering == 0:
+            if not binary:
+                raise ValueError("unbuffered streams must be binary")
+            return raw
+        if reading and writing:
+            buffer = io.BufferedRWPair(raw, raw, buffering)
+        elif reading:
+            buffer = io.BufferedReader(raw, buffering)
+        else:
+            assert writing
+            buffer = io.BufferedWriter(raw, buffering)
+        if binary:
+            return buffer
+        text = io.TextIOWrapper(buffer, encoding, errors, newline)
+        text.mode = mode
+        return text
+    
+    def makefile(self, mode='wr', bufsize=-1):
+        return DebugFileObject(special_makefile(self.dup(), mode=mode, buffering=bufsize))
 
 socket.socket.makefile = makefile
 
@@ -231,6 +300,7 @@ class TestCase(greentest.TestCase):
         self.server.start()
         self.port = self.server.server_port
         greentest.TestCase.setUp(self)
+        self.fds = []
 
     def tearDown(self):
         greentest.TestCase.tearDown(self)
@@ -239,13 +309,16 @@ class TestCase(greentest.TestCase):
             self.server.stop()
         finally:
             timeout.cancel()
+        for fd in self.fds:
+            fd.close()
         # XXX currently listening socket is kept open in gevent.wsgi
 
     def connect(self):
         return socket.create_connection(('127.0.0.1', self.port))
 
     def makefile(self):
-        return self.connect().makefile(bufsize=1)
+        self.fds.append(self.connect().makefile(bufsize=1))
+        return self.fds[-1]
 
     def urlopen(self, *args, **kwargs):
         fd = self.connect().makefile(bufsize=1)
@@ -367,10 +440,10 @@ class TestYield(CommonTests):
         path = env['PATH_INFO']
         if path == '/':
             start_response('200 OK', [('Content-Type', 'text/plain')])
-            yield "hello world"
+            yield to_wire("hello world")
         else:
             start_response('404 Not Found', [('Content-Type', 'text/plain')])
-            yield "not found"
+            yield to_wire("not found")
 
 
 if sys.version_info[:2] >= (2, 6):
@@ -384,10 +457,10 @@ if sys.version_info[:2] >= (2, 6):
             path = env['PATH_INFO']
             if path == '/':
                 start_response('200 OK', [('Content-Type', 'text/plain')])
-                return [bytearray("hello "), bytearray("world")]
+                return [bytearray(to_wire("hello ")), bytearray(to_wire("world"))]
             else:
                 start_response('404 Not Found', [('Content-Type', 'text/plain')])
-                return [bytearray("not found")]
+                return [bytearray(to_wire("not found"))]
 
 
 class MultiLineHeader(TestCase):
@@ -395,7 +468,7 @@ class MultiLineHeader(TestCase):
     def application(env, start_response):
         assert "test.submit" in env["CONTENT_TYPE"]
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        return ["ok"]
+        return [to_wire("ok")]
 
     def test_multiline_116(self):
         """issue #116"""
@@ -415,10 +488,10 @@ class TestGetArg(TestCase):
 
     @staticmethod
     def application(env, start_response):
-        body = env['wsgi.input'].read()
-        a = cgi.parse_qs(body).get('a', [1])[0]
+        body = to_local(env['wsgi.input'].read(-1))
+        a=cgi.parse_qs(body).get('a', [1])[0]
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        return ['a is %s, body is %s' % (a, body)]
+        return [to_wire('a is %s, body is %s' % (a, body))]
 
     def test_007_get_arg(self):
         # define a new handler that does a get_arg as well as a read_body
@@ -447,7 +520,7 @@ class TestChunkedApp(TestCase):
     def application(self, env, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
         for chunk in self.chunks:
-            yield chunk
+            yield to_wire(chunk)
 
     def test_chunked_response(self):
         fd = self.makefile()
@@ -482,12 +555,14 @@ class TestChunkedPost(TestCase):
     def application(env, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
         if env['PATH_INFO'] == '/a':
-            data = env['wsgi.input'].read()
-            return [data]
+            data = env['wsgi.input'].read(-1)
+            return [to_wire(data)]
         elif env['PATH_INFO'] == '/b':
-            return [x for x in iter(lambda: env['wsgi.input'].read(4096), '')]
+            response = [to_wire(x) for x in iter(lambda: env['wsgi.input'].read(4096), to_wire(''))]
+            return response
         elif env['PATH_INFO'] == '/c':
-            return [x for x in iter(lambda: env['wsgi.input'].read(1), '')]
+            response = [to_wire(x) for x in iter(lambda: env['wsgi.input'].read(1), to_wire(''))]
+            return response
 
     def test_014_chunked_post(self):
         fd = self.makefile()
@@ -519,17 +594,17 @@ class TestUseWrite(TestCase):
         if env['PATH_INFO'] == '/explicit-content-length':
             write = start_response('200 OK', [('Content-Type', 'text/plain'),
                                               ('Content-Length', self.content_length)])
-            write(self.body)
+            write(to_wire(self.body))
         elif env['PATH_INFO'] == '/no-content-length':
             write = start_response('200 OK', [('Content-Type', 'text/plain')])
-            write(self.body)
+            write(to_wire(self.body))
         elif env['PATH_INFO'] == '/no-content-length-twice':
             write = start_response('200 OK', [('Content-Type', 'text/plain')])
-            write(self.body)
-            write(self.body)
+            write(to_wire(self.body))
+            write(to_wire(self.body))
         else:
             raise Exception('Invalid url')
-        return [self.end]
+        return [to_wire(self.end)]
 
     def test_explicit_content_length(self):
         fd = self.makefile()
@@ -603,23 +678,23 @@ class TestHttps(HttpsTestCase):
 
 
 class TestInternational(TestCase):
-    validator = None  # wsgiref.validate.IteratorWrapper([]) does not have __len__
+    validator = None  # wsgiref.validate.IteratorWrapper([]) does not have __len__ 
 
     def application(self, environ, start_response):
-        assert environ['PATH_INFO'] == '/\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82', environ['PATH_INFO']
-        assert environ['QUERY_STRING'] == '%D0%B2%D0%BE%D0%BF%D1%80%D0%BE%D1%81=%D0%BE%D1%82%D0%B2%D0%B5%D1%82', environ['QUERY_STRING']
+        assert environ['PATH_INFO'] == '/\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82', asHex(environ['PATH_INFO'])
+        assert environ['QUERY_STRING'] == '%D0%B2%D0%BE%D0%BF%D1%80%D0%BE%D1%81=%D0%BE%D1%82%D0%B2%D0%B5%D1%82', asHex(environ['QUERY_STRING'])
         start_response("200 PASSED", [('Content-Type', 'text/plain')])
         return []
 
     def test(self):
-        sock = self.connect()
-        sock.sendall('''GET /%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82?%D0%B2%D0%BE%D0%BF%D1%80%D0%BE%D1%81=%D0%BE%D1%82%D0%B2%D0%B5%D1%82 HTTP/1.1
+        fd = self.makefile()
+        fd.write('''GET /%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82?%D0%B2%D0%BE%D0%BF%D1%80%D0%BE%D1%81=%D0%BE%D1%82%D0%B2%D0%B5%D1%82 HTTP/1.1
 Host: localhost
 Connection: close
 
 '''.replace('\n', '\r\n'))
-        read_http(sock.makefile(), reason='PASSED', chunks=False, body='', content_length=0)
-
+        read_http(fd, reason='PASSED', chunks=False, body='', content_length=0)
+ 
 
 class TestInputReadline(TestCase):
     # this test relies on the fact that readline() returns '' after it reached EOF
@@ -635,7 +710,7 @@ class TestInputReadline(TestCase):
             line = input.readline()
             if not line:
                 break
-            lines.append(repr(line) + ' ')
+            lines.append(repr(to_local(line)) + ' ')
         start_response('200 hello', [])
         return lines
 
@@ -656,7 +731,7 @@ class TestInputIter(TestInputReadline):
         for line in input:
             if not line:
                 break
-            lines.append(repr(line) + ' ')
+            lines.append(repr(to_local(line)) + ' ')
         start_response('200 hello', [])
         return lines
 
@@ -666,7 +741,7 @@ class TestInputReadlines(TestInputReadline):
     def application(self, environ, start_response):
         input = environ['wsgi.input']
         lines = input.readlines()
-        lines = [repr(line) + ' ' for line in lines]
+        lines = [repr(to_local(line)) + ' ' for line in lines]
         start_response('200 hello', [])
         return lines
 
@@ -716,8 +791,8 @@ class TestEmptyYield(TestCase):
     @staticmethod
     def application(env, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        yield ""
-        yield ""
+        yield to_wire("")
+        yield to_wire("")
 
     def test_err(self):
         fd = self.connect().makefile(bufsize=1)
@@ -739,8 +814,8 @@ class TestFirstEmptyYield(TestCase):
     @staticmethod
     def application(env, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        yield ""
-        yield "hello"
+        yield to_wire("")
+        yield to_wire("hello")
 
     def test_err(self):
         fd = self.connect().makefile(bufsize=1)
@@ -762,8 +837,8 @@ class TestEmptyYield304(TestCase):
     @staticmethod
     def application(env, start_response):
         start_response('304 Not modified', [])
-        yield ""
-        yield ""
+        yield to_wire("")
+        yield to_wire("")
 
     def test_err(self):
         fd = self.connect().makefile(bufsize=1)
@@ -781,7 +856,7 @@ class TestContentLength304(TestCase):
             start_response('304 Not modified', [('Content-Length', '100')])
         except AssertionError as ex:
             start_response('200 Raised', [])
-            return [str(ex)]
+            return [to_wire(str(ex))]
         else:
             raise AssertionError('start_response did not fail but it should')
 
@@ -799,7 +874,7 @@ class TestBody304(TestCase):
 
     def application(self, env, start_response):
         start_response('304 Not modified', [])
-        return ['body']
+        return [to_wire('body')]
 
     def test_err(self):
         fd = self.connect().makefile(bufsize=1)
@@ -841,8 +916,8 @@ class TestEmptyWrite(TestEmptyYield):
     @staticmethod
     def application(env, start_response):
         write = start_response('200 OK', [('Content-Type', 'text/plain')])
-        write("")
-        write("")
+        write(to_wire(""))
+        write(to_wire(""))
         return []
 
 
@@ -853,7 +928,7 @@ class BadRequestTests(TestCase):
     def application(self, env, start_response):
         assert env['CONTENT_LENGTH'] == self.content_length, (env['CONTENT_LENGTH'], self.content_length)
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        return ['hello']
+        return [to_wire('hello')]
 
     def test_negative_content_length(self):
         self.content_length = '-100'
@@ -863,8 +938,9 @@ class BadRequestTests(TestCase):
 
     def test_illegal_content_length(self):
         self.content_length = 'abc'
+        req = 'GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: %s\r\n\r\n' % self.content_length
         fd = self.connect().makefile(bufsize=1)
-        fd.write('GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: %s\r\n\r\n' % self.content_length)
+        fd.write(req)
         read_http(fd, code=(200, 400))
 
 
@@ -927,9 +1003,7 @@ class ChunkedInputTests(TestCase):
 
     def test_short_read_with_zero_content_length(self):
         body = self.body()
-        req = "POST /short-read HTTP/1.1\r\ntransfer-encoding: Chunked\r\nContent-Length:0\r\n\r\n" + body
-        print("REQUEST:", repr(req))
-
+        req = "POST /short-read HTTP/1.1\r\ntransfer-encoding: Chunked\r\nContent-Length:0\r\n\r\n" + body 
         fd = self.connect().makefile(bufsize=1)
         fd.write(req)
         read_http(fd, body="this is ch")
@@ -991,14 +1065,14 @@ class Expect100ContinueTests(TestCase):
         content_length = int(environ['CONTENT_LENGTH'])
         if content_length > 1024:
             start_response('417 Expectation Failed', [('Content-Length', '7'), ('Content-Type', 'text/plain')])
-            return ['failure']
+            return [to_wire('failure')]
         else:
             # pywsgi did sent a "100 continue" for each read
             # see http://code.google.com/p/gevent/issues/detail?id=93
             text = environ['wsgi.input'].read(1)
             text += environ['wsgi.input'].read(content_length - 1)
             start_response('200 OK', [('Content-Length', str(len(text))), ('Content-Type', 'text/plain')])
-            return [text]
+            return [to_wire(text)]
 
     def test_continue(self):
         fd = self.connect().makefile(bufsize=1)
@@ -1050,7 +1124,7 @@ class TestLeakInput(TestCase):
 
         text = "foobar"
         start_response('200 OK', [('Content-Length', str(len(text))), ('Content-Type', 'text/plain')])
-        return [text]
+        return [to_wire(text)]
 
     def test_connection_close_leak_simple(self):
         fd = self.connect().makefile(bufsize=1)
@@ -1090,10 +1164,10 @@ class TestInvalidEnviron(TestCase):
 class Handler(pywsgi.WSGIHandler):
 
     def read_requestline(self):
-        data = self.rfile.read(7)
+        data = to_local(self.rfile.read(7))
         if data[0] == '<':
             try:
-                data += self.rfile.read(15)
+                data += to_local(self.rfile.read(15))
                 if data.lower() == '<policy-file-request/>':
                     self.socket.sendall('HELLO')
                 else:
@@ -1103,7 +1177,7 @@ class Handler(pywsgi.WSGIHandler):
                 self.socket.close()
                 self.socket = None
         else:
-            return data + self.rfile.readline()
+            return data + to_local(self.rfile.readline())
 
 
 class TestSubclass1(TestCase):
@@ -1181,22 +1255,22 @@ class TestInputRaw(greentest.BaseTestCase):
     def test_post(self):
         i = self.make_input("12", content_length=2)
         data = i.read()
-        self.assertEqual(data, "12")
+        self.assertEqual(data, to_wire("12"))
 
     def test_post_read_with_length(self):
         i = self.make_input("12", content_length=2)
         data = i.read(10)
-        self.assertEqual(data, "12")
+        self.assertEqual(data, to_wire("12"))
 
     def test_chunked(self):
         i = self.make_input(["1", "2", ""])
         data = i.read()
-        self.assertEqual(data, "12")
+        self.assertEqual(data, to_wire("12"))
 
     def test_chunked_read_with_length(self):
         i = self.make_input(["1", "2", ""])
         data = i.read(10)
-        self.assertEqual(data, "12")
+        self.assertEqual(data, to_wire("12"))
 
     def test_chunked_missing_chunk(self):
         i = self.make_input(["1", "2"])


### PR DESCRIPTION
Change addresses:
- strings not being encoded before sent
- missing attributes in PY3
- bytes not being decoded after received
- headers_factory had wrong amount of arguments
- PYWSGI tests failing

bump version, 1.1.1 all PYWSGI test pass now.  Integrated with fantix's pull request for the same.