### PR TITLE
Decorate gevent.select.select with @staticmethod

### DIFF
--- a/gevent/select.py
+++ b/gevent/select.py
@@ -39,7 +39,7 @@ class SelectResult(object):
         self.write.append(socket)
         self.event.set()
 
-
+@staticmethod
 def select(rlist, wlist, xlist, timeout=None):
     """An implementation of :meth:`select.select` that blocks only the current greenlet.
 


### PR DESCRIPTION
The original select.select has that decorator, too, so it works as a method
(assigned to selectors.SelectSelector._select).

Discovered while porting flask.socketio to Python3.