### PR TITLE
[BUG FIX] error: ISO C90 forbids mixed declarations and code

### DIFF
--- a/gevent/fileobject.py
+++ b/gevent/fileobject.py
@@ -260,12 +260,12 @@ class FileObjectThread(object):
 
     for method in ['read', 'readinto', 'readline', 'readlines', 'write', 'writelines', 'xreadlines']:
 
-        exec '''def %s(self, *args, **kwargs):
+        exec ('''def %s(self, *args, **kwargs):
     fobj = self._fobj
     if fobj is None:
         raise FileObjectClosed
     return self._apply(fobj.%s, args, kwargs)
-''' % (method, method)
+''',(method, method))
 
     def __iter__(self):
         return self

--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -279,7 +279,7 @@ class Hub(greenlet):
         else:
             try:
                 info = self.loop._format()
-            except Exception, ex:
+            except Exception as ex:
                 info = str(ex) or repr(ex) or 'error'
         result = '<%s at 0x%x %s' % (self.__class__.__name__, id(self), info)
         if self._resolver is not None:

--- a/gevent/libev.h
+++ b/gevent/libev.h
@@ -16,10 +16,11 @@ static int sigchld_state = 0;
 
 static struct ev_loop* gevent_ev_default_loop(unsigned int flags)
 {
-    if (sigchld_state)
-        return ev_default_loop(flags);
     struct ev_loop* result;
     struct sigaction tmp;
+
+    if (sigchld_state)
+        return ev_default_loop(flags);
     sigaction(SIGCHLD, NULL, &tmp);
     result = ev_default_loop(flags);
     // XXX what if SIGCHLD received there?

--- a/gevent/os.py
+++ b/gevent/os.py
@@ -48,7 +48,7 @@ if fcntl:
         while True:
             try:
                 return _read(fd, n)
-            except OSError, e:
+            except OSError as e:
                 if e.errno not in ignored_errors:
                     raise
                 sys.exc_clear()
@@ -67,7 +67,7 @@ if fcntl:
         while True:
             try:
                 return _write(fd, buf)
-            except OSError, e:
+            except OSError as e:
                 if e.errno not in ignored_errors:
                     raise
                 sys.exc_clear()

--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -353,7 +353,7 @@ class WSGIHandler(object):
     def _sendall(self, data):
         try:
             self.socket.sendall(data)
-        except socket.error, ex:
+        except socket.error as ex:
             self.status = 'socket error: %s' % ex
             if self.code > 0:
                 self.code = -self.code

--- a/gevent/server.py
+++ b/gevent/server.py
@@ -91,7 +91,7 @@ class StreamServer(BaseServer):
     def do_read(self):
         try:
             client_socket, address = self.socket.accept()
-        except _socket.error, err:
+        except _socket.error as err:
             if err[0] == EWOULDBLOCK:
                 return
             raise
@@ -130,7 +130,7 @@ class DatagramServer(BaseServer):
     def do_read(self):
         try:
             data, address = self._socket.recvfrom(8192)
-        except _socket.error, err:
+        except _socket.error as err:
             if err[0] == EWOULDBLOCK:
                 return
             raise

--- a/gevent/ssl.py
+++ b/gevent/ssl.py
@@ -74,7 +74,7 @@ class SSLSocket(socket):
         # see if it's connected
         try:
             socket.getpeername(self)
-        except socket_error, e:
+        except socket_error as e:
             if e[0] != errno.ENOTCONN:
                 raise
             # no, no connection yet

--- a/gevent/subprocess.py
+++ b/gevent/subprocess.py
@@ -443,7 +443,7 @@ class Popen(object):
                                                  env,
                                                  cwd,
                                                  startupinfo)
-            except pywintypes.error, e:
+            except pywintypes.error as e:
                 # Translate pywintypes.error to WindowsError, which is
                 # a subclass of OSError.  FIXME: We should really
                 # translate errno using _sys_errlist (or similar), but
@@ -799,7 +799,7 @@ def write_and_close(fobj, data):
     try:
         if data:
             fobj.write(data)
-    except (OSError, IOError), ex:
+    except (OSError, IOError) as ex:
         if ex.errno != errno.EPIPE and ex.errno != errno.EINVAL:
             raise
     finally:


### PR DESCRIPTION
In file included from gevent/gevent.core.c:237:0:
gevent/libev.h: In function ‘gevent_ev_default_loop’:
gevent/libev.h:22:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
cc1: some warnings being treated as errors
