### PR TITLE
Bugfix: ipv6: when binding to "", use AF_INET6

### DIFF
--- a/gevent/baseserver.py
+++ b/gevent/baseserver.py
@@ -303,7 +303,7 @@ def _extract_family(host):
 
 def _parse_address(address):
     if isinstance(address, tuple):
-        if ':' in address[0]:
+        if not address[0] or ':' in address[0]:
             return _socket.AF_INET6, address
         return _socket.AF_INET, address
     elif isinstance(address, string_types):
@@ -314,9 +314,9 @@ def _parse_address(address):
                 host = ''
             return family, (host, int(port))
         else:
-            return _socket.AF_INET, ('', int(address))
+            return _socket.AF_INET6, ('', int(address))
     elif isinstance(address, integer_types):
-        return _socket.AF_INET, ('', int(address))
+        return _socket.AF_INET6, ('', int(address))
     else:
         raise TypeError('Expected tuple or string, got %s' % type(address))
 


### PR DESCRIPTION
That'll make the socket work both with IPv4 and IPv6.

(If for whatever reason you still want an IPv4-only socket, you can bind to 0.0.0.0.)