### PR TITLE
Fix gevent._ssl3.SSLContext.read to return empty bytes if SSLError occurs.

### DIFF
--- a/gevent/_ssl3.py
+++ b/gevent/_ssl3.py
@@ -173,7 +173,7 @@ class SSLSocket(socket):
             except SSLError as ex:
                 if ex.args[0] == SSL_ERROR_EOF and self.suppress_ragged_eofs:
                     if buffer is None:
-                        return ''
+                        return b''
                     else:
                         return 0
                 else:


### PR DESCRIPTION
In Python3, SSLSocket.read should return b'' if SSLError occurs.
(https://github.com/python/cpython/blob/master/Lib/ssl.py#L792)
However, it returns empty str object('') currently. This fix just change the return value to b''.