### PR TITLE
Remove SSL3 entirely as default TLS level

### DIFF
--- a/gevent/_ssl2.py
+++ b/gevent/_ssl2.py
@@ -399,7 +399,7 @@ def wrap_socket(sock, keyfile=None, certfile=None,
                      ciphers=ciphers)
 
 
-def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
+def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
     """Retrieve the certificate from the server at the specified address,
     and return it as a PEM-encoded string.
     If 'ca_certs' is specified, validate the server cert against it.

--- a/gevent/_ssl3.py
+++ b/gevent/_ssl3.py
@@ -442,7 +442,7 @@ def wrap_socket(sock, keyfile=None, certfile=None,
                      ciphers=ciphers)
 
 
-def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
+def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
     """Retrieve the certificate from the server at the specified address,
     and return it as a PEM-encoded string.
     If 'ca_certs' is specified, validate the server cert against it.


### PR DESCRIPTION
Since SSL3 is pretty much [completely broken now](https://www.imperialviolet.org/2014/12/08/poodleagain.html), everyone should move away from it.

Should also fix #513
