### PR TITLE
Use the TravisCI container infrastructure and enable linters

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,4 @@
 [pep8]
-ignore=E702,E265,E402,E731,E266
+ignore=E702,E265,E402,E731,E266,E261
 max_line_length=160
-exclude=.git,build,2.6,2.7,2.7pypy,3.3,test_support.py,test_queue.py,patched_tests_setup.py,test_threading_2.py,lock_tests.py,_sslgte279.py
+exclude=.tox,.git,build,2.6,2.7,2.7pypy,3.3,test_support.py,test_queue.py,patched_tests_setup.py,test_threading_2.py,lock_tests.py,_sslgte279.py

--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,4 @@
 [pep8]
-ignore=E702,E265,E402,E731,E266,E261
+ignore=E702,E265,E402,E731,E266,E261,W503
 max_line_length=160
 exclude=.tox,.git,build,2.6,2.7,2.7pypy,3.3,test_support.py,test_queue.py,patched_tests_setup.py,test_threading_2.py,lock_tests.py,_sslgte279.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
  - "2.6"
  - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - travis_retry pip install -U tox cython greenlet pep8 pyflakes
     - travis_retry python setup.py develop
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && LINT == true ]]; then make travis_test_linters; else make toxtest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then make travis_test_linters; elif [[$LINT == false]]; then make toxtest; fi
 notifications:
   email: false
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - travis_retry pip install -U tox cython greenlet pep8 pyflakes
     - travis_retry python setup.py develop
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then make travis_test_linters; elif [[$LINT == false]]; then make toxtest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then make travis_test_linters; elif [[ $LINT == false ]]; then make toxtest; fi
 notifications:
   email: false
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-python:
+env:
     - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ notifications:
 cache:
   directories:
     - $HOME/.cache/pip
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TOXENV=travis-lint
 install:
     - travis_retry pip install tox
+    - travis_retry pip install cython
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
 sudo: false
 python:
- - "2.6"
- - "2.7"
- - "3.3"
- - "3.4"
- - "pypy"
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy
+    - TOXENV=travis-lint
+install:
+    - travis_retry pip install tox
 script:
- - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then NWORKERS=4 PYTHON=pypy make travis_pypy; fi
- - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then NWORKERS=4 PYTHON=python$TRAVIS_PYTHON_VERSION make travis_cpython; fi
+    - tox
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ env:
     - TOXENV=py33
     - TOXENV=py34
 install:
-    - travis_retry pip install -U pip
-    - travis_retry pip install -U tox cython
+    - travis_retry pip install -U pip tox
+    # We only have a few files to compile, so not compiling cython itself
+    # makes the overall build much faster.
+    - travis_retry pip install --install-option='--no-cython-compile' cython
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
     - tox --sitepackages --develop
 notifications:
   email: false
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     # disables the cache.
     - travis_retry pip install -U tox cython greenlet pep8 pyflakes
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false ]]; then python setup.py develop && make fulltoxtest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false && $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then python setup.py develop && make toxtest; elif [[ $LINT == false ]]; then python setup.py develop && make fulltoxtest; fi
 notifications:
   email: false
 # cache: pip seems not to work

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,7 @@ script:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false ]]; then python setup.py develop && make toxtest; fi
 notifications:
   email: false
-cache: pip
+# cache: pip seems not to work
+cache:
+  directories:
+    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
     - TOXENV=py33
     - TOXENV=py34
 install:
-    - travis_retry pip install tox
-    - travis_retry pip install cython
+    - travis_retry pip install -U pip
+    - travis_retry pip install -U tox,cython
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 sudo: false
 env:
+    - TOXENV=travis-lint
     - TOXENV=py26
     - TOXENV=py27
+    - TOXENV=pypy
     - TOXENV=py33
     - TOXENV=py34
-    - TOXENV=pypy
-    - TOXENV=travis-lint
 install:
     - travis_retry pip install tox
     - travis_retry pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,24 @@
 language: python
 sudo: false
