### PR TITLE
Return whether the pool became empty in join.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -19,6 +19,9 @@
 - Nested callbacks that set and clear an Event no longer cause
   ``wait`` to return prematurely. Reported in :issue:`771` by Sergey
   Vasilyev.
+- :class:`~.Group` and :class:`~.Pool` now return whether
+  :meth:`~.Group.join` returned with an empty group. Suggested by Filippo Sironi in
+  :pr:`503`.
 
 1.1.0 (Mar 5, 2016)
 ===================

--- a/greentest/test__pool.py
+++ b/greentest/test__pool.py
@@ -465,7 +465,8 @@ class TestJoinEmpty(greentest.TestCase):
 
     def test(self):
         p = pool.Pool()
-        p.join()
+        res = p.join()
+        self.assertTrue(res, "empty should return true")
 
 
 class TestSpawn(greentest.TestCase):
@@ -481,6 +482,16 @@ class TestSpawn(greentest.TestCase):
         gevent.sleep(0.19 if not greentest.RUNNING_ON_APPVEYOR else 0.5)
         self.assertEqual(len(p), 0)
 
+    def testSpawnAndWait(self):
+        p = pool.Pool(1)
+        self.assertEqual(len(p), 0)
+        p.spawn(gevent.sleep, 0.1)
+        self.assertEqual(len(p), 1)
+        res = p.join(0.01)
+        self.assertFalse(res, "waiting on a full pool should return false")
+        res = p.join()
+        self.assertTrue(res, "waiting to finish should be true")
+        self.assertEqual(len(p), 0)
 
 def error_iter():
     yield 1


### PR DESCRIPTION
Useful with a timeout argument.

Fixes #503.