### PR TITLE
Fix for issues #461 and #471.

### DIFF
--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -334,7 +334,12 @@ class Hub(greenlet):
                     cb.stop()
 
     def print_exception(self, context, type, value, tb):
-        traceback.print_exception(type, value, tb)
+        # Python 3 does not gracefully handle None value or tb in
+        # traceback.print_exception() as previous versions did.
+        if value is None:
+            sys.stderr.write('%s\n' % type.__name__)
+        else:
+            traceback.print_exception(type, value, tb)
         del tb
         if context is not None:
             if not isinstance(context, str):

--- a/greentest/test__issues461_471.py
+++ b/greentest/test__issues461_471.py
@@ -10,6 +10,7 @@ import sys
 
 if sys.argv[1:] == ['subprocess']:
     import gevent
+
     def task():
         sys.stdout.write('ready\n')
         sys.stdout.flush()
@@ -20,7 +21,9 @@ if sys.argv[1:] == ['subprocess']:
         pass
 else:
     import signal
-    from subprocess import Popen, PIPE, TimeoutExpired
+    from subprocess import Popen, PIPE
+    import time
+
     if sys.platform.startswith('win'):
         from subprocess import CREATE_NEW_PROCESS_GROUP
         kwargs = {'creationflags': CREATE_NEW_PROCESS_GROUP}
@@ -29,9 +32,11 @@ else:
     p = Popen([sys.executable, __file__, 'subprocess'], stdout=PIPE, **kwargs)
     p.stdout.readline()
     p.send_signal(signal.SIGINT)
-    try:
-        p.wait(3)
-    except TimeoutExpired:
+    for i in range(30):
+        if p.poll() is not None:
+            break
+        time.sleep(0.1)
+    else:
         p.terminate()
         sys.exit(1)
     sys.exit(p.returncode)

--- a/greentest/test__issues461_471.py
+++ b/greentest/test__issues461_471.py
@@ -30,13 +30,19 @@ else:
     else:
         kwargs = {}
     p = Popen([sys.executable, __file__, 'subprocess'], stdout=PIPE, **kwargs)
-    p.stdout.readline()
+    line = p.stdout.readline()
+    if not isinstance(line, str):
+        line = line.decode('ascii')
+    assert line == 'ready\n'
     p.send_signal(signal.SIGINT)
+    # Wait up to 3 seconds for child process to die
     for i in range(30):
         if p.poll() is not None:
             break
         time.sleep(0.1)
     else:
+        # Kill unresponsive child and exit with error 1
         p.terminate()
+        p.wait()
         sys.exit(1)
     sys.exit(p.returncode)

--- a/greentest/test__issues461_471.py
+++ b/greentest/test__issues461_471.py
@@ -1,0 +1,37 @@
+'''Test for GitHub issues 461 and 471.
+
+When moving to Python 3, handling of KeyboardInterrupt exceptions caused
+by a Ctrl-C raise an exception while printing the traceback for a
+greenlet preventing the process from exiting. This test tests for proper
+handling of KeyboardInterrupt.
+'''
+
+import sys
+
+if sys.argv[1:] == ['subprocess']:
+    import gevent
+    def task():
+        sys.stdout.write('ready\n')
+        sys.stdout.flush()
+        gevent.sleep(30)
+    try:
+        gevent.spawn(task).get()
+    except KeyboardInterrupt:
+        pass
+else:
+    import signal
+    from subprocess import Popen, PIPE, TimeoutExpired
+    if sys.platform.startswith('win'):
+        from subprocess import CREATE_NEW_PROCESS_GROUP
+        kwargs = {'creationflags': CREATE_NEW_PROCESS_GROUP}
+    else:
+        kwargs = {}
+    p = Popen([sys.executable, __file__, 'subprocess'], stdout=PIPE, **kwargs)
+    p.stdout.readline()
+    p.send_signal(signal.SIGINT)
+    try:
+        p.wait(3)
+    except TimeoutExpired:
+        p.terminate()
+        sys.exit(1)
+    sys.exit(p.returncode)


### PR DESCRIPTION
This handles None exception values that would otherwise fail when passed
to traceback.print_exception() and prevent the process from exiting. An associated test is also included.

Related to #564.