### PR TITLE
Fix ThreadResult not handling exceptions; remove apply_e.

### DIFF
--- a/gevent/fileobject.py
+++ b/gevent/fileobject.py
@@ -247,7 +247,7 @@ class FileObjectThread(object):
 
     def _apply(self, func, args=None, kwargs=None):
         with self.lock:
-            return self.threadpool.apply_e(BaseException, func, args, kwargs)
+            return self.threadpool.apply(func, args, kwargs)
 
     def close(self):
         fobj = self._fobj

--- a/gevent/os.py
+++ b/gevent/os.py
@@ -84,13 +84,13 @@ def tp_read(fd, n):
     """Read up to `n` bytes from file descriptor `fd`. Return a string
     containing the bytes read. If end-of-file is reached, an empty string
     is returned."""
-    return get_hub().threadpool.apply_e(BaseException, _read, (fd, n))
+    return get_hub().threadpool.apply(_read, (fd, n))
 
 
 def tp_write(fd, buf):
     """Write bytes from buffer `buf` to file descriptor `fd`. Return the
     number of bytes written."""
-    return get_hub().threadpool.apply_e(BaseException, _write, (fd, buf))
+    return get_hub().threadpool.apply(_write, (fd, buf))
 
 
 if hasattr(os, 'fork'):

--- a/gevent/resolver_thread.py
+++ b/gevent/resolver_thread.py
@@ -12,8 +12,6 @@ text_type('foo').encode('idna')
 
 class Resolver(object):
 
-    expected_errors = Exception
-
     def __init__(self, hub=None):
         if hub is None:
             hub = get_hub()
@@ -29,16 +27,16 @@ class Resolver(object):
     # below are thread-safe in Python, even if they are not thread-safe in C.
 
     def gethostbyname(self, *args):
-        return self.pool.apply_e(self.expected_errors, _socket.gethostbyname, args)
+        return self.pool.apply(_socket.gethostbyname, args)
 
     def gethostbyname_ex(self, *args):
-        return self.pool.apply_e(self.expected_errors, _socket.gethostbyname_ex, args)
+        return self.pool.apply(_socket.gethostbyname_ex, args)
 
     def getaddrinfo(self, *args, **kwargs):
-        return self.pool.apply_e(self.expected_errors, _socket.getaddrinfo, args, kwargs)
+        return self.pool.apply(_socket.getaddrinfo, args, kwargs)
 
     def gethostbyaddr(self, *args, **kwargs):
-        return self.pool.apply_e(self.expected_errors, _socket.gethostbyaddr, args, kwargs)
+        return self.pool.apply(_socket.gethostbyaddr, args, kwargs)
 
     def getnameinfo(self, *args, **kwargs):
-        return self.pool.apply_e(self.expected_errors, _socket.getnameinfo, args, kwargs)
+        return self.pool.apply(_socket.getnameinfo, args, kwargs)


### PR DESCRIPTION
Using threadpools to do normal things like `.spawn`, `.apply` etc worked significantly differently (erroneously) compared to other pools. Specifically, they would always swallow all exceptions: you'd get an `AsyncResult` back that would say success and no value.

The very strange `apply_e` wrapper attempted to work around this by wrapping functions in a try/catch that would return the result for `apply_e` to re-raise. Except that all "non-expected" exceptions would be silently swallowed as successful. Thankfully(?) the only users of this used `Exception` and `BaseException`.

The correct thing is to store the exception for the AsyncResult to handle/raise/etc. as normal, which eliminates the weirdness and the danger of silently dropping exceptions.

To further clarify: by setting returning `False` from `ThreadResult.successful` and setting `ThreadResult.exception` member, the `AsyncResult` will correctly capture that exception to potentially reraise on a `.get` if necessary.