+python:
+    - 2.6
+    - 2.7
+    - pypy
+    - 3.3
+    - 3.4
 env:
-    - TOXENV=travis-lint
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=pypy
-    - TOXENV=py33
-    - TOXENV=py34
+    - LINT=true
+    - LINT=false
 install:
     # First install a newer pip so that it can use the wheel cache
     # (only needed until travis upgrades pip to 7.x)
     - travis_retry pip install -U pip
     # Then start installing our deps. Note that use of --build-options / --global-options / --install-options
     # disables the cache.
-    # XXX: This may be useless; our environment based test matrix means these commands all
-    # run with the same python version.
-    - travis_retry pip install -U tox cython greenlet
+    - travis_retry pip install -U tox cython greenlet pep8 pyflakes
+    - travis_retry python setup.py develop
 script:
-    # Try to use the site packages of cython we just installed. Also use development mode
-    # so that our actual source is not included in the cache (because it changes all the time
-    # the cache would be useless).
-    - tox --sitepackages --develop
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && LINT == true ]]; then make travis_test_linters; else make toxtest; fi
 notifications:
   email: false
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/build/gevent/gevent/.tox
+cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,22 @@ env:
     - TOXENV=py33
     - TOXENV=py34
 install:
-    - travis_retry pip install -U pip tox
-    # We only have a few files to compile, so not compiling cython itself
-    # makes the overall build much faster.
-    - travis_retry pip install --install-option='--no-cython-compile' cython
+    # First install a newer pip so that it can use the wheel cache
+    # (only needed until travis upgrades pip to 7.x)
+    - travis_retry pip install -U pip
+    # Then start installing our deps. Note that use of --build-options / --global-options / --install-options
+    # disables the cache.
+    # XXX: This may be useless; our environment based test matrix means these commands all
+    # run with the same python version.
+    - travis_retry pip install -U tox cython greenlet
 script:
-    # Try to use the site packages of cython we just installed
+    # Try to use the site packages of cython we just installed. Also use development mode
+    # so that our actual source is not included in the cache (because it changes all the time
+    # the cache would be useless).
     - tox --sitepackages --develop
 notifications:
   email: false
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/build/gevent/gevent/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
     # makes the overall build much faster.
     - travis_retry pip install --install-option='--no-cython-compile' cython
 script:
-    - tox
+    # Try to use the site packages of cython we just installed
+    - tox --sitepackages
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ install:
     - travis_retry pip install --install-option='--no-cython-compile' cython
 script:
     # Try to use the site packages of cython we just installed
-    - tox --sitepackages
+    - tox --sitepackages --develop
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ install:
     # Then start installing our deps. Note that use of --build-options / --global-options / --install-options
     # disables the cache.
     - travis_retry pip install -U tox cython greenlet pep8 pyflakes
-    - travis_retry python setup.py develop
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then make travis_test_linters; elif [[ $LINT == false ]]; then make toxtest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false ]]; then python setup.py develop && make toxtest; fi
 notifications:
   email: false
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     # disables the cache.
     - travis_retry pip install -U tox cython greenlet pep8 pyflakes
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false ]]; then python setup.py develop && make toxtest; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $LINT == true ]]; then python setup.py develop && make travis_test_linters; elif [[ $LINT == false ]]; then python setup.py develop && make fulltoxtest; fi
 notifications:
   email: false
 # cache: pip seems not to work

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - TOXENV=py34
 install:
     - travis_retry pip install -U pip
-    - travis_retry pip install -U tox,cython
+    - travis_retry pip install -U tox cython
 script:
     - tox
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -79,24 +79,10 @@ travis_pypy:
 	cd greentest && ${PYTHON} testrunner.py --config ../known_failures.py
 
 travis_cpython:
-	sudo add-apt-repository -y ppa:chris-lea/cython
+	pip install cython greenlet
 
-	# somehow travis changed something and python2.6 and python3.3 no longer accessible anymore
-	sudo add-apt-repository -y ppa:fkrull/deadsnakes
-	sudo apt-get -qq -y update
-	sudo -E apt-get -qq -y install ${PYTHON} ${PYTHON}-dev
+	make travistest
 
