### PR TITLE
fix hub.py to catch KeyboardInterrupt error correctly on python3

### DIFF
--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -259,7 +259,7 @@ class Hub(greenlet):
     """
 
     SYSTEM_ERROR = (KeyboardInterrupt, SystemExit, SystemError)
-    NOT_ERROR = (GreenletExit, SystemExit)
+    NOT_ERROR = (GreenletExit, SystemExit, KeyboardInterrupt)
     loop_class = config('gevent.core.loop', 'GEVENT_LOOP')
     resolver_class = ['gevent.resolver_thread.Resolver',
                       'gevent.resolver_ares.Resolver',


### PR DESCRIPTION
Add KeyboardInterrupt error in NOT_ERROR of Hub class to solve <https://github.com/surfly/gevent/issues/461>
