### PR TITLE
Fixed typo in the socket3 functions.

### DIFF
--- a/gevent/_socket3.py
+++ b/gevent/_socket3.py
@@ -130,7 +130,7 @@ class socket(_socket.socket):
             sock.setblocking(True)
         return sock, addr
 
-    def makefile(self, mode="r", buffering=None, *,
+    def makefile(self, mode="r", buffering=None, 
                  encoding=None, errors=None, newline=None):
         """makefile(...) -> an I/O stream connected to the socket
 


### PR DESCRIPTION
Related to issue: https://github.com/surfly/gevent/issues/478.