-	sudo apt-get -qq -y install cython
-	cython --version
-
-	pip install -q --download . greenlet
-	unzip -q greenlet-*.zip
-
-	sudo -E make travistest
-
-	sudo -E apt-get install ${PYTHON}-dbg
-
-	sudo -E PYTHON=${PYTHON}-dbg GEVENTSETUP_EV_VERIFY=3 make travistest
 
 
 .PHONY: clean all doc pep8 whitespace pyflakes lint travistest travis

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ doc:
 	cd doc && PYTHONPATH=.. make html
 
 whitespace:
-	! find . -not -path "./.tox/*" -not -path "*/__pycache__/*" -not -path "*.pyc" -not -path "./.git/*" -not -path "./build/*" -not -path "./libev/*" -not -path "./gevent/libev/*" -not -path "./gevent.egg-info/*" -not -path "./dist/*" -not -path "./.DS_Store" -not -path "./c-ares/*" -not -path "./gevent/gevent.*.[ch]" -not -path "./gevent/core.pyx" -not -path "./doc/_build/*" -not -path "./doc/mytheme/static/*" -type f | xargs egrep -l " $$"
+	! find . -not -path "./.tox/*" -not -path "*/__pycache__/*" -not -path "*.so" -not -path "*.pyc" -not -path "./.git/*" -not -path "./build/*" -not -path "./libev/*" -not -path "./gevent/libev/*" -not -path "./gevent.egg-info/*" -not -path "./dist/*" -not -path "./.DS_Store" -not -path "./c-ares/*" -not -path "./gevent/gevent.*.[ch]" -not -path "./gevent/core.pyx" -not -path "./doc/_build/*" -not -path "./doc/mytheme/static/*" -type f | xargs egrep -l " $$"
 
 pep8:
 	${PYTHON} `which pep8` .

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ doc:
 	cd doc && PYTHONPATH=.. make html
 
 whitespace:
-	! find . -not -path "./.git/*" -not -path "./build/*" -not -path "./libev/*" -not -path "./c-ares/*" -not -path "./doc/_build/*" -not -path "./doc/mytheme/static/*" -type f | xargs egrep -l " $$"
+	! find . -not -path "./.tox/*" -not -path "*/__pycache__/*" -not -path "*.pyc" -not -path "./.git/*" -not -path "./build/*" -not -path "./libev/*" -not -path "./gevent/libev/*" -not -path "./gevent.egg-info/*" -not -path "./dist/*" -not -path "./.DS_Store" -not -path "./c-ares/*" -not -path "./gevent/gevent.*.[ch]" -not -path "./gevent/core.pyx" -not -path "./doc/_build/*" -not -path "./doc/mytheme/static/*" -type f | xargs egrep -l " $$"
 
 pep8:
 	${PYTHON} `which pep8` .
@@ -43,7 +43,7 @@ pep8:
 pyflakes:
 	${PYTHON} util/pyflakes.py
 
-lint: whitespace pep8 pyflakes
+lint: whitespace pyflakes pep8
 
 travistest:
 	which ${PYTHON}
@@ -66,11 +66,13 @@ fulltoxtest:
 	cd greentest && GEVENT_RESOLVER=ares GEVENTARES_SERVERS=8.8.8.8 python testrunner.py --config ../known_failures.py --ignore tests_that_dont_use_resolver.txt
 	cd greentest && GEVENT_FILE=thread python testrunner.py --config ../known_failures.py `grep -l subprocess test_*.py`
 
+leaktest:
+	GEVENTSETUP_EV_VERIFY=3 GEVENTTEST_LEAKCHECK=1 make travistest
+
 bench:
 	${PYTHON} greentest/bench_sendall.py
 
 travis_pypy:
-	# no need to repeat linters here
 	which ${PYTHON}
 	${PYTHON} --version
 	${PYTHON} setup.py install
