### PR TITLE
Fix a possible typo

### DIFF
--- a/gevent/_socket3.py
+++ b/gevent/_socket3.py
@@ -173,7 +173,7 @@ class socket(object):
             sock.setblocking(True)
         return sock, addr
 
-    def makefile(self, mode="r", buffering=None, *,
+    def makefile(self, mode="r", buffering=None, 
                  encoding=None, errors=None, newline=None):
         """makefile(...) -> an I/O stream connected to the socket
 


### PR DESCRIPTION
The "def makefile" prototype in gevent/_socket3.py seems wrong with an extra argument called '*'.

This syntax prevents a compilation of the library as a conda recipe.

All tests passed succesfully locally under Python2.7 (running the tests in ./greentest directory).