### PR TITLE
fix bug in PriorityQueue._init

### DIFF
--- a/src/gevent/queue.py
+++ b/src/gevent/queue.py
@@ -375,6 +375,7 @@ class PriorityQueue(Queue):
     def _init(self, maxsize, items=None):
         if items:
             self.queue = list(items)
+            heapq.heapify(self.queue)
         else:
             self.queue = []
 

--- a/src/greentest/test_queue.py
+++ b/src/greentest/test_queue.py
@@ -237,6 +237,12 @@ class LifoQueueTest(BaseQueueTest):
 class PriorityQueueTest(BaseQueueTest):
     type2test = Queue.PriorityQueue
 
+    def test__init(self):
+        item1 = (2, 'b')
+        item2 = (1, 'a')
+        q = self.type2test(items=[item1, item2])
+        self.assertTupleEqual(item2, q.get_nowait())
+        self.assertTupleEqual(item1, q.get_nowait())
 
 
 # A Queue subclass that can provoke failure at a moment's notice :)


### PR DESCRIPTION
When `items` is given, `PriorityQueue` can not maintain a correct heap.

```
import heapq
from gevent.queue import PriorityQueue

items = [(4, 'd'), (1, 'a'), (3, 'c'), (2, 'b')]

q = PriorityQueue(items=items)

print(q.get_nowait())

heapq.heapify(items)
print(heapq.heappop(items))
```