@@ -82,6 +84,9 @@ travis_cpython:
 
 	make travistest
 
+travis_test_linters:
+	make lint
+	make leaktest
 
 
 .PHONY: clean all doc pep8 whitespace pyflakes lint travistest travis

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ travistest:
 	which ${PYTHON}
 	${PYTHON} --version
 
-	cd greenlet-* && ${PYTHON} setup.py install -q
 	${PYTHON} -c 'import greenlet; print(greenlet, greenlet.__version__)'
 
 	${PYTHON} setup.py install

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,23 @@ To install the latest development version:
 running tests
 -------------
 
+There are a few different ways to run the tests. To simply run the
+tests on one version of Python during development, try this:
+
   python setup.py build
 
   cd greentest
 
   PYTHONPATH=.. python testrunner.py --config ../known_failures.py
+
+Before submitting a pull request, it's a good idea to run the tests
+across all supported versions of Python, and to check the code quality
+using pep8 and pyflakes. This is what is done on Travis CI. Locally it
+can be done using tox:
+
+  pip install tox
+
+  tox
 
 
 .. _gevent: http://www.gevent.org
@@ -61,4 +73,3 @@ running tests
 .. _mailing list: http://groups.google.com/group/gevent
 .. _blog: http://blog.gevent.org
 .. _twitter (@gevent): http://twitter.com/gevent
-

--- a/gevent/_socket2.py
+++ b/gevent/_socket2.py
@@ -291,17 +291,14 @@ class socket(object):
             data_sent = 0
             while data_sent < len(data):
                 data_sent += self.send(_get_memory(data, data_sent), flags)
-            return data_sent, 'no timeout'
         else:
             timeleft = self.timeout
             end = time.time() + timeleft
             data_sent = 0
-            trips = 0
             while True:
-                trips += 1
                 data_sent += self.send(_get_memory(data, data_sent), flags, timeout=timeleft)
                 if data_sent >= len(data):
-                    return data_sent, 'timeout', self.timeout, trips
+                    return
                 timeleft = end - time.time()
                 if timeleft <= 0:
                     raise timeout('timed out')

--- a/gevent/_socket2.py
+++ b/gevent/_socket2.py
@@ -296,10 +296,12 @@ class socket(object):
             timeleft = self.timeout
             end = time.time() + timeleft
             data_sent = 0
+            trips = 0
             while True:
+                trips += 1
                 data_sent += self.send(_get_memory(data, data_sent), flags, timeout=timeleft)
                 if data_sent >= len(data):
-                    return data_sent, 'timeout', self.timeout
+                    return data_sent, 'timeout', self.timeout, trips
                 timeleft = end - time.time()
                 if timeleft <= 0:
                     raise timeout('timed out')

--- a/gevent/_socket2.py
+++ b/gevent/_socket2.py
@@ -291,6 +291,7 @@ class socket(object):
             data_sent = 0
             while data_sent < len(data):
                 data_sent += self.send(_get_memory(data, data_sent), flags)
+            return data_sent, 'no timeout'
         else:
             timeleft = self.timeout
             end = time.time() + timeleft
@@ -298,7 +299,7 @@ class socket(object):
             while True:
                 data_sent += self.send(_get_memory(data, data_sent), flags, timeout=timeleft)
                 if data_sent >= len(data):
-                    break
+                    return data_sent, 'timeout', self.timeout
                 timeleft = end - time.time()
                 if timeleft <= 0:
                     raise timeout('timed out')

--- a/gevent/_socket2.py
+++ b/gevent/_socket2.py
@@ -398,6 +398,7 @@ else:
 
 if hasattr(__socket__, 'ssl'):
     from gevent.hub import PYGTE279
+
     def ssl(sock, keyfile=None, certfile=None):
         # deprecated in 2.7.9 but still present
         if PYGTE279:

--- a/gevent/baseserver.py
+++ b/gevent/baseserver.py
@@ -127,6 +127,7 @@ class BaseServer(object):
     def do_handle(self, *args):
         spawn = self._spawn
         handle = self._handle
