### PR TITLE
Added NativeFriendlyRLock to gevent.lock

### DIFF
--- a/gevent/lock.py
+++ b/gevent/lock.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2009-2012 Denis Bilenko. See LICENSE for details.
 """Locking primitives"""
 
-from gevent.hub import getcurrent
+from gevent.hub import getcurrent, sleep
 from gevent._semaphore import Semaphore
+from gevent._threading import get_ident, local
 
 
-__all__ = ['Semaphore', 'DummySemaphore', 'BoundedSemaphore', 'RLock']
+__all__ = ['Semaphore', 'DummySemaphore', 'BoundedSemaphore', 'RLock', 'NativeFriendlyRLock']
 
 
 class DummySemaphore(object):
@@ -116,3 +117,78 @@ class RLock(object):
 
     def _is_owned(self):
         return self._owner is getcurrent()
+
+
+class NativeFriendlyRLock(object):
+    def __init__(self):
+        self._thread_local = local()
+        self._owner = None
+        self._wait_queue = []
+        self._count = 0
+
+    def __repr__(self):
+        owner = self._owner
+        return "<%s owner=%r count=%d>" % (self.__class__.__name__, owner, self._count)
+
+    def acquire(self, blocking=1):
+        tid = get_ident()
+        gid = id(getcurrent())
+        tid_gid = (tid, gid)
+        if tid_gid == self._owner:  # We trust the GIL here so we can do this comparison w/o locking.
+            self._count = self._count + 1
+            return True
+
+        greenlet_lock = self._get_greenlet_lock()
+
+        self._wait_queue.append(gid)
+        # this is a safety in case an exception is raised somewhere and we must make sure we're not in the queue
+        # otherwise it'll get stuck forever.
+        remove_from_queue_on_return = True
+        try:
+            while True:
+                if not greenlet_lock.acquire(blocking):
+                    return False  # non-blocking and failed to acquire lock
+
+                if self._wait_queue[0] == gid:
+                    # Hurray, we can have the lock.
+                    self._owner = tid_gid
+                    self._count = 1
+                    remove_from_queue_on_return = False  # don't remove us from the queue
+                    return True
+                else:
+                    # we already hold the greenlet lock so obviously the owner is not in our thread.
+                    greenlet_lock.release()
+                    if blocking:
+                        sleep(0.0005)  # 500 us -> initial delay of 1 ms
+                    else:
+                        return False
+        finally:
+            if remove_from_queue_on_return:
+                self._wait_queue.remove(gid)
+
+    def release(self):
+        tid_gid = (get_ident(), id(getcurrent()))
+        if tid_gid != self._owner:
+            raise RuntimeError("cannot release un-acquired lock")
+
+        self._count = self._count - 1
+        if not self._count:
+            self._owner = None
+            gid = self._wait_queue.pop(0)
+            assert gid == tid_gid[1]
+            self._thread_local.greenlet_lock.release()
+
+    __enter__ = acquire
+
+    def __exit__(self, t, v, tb):
+        self.release()
+
+    def _get_greenlet_lock(self):
+        if not hasattr(self._thread_local, 'greenlet_lock'):
+            greenlet_lock = self._thread_local.greenlet_lock = Semaphore(1)
+        else:
+            greenlet_lock = self._thread_local.greenlet_lock
+        return greenlet_lock
+
+    def _is_owned(self):
+        return self._owner == (get_ident(), id(getcurrent()))

