### PR TITLE
Add support for the new onerror attribute in CFFI 1.2.0

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -28,6 +28,9 @@ Unreleased
 - ``gevent.socket.socket.sendall`` supports arbitrary objects that
   implement the buffer protocol (such as ctypes structurs), just like
   native sockets. Reported in :issue:`466` by tzickel.
+- Added support for the ``onerror`` attribute present in CFFI 1.2.0
+  for better signal handling under PyPy. Thanks to Armin Rigo and Omer
+  Katz. (See https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in)
 
 1.1a1 (Jun 29, 2015)
 ====================
@@ -35,7 +38,8 @@ Unreleased
 - Add support for Python 3.3 and 3.4. Many people have contributed to
   this effort, including but not limited to Fantix King, hashstat,
   Elizabeth Myers, jander, Luke Woydziak, and others. See :issue:`38`.
-- Add support for PyPy. See :issue:`248`.
+- Add support for PyPy. See :issue:`248`. Note that for best results,
+  you'll need a very recent PyPy build including CFFI 1.2.0.
 - Drop support for Python 2.5. Python 2.5 users can continue to use
   gevent 1.0.x.
 - Fix ``gevent.greenlet.joinall`` to not ignore ``count`` when

--- a/greentest/2.7pypy/test_ssl.py
+++ b/greentest/2.7pypy/test_ssl.py
@@ -181,7 +181,11 @@ class BasicSocketTests(unittest.TestCase):
         self.assertGreaterEqual(fix, 0)
         self.assertLess(fix, 256)
         self.assertGreaterEqual(patch, 0)
-        self.assertLessEqual(patch, 26)
+        if sys.pypy_version_info[:3] < (2, 7, 0):
+            # gevent: compat with 2.7.0+; actually, this might depend on the local build environment
+            self.assertLessEqual(patch, 26)
+        else:
+            self.assertLessEqual(patch, 29)
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
         # Version string as returned by OpenSSL, the format might change

--- a/greentest/2.7pypy/test_urllib2.py
+++ b/greentest/2.7pypy/test_urllib2.py
@@ -279,6 +279,7 @@ class MockHTTPClass:
         self.data = None
         self.raise_on_endheaders = False
         self._tunnel_headers = {}
+        self.sock = None # gevent: compat with 2.7.0+
 
     def __call__(self, host, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
         self.host = host

--- a/greentest/patched_tests_setup.py
+++ b/greentest/patched_tests_setup.py
@@ -187,11 +187,15 @@ if hasattr(sys, 'pypy_version_info'):
         # in PyPy's forking. Only runs on linux and is specific to the PyPy
         # implementation of subprocess (possibly explains the extra parameter to
         # _execut_child)
-
-        'test_signal.InterProcessSignalTests.test_main',
-        # Fails to get the signal to the correct handler due to
-        # https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in
     ]
+
+    import cffi
+    if cffi.__version_info__ < (1, 2, 0):
+        disabled_tests += [
+            'test_signal.InterProcessSignalTests.test_main',
+            # Fails to get the signal to the correct handler due to
+            # https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in
+        ]
 
 # if 'signalfd' in os.environ.get('GEVENT_BACKEND', ''):
 #     # tests that don't interact well with signalfd

--- a/known_failures.py
+++ b/known_failures.py
@@ -77,13 +77,17 @@ if PYPY:
         # non-traceability? (Is it even repeatable? Possibly not; a lot of the test time is spent in,
         # e.g., test__socket_dns.py doing network stuff.)
         'test__threading_vs_settrace.py',
-
-
-        # check_sendall_interrupted and testInterruptedTimeout fail due to
-        # https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in
-        # See also patched_tests_setup and 'test_signal.InterProcessSignalTests.test_main'
-        'test_socket.py',
     ]
+
+    import cffi
+    if cffi.__version_info__ < (1, 2, 0):
+        FAILING_TESTS += [
+
+            # check_sendall_interrupted and testInterruptedTimeout fail due to
+            # https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in
+            # See also patched_tests_setup and 'test_signal.InterProcessSignalTests.test_main'
+            'test_socket.py',
+        ]
 
 
 if PY3:


### PR DESCRIPTION
This fixes our signal handling issue on PyPy 2.7.0 and above. See [the CFFI bug report](https://bitbucket.org/cffi/cffi/issue/152/handling-errors-from-signal-handlers-in) for discussion.