### PR TITLE
Issue some warnings for patch_all with invalid parameters

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -30,6 +30,16 @@
   requires having Cython installed first. (Note that the binary installation
   formats (wheels, exes, msis) are preferred on Windows.) Reported in
   :issue:`757` by Ned Batchelder.
+- Issue a warning when :func:`~gevent.monkey.patch_all` is called with
+  ``os`` set to False (*not* the default) but ``signal`` is still True
+  (the default). This combination of parameters will cause signal
+  handlers for ``SIGCHLD`` to not get called. In the future this might
+  raise an error. Reported by Josh Zuech.
+- Issue a warning when :func:`~gevent.monkey.patch_all` is called more
+  than once with different arguments. That causes the cumulative set of all True
+  arguments to be patched, which may cause unexpected results.
+- Fix returning the original values of certain ``threading``
+  attributes from :func:`gevent.monkey.get_original`.
 
 .. _bug 13502: http://bugs.python.org/issue13502
 

--- a/doc/whatsnew_1_1.rst
+++ b/doc/whatsnew_1_1.rst
@@ -119,6 +119,11 @@ downstream libraries, notably `gunicorn`_.
   :func:`gevent.os.waitpid` (again monkey patched by default) and
   :func:`gevent.signal.signal` (which is monkey patched only for the
   :data:`signal.SIGCHLD` case). The latter two patches are new in 1.1.
+- In gevent 1.0, use of libev child watchers (which are used
+  internally by ``gevent.subprocess``) had race conditions with
+  user-provided ``SIGCHLD`` handlers, causing many types of
+  unpredictable breakage. The two new APIs described above are
+  intended to rectify this.
 - Fork-watchers will be called, even in multi-threaded programs
   (except on Windows).
 - The default threadpool and threaded resolver work in child
@@ -137,6 +142,12 @@ possible in a monkey patched system, at least on POSIX platforms.
 
 .. caution:: It is not possible to use :mod:`gevent.subprocess` from
              native threads. See :mod:`gevent.subprocess` for details.
+
+.. note:: If the ``SIGCHLD`` signal is to be handled, it is important
+          to monkey patch (or directly use) both :mod:`os` and
+          :mod:`signal`; this is the default for
+          :func:`~gevent.monkey.patch_all`. Failure to do so can
+          result in the ``SIGCHLD`` signal being lost.
 
 .. tip:: All of the above entail forking a child process. Forking
 		 a child process that uses gevent, greenlets, and libev

--- a/gevent/monkey.py
+++ b/gevent/monkey.py
@@ -89,8 +89,8 @@ if sys.platform.startswith("win"):
 else:
     WIN = False
 
-# maps module name -> attribute name -> original item
-# e.g. "time" -> "sleep" -> built-in function sleep
+# maps module name -> {attribute name: original item}
+# e.g. "time" -> {"sleep": built-in function sleep}
 saved = {}
 
 
@@ -161,6 +161,25 @@ def patch_module(name, items=None):
             raise AttributeError('%r does not have __implements__' % gevent_module)
     for attr in items:
         patch_item(module, attr, getattr(gevent_module, attr))
+    return module
+
+
+_warnings = list()
+
+
+def _queue_warning(message):
+    # Queues a warning to show after the monkey-patching process is all done.
+    # Done this way to avoid extra imports during the process itself, just
+    # in case
+    _warnings.append(message)
+
+
+def _process_warnings():
+    import warnings
+    _w = list(_warnings)
+    del _warnings[:]
+    for warning in _w:
+        warnings.warn(warning, RuntimeWarning, stacklevel=3)
 
 
 def _patch_sys_std(name):