--- a/greentest/test__native_friendly_rlock.py
+++ b/greentest/test__native_friendly_rlock.py
@@ -1,0 +1,156 @@
+import sys
+import random
+import gevent
+from gevent.lock import NativeFriendlyRLock
+import threading
+import lock_tests
+
+try:
+    from test import support
+except ImportError:
+    from test import test_support as support
+
+
+class NativeFriendlyRLockTestCase(lock_tests.RLockTests):
+    locktype = staticmethod(NativeFriendlyRLock)
+
+    def setUp(self):
+        super(NativeFriendlyRLockTestCase, self).setUp()
+        sys.setcheckinterval(100)
+
+    def test_acquire_release(self):
+        l = self.locktype()
+        l.acquire()
+        l.release()
+
+    def test_double_acquire_double_release(self):
+        l = self.locktype()
+        l.acquire()
+        l.acquire()
+        l.release()
+        l.release()
+
+    def test_release_too_much(self):
+        l = self.locktype()
+        self.assertRaises(RuntimeError, l.release)
+        l.acquire()
+        l.release()
+        self.assertRaises(RuntimeError, l.release)
+
+    def test_acquire_release__two_threads(self):
+        l = self.locktype()
+
+        def foo(lock):
+            lock.acquire()
+            lock.release()
+
+        a = threading.Thread(target=foo, args=(l,))
+        b = threading.Thread(target=foo, args=(l,))
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+
+    def test_lock_sharing_blocking(self):
+        def greenlet_func(lock, n_threads, thread_idx, n_greenlets, greenlet_idx, l):
+            with lock:
+                l.append(thread_idx * n_greenlets + greenlet_idx)
+
+        def thread_func(lock, n_threads, thread_idx, n_greenlets, l):
+            greenlets = []
+            for i in range(n_greenlets):
+                greenlets.append(gevent.spawn(greenlet_func, lock, n_threads, thread_idx, n_greenlets, i, l))
+            gevent.joinall(greenlets)
+
+        n_threads = 10
+        n_greenlets = 20
+        threads = []
+        lock = self.locktype()
+        result = []
+        for i in range(n_threads):
+            threads.append(threading.Thread(target=thread_func, args=(lock, n_threads, i, n_greenlets, result)))
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        self.assertEquals(list(range(n_threads * n_greenlets)), sorted(result))
+
+    def test_lock_sharing_between_greenlets(self):
+        def greenlet_func(l):
+            for i in range(5):
+                l.append(i)
+                gevent.sleep(0.01)
+
+        def greenlet_lock_func(lock):
+            lock.acquire()
+
+    def test_fair_acquire_between_threads(self):
+        random.seed(1)
+
+        def thread_func(lock, acquire_array, lock_array, index):
+            gevent.sleep(random.uniform(0, 0.1))
+            # We use the fact that the GIL prevents CPython from context switching between the acquire_array.append()
+            # and the lock.acquire() when we set the check interval to a great value
+            sys.setcheckinterval(10000000)
+            acquire_array.append(index)
+            with lock:
+                sys.setcheckinterval(1)
+                lock_array.append(index)
+
+        lock = self.locktype()
+        acquire_array = []
+        lock_array = []
+        n_threads = 30
+        threads = [threading.Thread(target=thread_func, args=(lock, acquire_array, lock_array, i))
+                   for i in range(n_threads)]
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+
+        self.assertEquals(n_threads, len(acquire_array))
+        self.assertEquals(list(range(n_threads)), sorted(acquire_array))
+        self.assertEquals(acquire_array, lock_array)
+
+    def test_fair_acquire_between_threads_and_greenlets(self):
+        random.seed(1)
+
+        def greenlet_func(lock, acquire_array, lock_array, n):
+            gevent.sleep(random.uniform(0, 0.1))
+            # We use the fact that the GIL prevents CPython from context switching between the acquire_array.append()
+            # and the lock.acquire() when we set the check interval to a great value
+            sys.setcheckinterval(10000000)
+            acquire_array.append(n)
+            with lock:
+                sys.setcheckinterval(1)
+                lock_array.append(n)
+
+        def thread_func(lock, acquire_array, lock_array, n_greenlets, index):
+            gevent.sleep(random.uniform(0, 0.1))
+            greenlets = [gevent.spawn(greenlet_func, lock, acquire_array, lock_array, n_greenlets * index + i)
+                         for i in range(n_greenlets)]
+            gevent.joinall(greenlets)
+
+        lock = self.locktype()
+        acquire_array = []
+        lock_array = []
+        n_threads = 20
+        n_greenlets = 20
+        threads = [threading.Thread(target=thread_func, args=(lock, acquire_array, lock_array, n_greenlets, i))
+                   for i in range(n_threads)]
+        [t.start() for t in threads]
+        [t.join() for t in threads]
+
+        self.assertEquals(n_threads * n_greenlets, len(acquire_array))
+        self.assertEquals(list(range(n_threads * n_greenlets)), sorted(acquire_array))
+        self.assertEquals(list(range(n_threads * n_greenlets)), sorted(lock_array))
+        self.maxDiff = None
+        self.assertEquals(acquire_array, lock_array)
+
+
+def main():
+    support.run_unittest(NativeFriendlyRLockTestCase)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Gevent is awesome. I use it in tons of projects and couldn't be happier.  While gevent can be safely used in a (native) threaded application,  there is no solution (that I'm aware of at least) to synchronize greenlets between different native threads. While this type of lock may seem not necessary at first, its necessity becomes apparent when there's a resource shared between different native threads such as a logging infrastructure that innocently holds a lock to synchronize log writes.

NativeFriendlyRLock (for lack of a better name) is an RLock that can be used across different native threads (e.g. Python's threading module) and greenlets. It provides a fair synchronization between threads/greenlets while keeping the "blocking" part gevent-friendly.

The commit adds the new lock type and a new test file that also tests fairness.

Your feedback (and hopefully pull request approval) is very appreciated :)