### PR TITLE
Fix test_httpservers, test_ares_timeout and test__socket_dns6.

### DIFF
--- a/greentest/2.7/test_httpservers.py
+++ b/greentest/2.7/test_httpservers.py
@@ -418,6 +418,8 @@ class CGIHTTPServerTestCase(BaseTestCase):
         finally:
             BaseTestCase.tearDown(self)
 
+    @unittest.skipIf(hasattr(CGIHTTPServer, '_url_collapse_path'),
+                     "Only on <= 2.7.3")
     def test_url_collapse_path_split(self):
         test_vectors = {
             '': ('/', ''),
@@ -453,6 +455,50 @@ class CGIHTTPServerTestCase(BaseTestCase):
                                   CGIHTTPServer._url_collapse_path_split, path)
             else:
                 actual = CGIHTTPServer._url_collapse_path_split(path)
+                self.assertEqual(expected, actual,
+                                 msg='path = %r\nGot:    %r\nWanted: %r' %
+                                 (path, actual, expected))
+
+    @unittest.skipIf(hasattr(CGIHTTPServer, '_url_collapse_path_split'),
+                     "Only on >= 2.7.3")
+    def test_url_collapse_path(self):
+        # verify tail is the last portion and head is the rest on proper urls
+        test_vectors = {
+            '': '//',
+            '..': IndexError,
+            '/.//..': IndexError,
+            '/': '//',
+            '//': '//',
+            '/\\': '//\\',
+            '/.//': '//',
+            'cgi-bin/file1.py': '/cgi-bin/file1.py',
+            '/cgi-bin/file1.py': '/cgi-bin/file1.py',
+            'a': '//a',
+            '/a': '//a',
+            '//a': '//a',
+            './a': '//a',
+            './C:/': '/C:/',
+            '/a/b': '/a/b',
+            '/a/b/': '/a/b/',
+            '/a/b/.': '/a/b/',
+            '/a/b/c/..': '/a/b/',
+            '/a/b/c/../d': '/a/b/d',
+            '/a/b/c/../d/e/../f': '/a/b/d/f',
+            '/a/b/c/../d/e/../../f': '/a/b/f',
+            '/a/b/c/../d/e/.././././..//f': '/a/b/f',
+            '../a/b/c/../d/e/.././././..//f': IndexError,
+            '/a/b/c/../d/e/../../../f': '/a/f',
+            '/a/b/c/../d/e/../../../../f': '//f',
+            '/a/b/c/../d/e/../../../../../f': IndexError,
+            '/a/b/c/../d/e/../../../../f/..': '//',
+            '/a/b/c/../d/e/../../../../f/../.': '//',
+        }
+        for path, expected in test_vectors.iteritems():
+            if isinstance(expected, type) and issubclass(expected, Exception):
+                self.assertRaises(expected,
+                                  CGIHTTPServer._url_collapse_path, path)
+            else:
+                actual = CGIHTTPServer._url_collapse_path(path)
                 self.assertEqual(expected, actual,
                                  msg='path = %r\nGot:    %r\nWanted: %r' %
                                  (path, actual, expected))


### PR DESCRIPTION
As mentioned in #551, #552, #248 and others, these three tests have been failing due to reasons out of gevent's control. (The `httpservers` failure is because it relies on the internals of the CGI module that have now been moved. The DNS failures are due to differences in DNS configuration or real-world data. `test_ares_timeout` is because it tries to bind to port 53, which doesn't work for non-root users under unix, and to detect this it relies on a specific error message which has either changed or varies between platforms. )

This PR fixes all three: 

* `test_httpservers` gets an updated test from the main CPython repository when running on newer versions of Python.
* `test_ares_timeout` uses a different port (so it usually runs), and more carefully detects errors that prevent it from running.
* `test_socket_dns6` already had relaxed checks for IPV6 addresses, this relaxes them a bit further to account for the differences I'm seeing. (I'd be curious to know if others see more differences).