@@ -293,10 +312,20 @@ def patch_thread(threading=True, _threading_local=True, Event=False, logging=Tru
     #   return r, w
     # os.pipe = _pipe
 
+    # The 'threading' module copies some attributes from the
+    # thread module the first time it is imported. If we patch 'thread'
+    # before that happens, then we store the wrong values in 'saved',
+    # So if we're going to patch threading, we either need to import it
+    # before we patch thread, or manually clean up the attributes that
+    # are in trouble. The latter is tricky because of the different names
+    # on different versions.
+    if threading:
+        __import__('threading')
+
     patch_module('thread')
     if threading:
-        patch_module('threading')
-        threading = __import__('threading')
+        threading = patch_module('threading')
+
         if Event:
             from gevent.event import Event
             patch_item(threading, 'Event', Event)
@@ -348,11 +377,19 @@ def patch_thread(threading=True, _threading_local=True, Event=False, logging=Tru
                         sleep(0.01)
 
             main_thread.join = join
+
+            # Patch up the ident of the main thread to match. This
+            # matters if threading was imported before monkey-patching
+            # thread
+            oldid = main_thread.ident
+            main_thread._ident = threading.get_ident()
+            if oldid in threading._active:
+                threading._active[main_thread.ident] = threading._active[oldid]
+            if oldid != main_thread.ident:
+                del threading._active[oldid]
         else:
-            # TODO: Can we use warnings here or does that mess up monkey patching?
-            print("Monkey-patching not on the main thread; "
-                  "threading.main_thread().join() will hang from a greenlet",
-                  file=sys.stderr)
+            _queue_warning("Monkey-patching not on the main thread; "
+                           "threading.main_thread().join() will hang from a greenlet")
 
 
 def patch_socket(dns=True, aggressive=True):
@@ -482,11 +519,20 @@ def patch_signal():
     """
     patch_module("signal")
 
+def _check_repatching(**module_settings):
+    if saved.get('_gevent_saved_patch_all', module_settings) != module_settings:
+        _queue_warning("Patching more than once will result in the union of all True"
+                       " parameters being patched")
+
+    saved['_gevent_saved_patch_all'] = module_settings
 
 def patch_all(socket=True, dns=True, time=True, select=True, thread=True, os=True, ssl=True, httplib=False,
               subprocess=True, sys=False, aggressive=True, Event=False,
               builtins=True, signal=True):
     """Do all of the default monkey patching (calls every other applicable function in this module)."""
+    # Check to see if they're changing the patched list
+    _check_repatching(**locals())
+
     # order is important
     if os:
         patch_os()
@@ -511,7 +557,14 @@ def patch_all(socket=True, dns=True, time=True, select=True, thread=True, os=Tru
     if builtins:
         patch_builtins()
     if signal:
+        if not os:
+            _queue_warning('Patching signal but not os will result in SIGCHLD handlers'
+                           ' installed after this not being called and os.waitpid may not'
+                           ' function correctly if gevent.subprocess is used. This may raise an'
+                           ' error in the future.')
         patch_signal()
+
+    _process_warnings()
 
 
 def main():

--- a/gevent/os.py
+++ b/gevent/os.py
@@ -210,6 +210,7 @@ if hasattr(os, 'fork'):
         _waitpid = os.waitpid
         _WNOHANG = os.WNOHANG
 
+        # replaced by the signal module.
         _on_child_hook = lambda: None
 
         # {pid -> watcher or tuple(pid, rstatus, timestamp)}

--- a/gevent/subprocess.py
+++ b/gevent/subprocess.py
@@ -45,7 +45,7 @@ __implements__ = [
     'check_call',
     'check_output',
 ]
-if PY3:
+if PY3 and not sys.platform.startswith('win32'):
     __implements__.append("_posixsubprocess")
     _posixsubprocess = None
 

--- a/greentest/test__monkey.py
+++ b/greentest/test__monkey.py
@@ -54,17 +54,16 @@ with warnings.catch_warnings(record=True) as issued_warnings:
     assert 'more than once' in str(issued_warnings[0].message), issued_warnings[0]
 
     # Patching with the exact same argument doesn't issue a second warning.
-    # (just repeats the signal warning)
+    # in fact, it doesn't do anything
     del issued_warnings[:]
     monkey.patch_all(os=False)
     orig_saved['_gevent_saved_patch_all'] = monkey.saved['_gevent_saved_patch_all']
 
-    assert len(issued_warnings) == 1, len(issued_warnings)
-    assert 'SIGCHLD' in str(issued_warnings[-1].message), issued_warnings[-1]
+    assert len(issued_warnings) == 0, len(issued_warnings)
 
 # Make sure that re-patching did not change the monkey.saved
-# attribute, overwriting the original functions
-assert orig_saved == monkey.saved
+# attribute, overwriting the original functions.
+assert orig_saved == monkey.saved, (orig_saved, monkey.saved)
 
 # Make sure some problematic attributes stayed correct.
 # NOTE: This was only a problem if threading was not previously imported.


### PR DESCRIPTION
The main purpose of this patch is to issue a warning for some errors seen in production cases (running gunicorn apps). I consider them in scope for 1.1 because they're mostly about refining features that were added in 1.1 and which could trip up some unsuspecting users coming from 1.0.

- Patching signal but not os results in SIGCHLD handlers not getting called. Under gunicorn, this leads to the arbiter process not being aware of dead children, causing extended shutdown times and/or out-of-service scenarios. This may be an error in the future (because it's effectively a broken case), but right now it's just a warning because it's possible to not use the broken features.
- Patching multiple times with different arguments has an unintuitive effect. It's not always clear where this is being done either, so issue a warning about it.

Coming from a 1.0 code-base that had `os=False` in one monkey-patch call but not another (two semi-independent modules glued together in the app), the extended shutdowns were annoying to debug.

I also fixed some threading attributes being reported incorrectly from get_original that I happened to notice.