### PR TITLE
Use the new ssl module on any python version that natively supports it

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,7 +7,11 @@
 1.1rc3 (Unreleased)
 ===================
 
-- TBD
+- Support the new PEP 466 :mod:`ssl` interfaces on any Python 2
+  version that supplies them, not just on the versions it officially
+  shipped with. Some Linux distributions, including RedHat/CentOS and
+  Amazon have backported the changes to older versions. Reported in
+  :issue:`702`.
 
 1.1rc2 (Dec 11, 2015)
 =====================

--- a/gevent/_socket2.py
+++ b/gevent/_socket2.py
@@ -494,16 +494,15 @@ elif 'fromfd' in __implements__:
     __implements__.remove('fromfd')
 
 if hasattr(__socket__, 'ssl'):
-    from gevent.hub import PYGTE279
 
     def ssl(sock, keyfile=None, certfile=None):
-        # deprecated in 2.7.9 but still present
-        if PYGTE279:
-            from . import _sslgte279
-            return _sslgte279.wrap_socket(sock, keyfile, certfile)
-        else:
-            from . import _ssl2
-            return _ssl2.sslwrap_simple(sock, keyfile, certfile)
+        # deprecated in 2.7.9 but still present;
+        # sometimes backported by distros. See ssl.py
+        from gevent import ssl as _sslmod
+        # wrap_socket is 2.7.9/backport, sslwrap_simple is older. They take
+        # the same arguments.
+        wrap = getattr(_sslmod, 'wrap_socket', None) or getattr(_sslmod, 'sslwrap_simple')
+        return wrap(sock, keyfile, certfile)
     __implements__.append('ssl')
 
 __all__ = __implements__ + __extensions__ + __imports__

--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -22,14 +22,7 @@ __all__ = ['getcurrent',
            'Hub',
            'Waiter']
 
-# Sniff Python > 2.7.9 for new SSL interfaces
-# If True, Python is greater than or equal to 2.7.9 (but not Python 3).
-PYGTE279 = (
-    sys.version_info[0] == 2
-    and sys.version_info[1] >= 7
-    and sys.version_info[2] >= 9
-)
-
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/gevent/ssl.py
+++ b/gevent/ssl.py
@@ -1,16 +1,21 @@
 """
 Secure Sockets Layer (SSL/TLS) module.
 """
-from gevent.hub import PY3
-from gevent.hub import PYGTE279
+from gevent.hub import PY2
 
 
-if PYGTE279:
-    from gevent import _sslgte279 as _source
-elif PY3:
-    from gevent import _ssl3 as _source
+if PY2:
+    if hasattr(__import__('ssl'), 'SSLContext'):
+        # It's not sufficient to check for >= 2.7.9; some distributions
+        # have backported most of PEP 466. Try to accommodate them. See Issue #702.
+        # We're just about to import ssl anyway so it's fine to import it here, just
+        # don't pollute the namespace
+        from gevent import _sslgte279 as _source
+    else:
+        from gevent import _ssl2 as _source
 else:
-    from gevent import _ssl2 as _source
+    # Py3
+    from gevent import _ssl3 as _source
 
 
 for key in _source.__dict__:


### PR DESCRIPTION
Support the new PEP 466 `ssl` interfaces on any Python 2 version that supplies them, not just on the versions it officially shipped with. Some Linux distributions, including RedHat/CentOS and Amazon have backported the changes to older versions. Reported in #702.

Tests pass locally for me on Python 2.6, 2.7.8 and 2.7.11. I don't have access to one of the backported versions for testing. 