+
         def _close_when_done(*args):
             try:
                 return handle(*args)

--- a/gevent/corecffi.py
+++ b/gevent/corecffi.py
@@ -1058,6 +1058,7 @@ class child(watcher):
     def rstatus(self, value):
         self._watcher.rstatus = value
 
+
 class stat(watcher):
     _watcher_start = libev.ev_stat_start
     _watcher_stop = libev.ev_stat_stop
@@ -1105,6 +1106,7 @@ class stat(watcher):
     @property
     def interval(self):
         return self._watcher.interval
+
 
 def _syserr_cb(msg):
     try:

--- a/gevent/threading.py
+++ b/gevent/threading.py
@@ -41,7 +41,7 @@ if PYPY:
     # otherwise we get a new DummyThread, which cannot be joined.
     # Fixes tests in test_threading_2
     if _get_ident() not in __threading__._active and len(__threading__._active) == 1:
-        k,v = __threading__._active.items()[0]
+        k, v = __threading__._active.items()[0]
         del __threading__._active[k]
         __threading__._active[_get_ident()] = v
 

--- a/greentest/greentest.py
+++ b/greentest/greentest.py
@@ -88,6 +88,30 @@ def wrap_refcount(method):
     if not os.getenv('GEVENTTEST_LEAKCHECK'):
         return method
 
+    # Some builtin things that we ignore
+    IGNORED_TYPES = (tuple, dict)
+
+    def type_hist():
+        import collections
+        d = collections.defaultdict(int)
+        for x in gc.get_objects():
+            k = type(x)
+            if k in IGNORED_TYPES:
+                continue
+            d[k] += 1
+        return d
+
+    def report_diff(a, b):
+        diff_lines = []
+        for k, v in sorted(a.items()):
+            if b[k] != v:
+                diff_lines.append("%s: %s != %s" % (k, v, b[k]))
+
+        if not diff_lines:
+            return None
+        diff = '\n'.join(diff_lines)
+        return diff
+
     @wraps(method)
     def wrapped(self, *args, **kwargs):
         gc.collect()
@@ -98,16 +122,29 @@ def wrap_refcount(method):
         gc.disable()
         try:
             while True:
-                d = len(gc.get_objects())
+
+                # Grab current snapshot
+                hist_before = type_hist()
+                d = sum(hist_before.values())
+
                 self.setUp()
                 method(self, *args, **kwargs)
                 self.tearDown()
+
+                # Grab post snapshot
                 if 'urlparse' in sys.modules:
                     sys.modules['urlparse'].clear_cache()
                 if 'urllib.parse' in sys.modules:
                     sys.modules['urllib.parse'].clear_cache()
-                d = len(gc.get_objects()) - d
+                hist_after = type_hist()
+                d = sum(hist_after.values()) - d
                 deltas.append(d)
+
+                # Reset and check for cycles
+                gc.collect()
+                if gc.garbage:
+                    raise AssertionError("Generated uncollectable garbage")
+
                 # the following configurations are classified as "no leak"
                 # [0, 0]
                 # [x, 0, 0]
@@ -122,7 +159,8 @@ def wrap_refcount(method):
                 elif len(deltas) >= 4 and sum(deltas[-4:]) == 0:
                     break
                 elif len(deltas) >= 3 and deltas[-1] > 0 and deltas[-1] == deltas[-2] and deltas[-2] == deltas[-3]:
-                    raise AssertionError('refcount increased by %r' % (deltas, ))
+                    diff = report_diff(hist_before, hist_after)
+                    raise AssertionError('refcount increased by %r\n%s' % (deltas, diff))
                 # OK, we don't know for sure yet. Let's search for more
                 if sum(deltas[-3:]) <= 0 or sum(deltas[-4:]) <= 0 or deltas[-4:].count(0) >= 2:
                     # this is suspicious, so give a few more runs
@@ -130,7 +168,7 @@ def wrap_refcount(method):
                 else:
                     limit = 7
                 if len(deltas) >= limit:
