### PR TITLE
Inherit from Exception instead of BaseException

### DIFF
--- a/gevent/timeout.py
+++ b/gevent/timeout.py
@@ -19,7 +19,7 @@ __all__ = ['Timeout',
            'with_timeout']
 
 
-class Timeout(BaseException):
+class Timeout(Exception):
     """Raise *exception* in the current greenlet after given time period::
 
         timeout = Timeout(seconds, exception)


### PR DESCRIPTION
Base Exception is not meant to be inherited directly. "The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception)."