### PR TITLE
Make DummySemaphore.acquire return True

### DIFF
--- a/gevent/lock.py
+++ b/gevent/lock.py
@@ -32,7 +32,7 @@ class DummySemaphore(object):
         pass
 
     def acquire(self, blocking=True, timeout=None):
-        pass
+        return True
 
     def __enter__(self):
         pass


### PR DESCRIPTION
Usually gevent.lock.DummySemaphore and gevent.lock.Semaphore are used interchangeably
and since gevent.lock.Semaphore.acquire return a boolean for checking if acquiring
lock failed or worked, it will make sense to just return True for DummySemaphore.acquire,
this way we can just use afterward ``if not acquired: ...``.