-                    raise AssertionError('refcount increased by %r' % (deltas, ))
+                    raise AssertionError('refcount increased by %r\n%s' % (deltas, report_diff(hist_before, hist_after)))
         finally:
             gc.enable()
         self.skipTearDown = True

--- a/greentest/greentest.py
+++ b/greentest/greentest.py
@@ -85,7 +85,7 @@ def wrap_timeout(timeout, method):
 
 
 def wrap_refcount(method):
-    if gettotalrefcount is None:
+    if not os.getenv('GEVENTTEST_LEAKCHECK'):
         return method
 
     @wraps(method)
@@ -98,7 +98,7 @@ def wrap_refcount(method):
         gc.disable()
         try:
             while True:
-                d = gettotalrefcount()
+                d = len(gc.get_objects())
                 self.setUp()
                 method(self, *args, **kwargs)
                 self.tearDown()
@@ -106,7 +106,7 @@ def wrap_refcount(method):
                     sys.modules['urlparse'].clear_cache()
                 if 'urllib.parse' in sys.modules:
                     sys.modules['urllib.parse'].clear_cache()
-                d = gettotalrefcount() - d
+                d = len(gc.get_objects()) - d
                 deltas.append(d)
                 # the following configurations are classified as "no leak"
                 # [0, 0]

--- a/greentest/test___example_servers.py
+++ b/greentest/test___example_servers.py
@@ -10,6 +10,7 @@ import util
 
 import ssl
 
+
 class Test_wsgiserver(util.TestServer):
     server = 'wsgiserver.py'
     URL = 'http://127.0.0.1:8088'

--- a/greentest/test__ares_host_result.py
+++ b/greentest/test__ares_host_result.py
@@ -10,7 +10,6 @@ except ImportError as ex:
     sys.exit(0)
 
 
-
 class TestPickle(greentest.TestCase):
     # Issue 104: ares.ares_host_result unpickleable
 
@@ -24,7 +23,7 @@ class TestPickle(greentest.TestCase):
 for i in range(0, pickle.HIGHEST_PROTOCOL):
     def make_test(j):
         return lambda self: self._test(j)
-    setattr(TestPickle, 'test' + str(i), make_test(i) )
+    setattr(TestPickle, 'test' + str(i), make_test(i))
 
 
 if __name__ == '__main__':

--- a/greentest/test__backdoor.py
+++ b/greentest/test__backdoor.py
@@ -25,7 +25,6 @@ class Test(greentest.TestCase):
 
     def test(self):
         server = backdoor.BackdoorServer(('127.0.0.1', 0))
-        server.start()
 
         def connect():
             conn = create_connection(('127.0.0.1', server.server_port))
@@ -34,9 +33,12 @@ class Test(greentest.TestCase):
             line = conn.makefile().readline()
             assert line.strip() == '4', repr(line)
 
-        jobs = [gevent.spawn(connect) for _ in xrange(10)]
-        gevent.joinall(jobs)
-        server.close()
+        server.start()
+        try:
+            jobs = [gevent.spawn(connect) for _ in xrange(10)]
+            gevent.joinall(jobs, raise_error=True)
+        finally:
+            server.close()
         #self.assertEqual(conn.recv(1), '')
 
     def test_quit(self):

--- a/greentest/test__greenlet.py
+++ b/greentest/test__greenlet.py
@@ -266,6 +266,7 @@ class TestStuff(greentest.TestCase):
         self.assertEqual(e.get(), 1)
 
     def test_wait_error(self):
+
         def x():
             sleep(DELAY)
             return 1
@@ -293,6 +294,7 @@ class TestStuff(greentest.TestCase):
         # works.
         def raises_but_ignored():
             raise ExpectedError("count")
+
         def sleep_forever():
             while True:
                 sleep(0.1)

--- a/greentest/test__pywsgi.py
+++ b/greentest/test__pywsgi.py
@@ -1000,7 +1000,6 @@ class ChunkedInputTests(TestCase):
             self.assert_error(IOError, 'unexpected end of file while parsing chunked data')
 
 
