### PR TITLE
Use latin-1 as decoding in unquote for conformance with PEP 3333

### DIFF
--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -949,7 +949,7 @@ class WSGIHandler(object):
             path, query = self.path.split('?', 1)
         else:
             path, query = self.path, ''
-        env['PATH_INFO'] = unquote(path)
+        env['PATH_INFO'] = unquote(path, encoding='latin-1')
         env['QUERY_STRING'] = query
 
         if self.headers.typeheader is not None:

--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -16,6 +16,7 @@ import sys
 import time
 import traceback
 from datetime import datetime
+
 try:
     from urllib import unquote
 except ImportError:
@@ -25,6 +26,12 @@ from gevent import socket
 import gevent
 from gevent.server import StreamServer
 from gevent.hub import GreenletExit, PY3, reraise
+
+from functools import partial
+if PY3:
+    unquote_latin1 = partial(unquote, encoding='latin-1')
+else:
+    unquote_latin1 = unquote
 
 _no_undoc_members = True # Don't put undocumented things into sphinx
 
@@ -949,7 +956,7 @@ class WSGIHandler(object):
             path, query = self.path.split('?', 1)
         else:
             path, query = self.path, ''
-        env['PATH_INFO'] = unquote(path, encoding='latin-1')
+        env['PATH_INFO'] = unquote_latin1(path)
         env['QUERY_STRING'] = query
 
         if self.headers.typeheader is not None:

--- a/greentest/test__pywsgi.py
+++ b/greentest/test__pywsgi.py
@@ -731,7 +731,7 @@ class TestInternational(TestCase):
         if not PY3:
             self.assertEqual(environ['PATH_INFO'], '/\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82')
         else:
-            self.assertEqual(environ['PATH_INFO'], '/\u043f\u0440\u0438\u0432\u0435\u0442')
+            self.assertEqual(environ['PATH_INFO'], '/\u043f\u0440\u0438\u0432\u0435\u0442'.encode('utf-8').decode('latin-1'))
         self.assertEqual(environ['QUERY_STRING'], '%D0%B2%D0%BE%D0%BF%D1%80%D0%BE%D1%81=%D0%BE%D1%82%D0%B2%D0%B5%D1%82')
         start_response("200 PASSED", [('Content-Type', 'text/plain')])
         return []


### PR DESCRIPTION
In Python 3, unquote will decode the resulting string according to the encoding keyword, which is utf-8 by default. However, according to PEP 3333 the native string representing PATH_INFO (among others) can only contain unicode codepoints from 0 to 255, which is why we need to decode to latin-1 instead of utf-8 here. Frameworks like Django turn this back into bytes for proper UTF-8 decoding by first encoding using latin-1 encoding, which can raise a UnicodeEncodeError if the string was decoded with UTF-8.

After applying this fix, gevent behaves the same as wsgiref for our application.

In Python 2 there is no such keyword so there will need to be a check for Python 3 here as well.