### PR TITLE
Improve compliance of select.select and select.poll

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -33,6 +33,20 @@
 - The modules :mod:`gevent.os`, :mod:`gevent.signal` and
   :mod:`gevent.select` export all the attributes from their
   corresponding standard library counterpart.
+- Compliance: If :func:`gevent.select.select` is given a negative *timeout*
+  argument, raise an exception like the standard library does.
+- Compliance: If :func:`gevent.select.select` is given closed or invalid
+  file descriptors in any of its lists, raise the appropriate
+  ``EBADF`` exception like the standard library does. Previously,
+  libev would tend to return the descriptor as ready. In the worst
+  case, this adds an extra system call, but may also reduce latency if
+  descriptors are ready at the time of entry.
+- Compliance: :meth:`gevent.select.poll.unregister` raises an exception if *fd* is not
+  registered, like the standard library.
+- Compliance: :meth:`gevent.select.poll.poll` returns an event with
+  ``POLLNVAL`` for registered fds that are invalid. Previously it
+  would tend to report both read and write events.
+
 
 1.1.0 (Mar 5, 2016)
 ===================

--- a/gevent/_compat.py
+++ b/gevent/_compat.py
@@ -40,8 +40,10 @@ else:
 ## Functions
 if PY3:
     iteritems = dict.items
+    itervalues = dict.values
     xrange = range
 
 else:
     iteritems = dict.iteritems # python 3: pylint:disable=no-member
+    itervalues = dict.itervalues # python 3: pylint:disable=no-member
     xrange = __builtin__.xrange # python 2: pylint:disable=redefined-variable-type

--- a/greentest/2.7pypy/test_select.py
+++ b/greentest/2.7pypy/test_select.py
@@ -57,7 +57,17 @@ class SelectTestCase(unittest.TestCase):
                 del a[-1]
                 return sys.__stdout__.fileno()
         a[:] = [F()] * 10
-        self.assertEqual(select.select([], a, []), ([], a[:5], []))
+        result = select.select([], a, [])
+        # CPython: 'a' ends up with 5 items, because each fileno()
+        # removes an item and at the middle the iteration stops.
+        # PyPy: 'a' ends up empty, because the iteration is done on
+        # a copy of the original list: fileno() is called 10 times.
+        if test_support.check_impl_detail(cpython=True):
+            self.assertEqual(len(result[1]), 5)
+            self.assertEqual(len(a), 5)
+        if test_support.check_impl_detail(pypy=True):
+            self.assertEqual(len(result[1]), 10)
+            self.assertEqual(len(a), 0)
 
 def test_main():
     test_support.run_unittest(SelectTestCase)

--- a/greentest/3.4/test_select.py
+++ b/greentest/3.4/test_select.py
@@ -1,0 +1,85 @@
+import errno
+import os
+import select
+import sys
+import unittest
+from test import support
+
+@unittest.skipIf((sys.platform[:3]=='win'),
+                 "can't easily test on this system")
+class SelectTestCase(unittest.TestCase):
+
+    class Nope:
+        pass
+
+    class Almost:
+        def fileno(self):
+            return 'fileno'
+
+    def test_error_conditions(self):
+        self.assertRaises(TypeError, select.select, 1, 2, 3)
+        self.assertRaises(TypeError, select.select, [self.Nope()], [], [])
+        self.assertRaises(TypeError, select.select, [self.Almost()], [], [])
+        self.assertRaises(TypeError, select.select, [], [], [], "not a number")
+        self.assertRaises(ValueError, select.select, [], [], [], -1)
+
+    # Issue #12367: http://www.freebsd.org/cgi/query-pr.cgi?pr=kern/155606
+    @unittest.skipIf(sys.platform.startswith('freebsd'),
+                     'skip because of a FreeBSD bug: kern/155606')
+    def test_errno(self):
+        with open(__file__, 'rb') as fp:
+            fd = fp.fileno()
+            fp.close()
+            #from IPython.core.debugger import Tracer; Tracer()() ## DEBUG ##
+
+            try:
+                select.select([fd], [], [], 0)
+            except OSError as err:
+                self.assertEqual(err.errno, errno.EBADF)
+            else:
+                self.fail("exception not raised")
+
+    def test_returned_list_identity(self):
+        # See issue #8329
+        r, w, x = select.select([], [], [], 1)
+        self.assertIsNot(r, w)
+        self.assertIsNot(r, x)
+        self.assertIsNot(w, x)
+
+    def test_select(self):
+        cmd = 'for i in 0 1 2 3 4 5 6 7 8 9; do echo testing...; sleep 1; done'
+        p = os.popen(cmd, 'r')
+        for tout in (0, 1, 2, 4, 8, 16) + (None,)*10:
+            if support.verbose:
+                print('timeout =', tout)
+            rfd, wfd, xfd = select.select([p], [], [], tout)
+            if (rfd, wfd, xfd) == ([], [], []):
+                continue
+            if (rfd, wfd, xfd) == ([p], [], []):
+                line = p.readline()
+                if support.verbose:
+                    print(repr(line))
+                if not line:
+                    if support.verbose:
+                        print('EOF')
+                    break
+                continue
+            self.fail('Unexpected return values from select():', rfd, wfd, xfd)
+        p.close()
+
+    # Issue 16230: Crash on select resized list
+    def test_select_mutated(self):
+        a = []
+        class F:
+            def fileno(self):
+                del a[-1]
+                return sys.__stdout__.fileno()
+        a[:] = [F()] * 10
+        self.assertEqual(select.select([], a, []), ([], a[:5], []))
+
+def test_main():
+    support.run_unittest(SelectTestCase)
+    support.reap_children()
+
+if __name__ == "__main__":
+    test_main()