-
 class Expect100ContinueTests(TestCase):
     validator = None
 

--- a/greentest/test__refcount.py
+++ b/greentest/test__refcount.py
@@ -25,6 +25,7 @@ are not leaked by the hub.
 from __future__ import print_function
 from _socket import socket
 
+
 class Socket(socket):
     "Something we can have a weakref to"
 

--- a/greentest/test__server.py
+++ b/greentest/test__server.py
@@ -33,6 +33,7 @@ class SimpleStreamServer(StreamServer):
         finally:
             fd.close()
 
+
 class Settings:
     ServerClass = StreamServer
     ServerSubClass = SimpleStreamServer

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -164,7 +164,7 @@ class TestTCP(greentest.TestCase):
             start = time.time()
             try:
                 count = client.sendall(data_sent)
-                print("Sent data in %s" % (time.time() - start))
+                print("Sent %s data in %s" % (count, time.time() - start))
                 #self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
                 self.fail("Should raise timeout error")
             except self.TIMEOUT_ERROR:

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -147,6 +147,9 @@ class TestTCP(greentest.TestCase):
     if sys.platform != 'win32':
 
         def test_sendall_timeout(self):
+            # Travis-CI container infrastructure is configured with
+            # large socket buffers, at least 2MB, as-of Jun 3, 2015,
+            # so we must be sure to send more data than that.
             data_sent = b'hello' * 1000000
             client_sock = []
             acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
@@ -156,11 +159,7 @@ class TestTCP(greentest.TestCase):
             client.settimeout(0.1)
             start = time.time()
             try:
-                count = client.sendall(data_sent)
-                print("Sent %s data in %s" % (count, time.time() - start))
-                #self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
-                self.fail("Should raise timeout error")
-            except self.TIMEOUT_ERROR:
+                self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
                 took = time.time() - start
                 assert 0.1 - 0.01 <= took <= 0.1 + 0.1, took
             finally:

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -149,14 +149,25 @@ class TestTCP(greentest.TestCase):
         def test_sendall_timeout(self):
             data_sent = b'h' * 2000000
             client_sock = []
-            acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
+            def target():
+                print("Running thread")
+                sock = self.listener.accept()
+                print("Accepted")
+                client_sock.append(sock)
+                print("Done")
+            acceptor = Thread(target=target)
+#            acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
             client = self.create_connection()
             time.sleep(0.1)
             assert client_sock
             client.settimeout(0.1)
             start = time.time()
             try:
-                self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
+                count = client.sendall(data_sent)
+                print("Sent data in %s" % (time.time() - start))
+                #self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
+                self.fail("Should raise timeout error")
+            except self.TIMEOUT_ERROR:
                 took = time.time() - start
                 assert 0.1 - 0.01 <= took <= 0.1 + 0.1, took
             finally:

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -147,16 +147,9 @@ class TestTCP(greentest.TestCase):
     if sys.platform != 'win32':
 
         def test_sendall_timeout(self):
-            data_sent = b'h' * 2000000
+            data_sent = b'hello' * 1000000
             client_sock = []
-            def target():
-                print("Running thread")
-                sock = self.listener.accept()
-                print("Accepted")
-                client_sock.append(sock)
-                print("Done")
-            acceptor = Thread(target=target)
-#            acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
+            acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
             client = self.create_connection()
             time.sleep(0.1)
             assert client_sock

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -146,20 +146,22 @@ class TestTCP(greentest.TestCase):
     if sys.platform != 'win32':
 
         def test_sendall_timeout(self):
+            data_sent = b'h' * 2000000
             client_sock = []
             acceptor = Thread(target=lambda: client_sock.append(self.listener.accept()))
             client = self.create_connection()
             time.sleep(0.1)
             assert client_sock
             client.settimeout(0.1)
-            data_sent = b'h' * 1000000
             start = time.time()
