### PR TITLE
Fix invalid syntax in _socket3.py

### DIFF
--- a/gevent/_socket3.py
+++ b/gevent/_socket3.py
@@ -132,7 +132,7 @@ class socket(_socket.socket):
             sock.setblocking(True)
         return sock, addr
 
-    def makefile(self, mode="r", buffering=None, *,
+    def makefile(self, mode="r", buffering=None,
                  encoding=None, errors=None, newline=None):
         """makefile(...) -> an I/O stream connected to the socket
 


### PR DESCRIPTION
    $ pyflakes gevent/_socket3.py
    gevent/_socket3.py:135: invalid syntax
        def makefile(self, mode="r", buffering=None, *,
                                                       ^