### PR TITLE
Fix JoinableQueue when items passed in constructor

### DIFF
--- a/gevent/queue.py
+++ b/gevent/queue.py
@@ -349,7 +349,12 @@ class JoinableQueue(Queue):
     def __init__(self, maxsize=None, items=None, unfinished_tasks=None):
         from gevent.event import Event
         Queue.__init__(self, maxsize, items)
-        self.unfinished_tasks = unfinished_tasks or 0
+        if unfinished_tasks:
+            self.unfinished_tasks = unfinished_tasks
+        elif items:
+            self.unfinished_tasks = len(items)
+        else:
+            self.unfinished_tasks = 0
         self._cond = Event()
         self._cond.set()
 


### PR DESCRIPTION
unfinished_tasks variable wasn't set when items are passed in constructor, leading to ValueError: 'task_done() called too many times' when task_done() is called.
test to duplicate the error:

from gevent.queue import JoinableQueue
q = JoinableQueue(items=[1,2,3])
q.get()
q.task_done()