-            self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
-            took = time.time() - start
-            assert 0.1 - 0.01 <= took <= 0.1 + 0.1, took
-            acceptor.join()
-            client.close()
-            client_sock[0][0].close()
+            try:
+                self.assertRaises(self.TIMEOUT_ERROR, client.sendall, data_sent)
+                took = time.time() - start
+                assert 0.1 - 0.01 <= took <= 0.1 + 0.1, took
+            finally:
+                acceptor.join()
+                client.close()
+                client_sock[0][0].close()
 
     def test_makefile(self):
 

--- a/greentest/test__socket.py
+++ b/greentest/test__socket.py
@@ -51,11 +51,12 @@ class TestTCP(greentest.TestCase):
         self.port = listener.getsockname()[1]
 
     def cleanup(self):
-        try:
-            self.listener.close()
-        except:
-            pass
-        del self.listener
+        if hasattr(self, 'listener'):
+            try:
+                self.listener.close()
+            except:
+                pass
+            del self.listener
 
     def create_connection(self):
         sock = socket.socket()

--- a/greentest/test__socket_dns.py
+++ b/greentest/test__socket_dns.py
@@ -105,7 +105,7 @@ def compare_relaxed(a, b):
     a_segments = a.count(':')
     b_segments = b.count(':')
     if a_segments and b_segments:
-        if a_segments == b_segments and a_segments in (4,5,6,7):
+        if a_segments == b_segments and a_segments in (4, 5, 6, 7):
             return True
         if a.rstrip(':').startswith(b.rstrip(':')) or b.rstrip(':').startswith(a.rstrip(':')):
             return True
@@ -245,8 +245,7 @@ class TestCase(greentest.TestCase):
         # because it calls assertSequenceEqual, which highlights the exact
         # difference in the tuple
         msg = format_call(func, args)
-        self.assertEqual((msg,gevent_result), (msg,real_result))
-
+        self.assertEqual((msg, gevent_result), (msg, real_result))
 
 
 class TestTypeError(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 [testenv]
 deps =
     greenlet
+    cython
 whitelist_externals =
     *
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 [testenv]
 deps =
     greenlet
-#    cython
+    cython
 whitelist_externals =
     *
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 [testenv]
 deps =
     greenlet
-    cython
+#    cython
 whitelist_externals =
     *
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,pypy,py33,py34
+    py26,py27,pypy,py33,py34,lint
 
 [testenv]
 deps =
@@ -17,3 +17,27 @@ commands =
 
 [testenv:pypy]
 deps =
+
+[testenv:lint]
+basepython =
+    python2.7
+deps =
+    {[testenv]deps}
+    pep8
+    pyflakes
+commands =
+    make lint
+
+[testenv:travis-lint]
+basepython =
+    python2.7
+deps =
+    {[testenv:lint]deps}
+commands =
+    make travis_test_linters
+
+[testenv:leak]
+basepython =
+    python2.7
+commonds =
+    make leaktest

--- a/util/pyflakes.py
+++ b/util/pyflakes.py
@@ -15,6 +15,7 @@ gevent/subprocess.py:\d+: undefined name
 gevent/_?ssl[23]?.py:\d+: undefined name
 gevent/__init__.py:\d+:.*imported but unused
 gevent/__init__.py:\d+: redefinition of unused 'signal' from line
+gevent/__init__.py:\d+: redefinition of unused 'socket' from line
 gevent/coros.py:\d+: 'from gevent.lock import *' used; unable to detect undefined names
 gevent/coros.py:\d+: '__all__' imported but unused
 gevent/hub.py:\d+: 'reraise' imported but unused


### PR DESCRIPTION
This comes with its own implicit speedups, but also allows use of caching the cython installation. Startup time goes from up to 30minutes to typically a few seconds.

This lets us use the travis test matrix more effectively. We spin off a separate process early on to run all the linting checks for code quality and garbage cycles. These should all be passing now and be maintained in a passing fashion. The linters were added to tox.ini for local developer convenience.