### PR TITLE
subprocess.Popen `bufsize` option actually used

### DIFF
--- a/gevent/subprocess.py
+++ b/gevent/subprocess.py
@@ -245,17 +245,17 @@ class Popen(object):
                 errread = msvcrt.open_osfhandle(errread.Detach(), 0)
 
         if p2cwrite is not None:
-            self.stdin = FileObject(p2cwrite, 'wb')
+            self.stdin = FileObject(p2cwrite, 'wb', bufsize)
         if c2pread is not None:
             if universal_newlines:
-                self.stdout = FileObject(c2pread, 'rU')
+                self.stdout = FileObject(c2pread, 'rU', bufsize)
             else:
-                self.stdout = FileObject(c2pread, 'rb')
+                self.stdout = FileObject(c2pread, 'rb', bufsize)
         if errread is not None:
             if universal_newlines:
-                self.stderr = FileObject(errread, 'rU')
+                self.stderr = FileObject(errread, 'rU', bufsize)
             else:
-                self.stderr = FileObject(errread, 'rb')
+                self.stderr = FileObject(errread, 'rb', bufsize)
 
     def __repr__(self):
         return '<%s at 0x%x pid=%r returncode=%r>' % (self.__class__.__name__, id(self), self.pid, self.returncode)

--- a/greentest/test__subprocess.py
+++ b/greentest/test__subprocess.py
@@ -159,6 +159,16 @@ class Test(greentest.TestCase):
         else:
             raise AssertionError('must fail with CalledProcessError')
 
+    def test_popen_bufsize(self):
+        # Test that subprocess has unbuffered output by default
+        # (as the vanilla subprocess module)
+        p = subprocess.Popen([sys.executable, '-u', '-c',
+                              'import sys; sys.stdout.write(sys.stdin.readline())'],
+                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        p.stdin.write('foobar\n')
+        r = p.stdout.readline()
+        self.assertEqual(r, 'foobar\n')
+
 
 if __name__ == '__main__':
     greentest.main()


### PR DESCRIPTION
The `bufsize` option of the `subprocess.Popen` module wasn't used (at all), meaning that the default was usually buffered (platform dependant), and was also not modifiable.

This was also different from the behavior of the vanilla `subprocess.Popen` module

Note that this change the default behavior of the class (buffered becomes unbuffered in most cases)