### PR TITLE
Security: Use subclass of dict for WSGI environ.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -53,6 +53,11 @@
 - Servers: Default to AF_INET6 when binding to all addresses (e.g.,
   ""). This supports both IPv4 and IPv6 connections (except on
   Windows). Original change in :pr:`495` by Felix Kaiser.
+- Security: The pywsgi ``environ`` dict doesn't print its contents by
+  default anymore, which could have lead to potential secure
+  information disclosure. Note that this is done using a subclass of
+  ``dict`` which is technically not compliant with PEP3333;
+  applications can configure pywsgi to use a ``dict`` again if required.
 
 
 1.1.0 (Mar 5, 2016)

--- a/changelog.rst
+++ b/changelog.rst
@@ -53,12 +53,10 @@
 - Servers: Default to AF_INET6 when binding to all addresses (e.g.,
   ""). This supports both IPv4 and IPv6 connections (except on
   Windows). Original change in :pr:`495` by Felix Kaiser.
-- Security: The pywsgi ``environ`` dict doesn't print its contents by
-  default anymore, which could have lead to potential secure
-  information disclosure. Note that this is done using a subclass of
-  ``dict`` which is technically not compliant with PEP3333;
-  applications can configure pywsgi to use a ``dict`` again if required.
-
+- Security: Errors logged by :class:`~gevent.pywsgi.WSGIHandler` no
+  longer print the entire WSGI environment by default. This avoids
+  possible information disclosure vulnerabilities. Originally reported
+  in :pr:`779` by sean-peters-au and changed in :pr:`781`.
 
 1.1.0 (Mar 5, 2016)
 ===================

--- a/gevent/hub.py
+++ b/gevent/hub.py
@@ -481,8 +481,12 @@ class Hub(RawGreenlet):
     resolver_class = resolver_config(resolver_class, 'GEVENT_RESOLVER')
     threadpool_class = config('gevent.threadpool.ThreadPool', 'GEVENT_THREADPOOL')
     backend = config(None, 'GEVENT_BACKEND')
-    format_context = 'pprint.pformat'
     threadpool_size = 10
+
+    # using pprint.pformat can override custom __repr__ methods on dict/list
+    # subclasses, which can be a security concern
+    format_context = 'pprint.saferepr'
+
 
     def __init__(self, loop=None, default=None):
         RawGreenlet.__init__(self)

--- a/gevent/pywsgi.py
+++ b/gevent/pywsgi.py
@@ -1131,9 +1131,27 @@ class LoggingLogAdapter(object):
     def __delattr__(self, name):
         delattr(self._logger, name)
 
+####
+## Environ classes.
+# These subclass dict. They could subclass collections.UserDict on
+# 3.3+ and proxy to the underlying real dict to avoid a copy if we
+# have to print them (on 2.7 it's slightly more complicated to be an
+# instance of collections.MutableMapping; UserDict.UserDict isn't.)
+# Then we could have either the WSGIHandler.get_environ or the
+# WSGIServer.get_environ return one of these proxies, and
+# WSGIHandler.run_application would know to access the `environ.data`
+# attribute to be able to pass the *real* dict to the application
+# (because PEP3333 requires no subclasses, only actual dict objects;
+# wsgiref.validator and webob.Request both enforce this). This has the
+# advantage of not being fragile if anybody else tries to print/log
+# self.environ (and not requiring a copy). However, if there are any
+# subclasses of Handler or Server, this could break if they don't know
+# to return this type.
+####
+
 class Environ(dict):
     """
-    The default class that's used for WSGI environment objects.
+    A base class that can be used for WSGI environment objects.
 
     Provisional API.
 

--- a/greentest/greentest.py
+++ b/greentest/greentest.py
@@ -397,7 +397,7 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
         finally:
             self._error = self._none
 
-    def assert_error(self, type=None, value=None, error=None):
+    def assert_error(self, type=None, value=None, error=None, where_type=None):
         if error is None:
             error = self.get_error()
         if type is not None:
@@ -407,6 +407,8 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
                 assert str(error[2]) == value, error
             else:
                 assert error[2] is value, error
+        if where_type is not None:
+            self.assertIsInstance(error[0], where_type)
         return error
 
     if RUNNING_ON_APPVEYOR:


### PR DESCRIPTION
Right now, this is only used for suppressing the printing of potentially sensitive information, but in the future there could be other uses.

This is technically not compliant with PEP3333 which specifies that the type(environ) must be dict, but it's not clear if that practically matters anymore (it looks like it might be a holdover from supporting
Python 1.5.2 before one could subclass the builtin dict; see https://mail.python.org/pipermail/web-sig/2003-December/000394.html).

Discussion on web-SIG ongoing at: https://mail.python.org/pipermail/web-sig/2016-March/005455.html Any comments here? 

Fixes #779.