### PR TITLE
Fix #289. Avoid OverflowError in Py2 for large WSGI uploads.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,11 @@
 - Python 2: Using the blocking API at import time when multiple
   greenlets are also importing should not lead to ``LoopExit``.
   Reported in :issue:`798` by Garrett Heel.
+- Python 2: Don't raise ``OverflowError`` when using the ``readline``
+  method of the WSGI input stream without a size hint or with a large
+  size hint when the client is uploading a large amount of data.
+  Reported in :issue:`289` by ggjjlldd, with contributions by Nathan
+  Hoad.
 
 1.1rc3 (Jan 04, 2016)
 =====================

--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -157,7 +157,7 @@ class Input(object):
 
         # On Python 2, self.rfile is usually socket.makefile(), which
         # uses cStringIO.StringIO. If *length* is greater than the C
-        # sizeof(int) (typically 32 bits), parsing the argument to
+        # sizeof(int) (typically 32 bits signed), parsing the argument to
         # readline raises OverflowError. StringIO.read(), OTOH, uses
         # PySize_t, typically a long (64 bits). In a bare readline()
         # case, because the header lines we're trying to read with


### PR DESCRIPTION
I believe this is both safe and useful for 1.1 this late in the game. CPython 2.7 was the only platform that raised an OverflowError, both PyPy and Python 3 did not, so this just makes all platforms behave the same.