--- a/greentest/3.5/test_select.py
+++ b/greentest/3.5/test_select.py
@@ -1,0 +1,82 @@
+import errno
+import os
+import select
+import sys
+import unittest
+from test import support
+
+@unittest.skipIf((sys.platform[:3]=='win'),
+                 "can't easily test on this system")
+class SelectTestCase(unittest.TestCase):
+
+    class Nope:
+        pass
+
+    class Almost:
+        def fileno(self):
+            return 'fileno'
+
+    def test_error_conditions(self):
+        self.assertRaises(TypeError, select.select, 1, 2, 3)
+        self.assertRaises(TypeError, select.select, [self.Nope()], [], [])
+        self.assertRaises(TypeError, select.select, [self.Almost()], [], [])
+        self.assertRaises(TypeError, select.select, [], [], [], "not a number")
+        self.assertRaises(ValueError, select.select, [], [], [], -1)
+
+    # Issue #12367: http://www.freebsd.org/cgi/query-pr.cgi?pr=kern/155606
+    @unittest.skipIf(sys.platform.startswith('freebsd'),
+                     'skip because of a FreeBSD bug: kern/155606')
+    def test_errno(self):
+        with open(__file__, 'rb') as fp:
+            fd = fp.fileno()
+            fp.close()
+            try:
+                select.select([fd], [], [], 0)
+            except OSError as err:
+                self.assertEqual(err.errno, errno.EBADF)
+            else:
+                self.fail("exception not raised")
+
+    def test_returned_list_identity(self):
+        # See issue #8329
+        r, w, x = select.select([], [], [], 1)
+        self.assertIsNot(r, w)
+        self.assertIsNot(r, x)
+        self.assertIsNot(w, x)
+
+    def test_select(self):
+        cmd = 'for i in 0 1 2 3 4 5 6 7 8 9; do echo testing...; sleep 1; done'
+        p = os.popen(cmd, 'r')
+        for tout in (0, 1, 2, 4, 8, 16) + (None,)*10:
+            if support.verbose:
+                print('timeout =', tout)
+            rfd, wfd, xfd = select.select([p], [], [], tout)
+            if (rfd, wfd, xfd) == ([], [], []):
+                continue
+            if (rfd, wfd, xfd) == ([p], [], []):
+                line = p.readline()
+                if support.verbose:
+                    print(repr(line))
+                if not line:
+                    if support.verbose:
+                        print('EOF')
+                    break
+                continue
+            self.fail('Unexpected return values from select():', rfd, wfd, xfd)
+        p.close()
+
+    # Issue 16230: Crash on select resized list
+    def test_select_mutated(self):
+        a = []
+        class F:
+            def fileno(self):
+                del a[-1]
+                return sys.__stdout__.fileno()
+        a[:] = [F()] * 10
+        self.assertEqual(select.select([], a, []), ([], a[:5], []))
+
+def tearDownModule():
+    support.reap_children()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Compliance: If :func:`gevent.select.select` is given a negative *timeout*
  argument, raise an exception like the standard library does.
- Compliance: If :func:`gevent.select.select` is given closed or invalid
  file descriptors in any of its lists, raise the appropriate
  ``EBADF`` exception like the standard library does. Previously,
  libev would tend to return the descriptor as ready. In the worst
  case, this adds an extra system call, but may also reduce latency if
  descriptors are ready at the time of entry.
- Compliance: :meth:`gevent.select.poll.unregister` raises an exception if *fd* is not
  registered, like the standard library.
- Compliance: :meth:`gevent.select.poll.poll` returns an event with
  ``POLLNVAL`` for registered fds that are invalid. Previously it
  would tend to report both read and write events.