### PR TITLE
Add empty() to Group.

### DIFF
--- a/gevent/pool.py
+++ b/gevent/pool.py
@@ -190,6 +190,9 @@ class Group(object):
         returned iterator should be considered in arbitrary order."""
         return IMapUnordered.spawn(func, iterable, spawn=self.spawn)
 
+    def empty(self):
+        return self.__len__() == 0
+
     def full(self):
         return False
 

--- a/gevent/pool.py
+++ b/gevent/pool.py
@@ -97,6 +97,7 @@ class Group(object):
                     raise greenlet.exception
         else:
             self._empty_event.wait(timeout=timeout)
+        return self._empty_event.is_set()
 
     def kill(self, exception=GreenletExit, block=True, timeout=None):
         timer = Timeout.start_new(timeout)


### PR DESCRIPTION
Add the empty() method to Group. In addition, join() returns self._empty_event.is_set() to signal if greenlets have been joined or not. I believe this could be especially useful if join() is invoked with the timeout parameter set.