### PR TITLE
use object.__getattribute in gevent.local instead.

### DIFF
--- a/gevent/local.py
+++ b/gevent/local.py
@@ -217,7 +217,7 @@ def _patch(self):
         dct = impl.create_dict()
         args, kw = impl.localargs
         with impl.locallock:
-            self.__init__(*args, **kw)
+            object.__getattribute__(self, '__init__')(*args, **kw)
     with impl.locallock:
         object.__setattr__(self, '__dict__', dct)
         yield
@@ -250,7 +250,7 @@ class local(object):
         if name == '__dict__':
             raise AttributeError(
                 "%r object attribute '__dict__' is read-only"
-                % self.__class__.__name__)
+                % object.__getattribute__(self, '__class__').__name__)
         with _patch(self):
             return object.__setattr__(self, name, value)
 
@@ -258,7 +258,7 @@ class local(object):
         if name == '__dict__':
             raise AttributeError(
                 "%r object attribute '__dict__' is read-only"
-                % self.__class__.__name__)
+                % object.__getattribute__(self, '__class__').__name__)
         with _patch(self):
             return object.__delattr__(self, name)
 


### PR DESCRIPTION
when an application define a subclass derived from gevent.local, if
directly use self.xxx get attribute, gevent can't guarantee the
__getatrribute__ behave.

usecase like the follow:
https:review.openstack.org/#c/1022/3/nova/local.py

use gevent instead of eventlet in the usecase, it will work under
gevent 1.0.1 but won't work under genvet 1.0.2. Although we can
work around this in app level, keeping compatibility in gevent is
better.