### PR TITLE
Consistently deal with LibreSSL in OpenSSL version tests

### DIFF
--- a/src/greentest/2.7.8/test_ssl.py
+++ b/src/greentest/2.7.8/test_ssl.py
@@ -189,8 +189,10 @@ class BasicSocketTests(unittest.TestCase):
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
         # Version string as returned by OpenSSL, the format might change
-        self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
-                        (s, t))
+        # LibreSSL's OPENSSL_VERSION_INFO is always (2, 0, 0, 0, 0)
+        if not "LibreSSL" in s:
+            self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
+                            (s, t))
 
     @test_support.requires_resource('network')
     def test_ciphers(self):

--- a/src/greentest/2.7/test_ssl.py
+++ b/src/greentest/2.7/test_ssl.py
@@ -279,11 +279,9 @@ class BasicSocketTests(unittest.TestCase):
         self.assertLessEqual(patch, 63)
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
-        # Version string as returned by {Open,Libre}SSL, the format might change
-        if "LibreSSL" in s:
-            self.assertTrue(s.startswith("LibreSSL {:d}.{:d}".format(major, minor)),
-                            (s, t))
-        else:
+        # Version string as returned by OpenSSL, the format might change
+        # LibreSSL's OPENSSL_VERSION_INFO is always (2, 0, 0, 0, 0)
+        if not "LibreSSL" in s:
             self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
                             (s, t))
 

--- a/src/greentest/2.7pypy/test_ssl.py
+++ b/src/greentest/2.7pypy/test_ssl.py
@@ -189,8 +189,9 @@ class BasicSocketTests(unittest.TestCase):
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
         # Version string as returned by OpenSSL, the format might change
-        self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
-                        (s, t))
+        # LibreSSL's OPENSSL_VERSION_INFO is always (2, 0, 0, 0, 0)
+            self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
+                            (s, t))
 
     def test_ciphers(self):
         if not test_support.is_resource_enabled('network'):

--- a/src/greentest/3.4/test_ssl.py
+++ b/src/greentest/3.4/test_ssl.py
@@ -295,11 +295,9 @@ class BasicSocketTests(unittest.TestCase):
         self.assertLessEqual(patch, 63)
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
-        # Version string as returned by {Open,Libre}SSL, the format might change
-        if "LibreSSL" in s:
-            self.assertTrue(s.startswith("LibreSSL {:d}.{:d}".format(major, minor)),
-                            (s, t))
-        else:
+        # Version string as returned by OpenSSL, the format might change
+        # LibreSSL's OPENSSL_VERSION_INFO is always (2, 0, 0, 0, 0)
+        if not "LibreSSL" in s:
             self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
                             (s, t))
 

--- a/src/greentest/3.5/test_ssl.py
+++ b/src/greentest/3.5/test_ssl.py
@@ -311,11 +311,9 @@ class BasicSocketTests(unittest.TestCase):
         self.assertLessEqual(patch, 63)
         self.assertGreaterEqual(status, 0)
         self.assertLessEqual(status, 15)
-        # Version string as returned by {Open,Libre}SSL, the format might change
-        if "LibreSSL" in s:
-            self.assertTrue(s.startswith("LibreSSL {:d}.{:d}".format(major, minor)),
-                            (s, t, hex(n)))
-        else:
+        # Version string as returned by OpenSSL, the format might change
+        # LibreSSL's OPENSSL_VERSION_INFO is always (2, 0, 0, 0, 0)
+        if not "LibreSSL" in s:
             self.assertTrue(s.startswith("OpenSSL {:d}.{:d}.{:d}".format(major, minor, fix)),
                             (s, t, hex(n)))
 


### PR DESCRIPTION
Don't test OpenSSL version on LibreSSL systems: `ssl.OPENSSL_VERSION_INFO` on LibreSSL is always `(2, 0, 0, 0, 0)`, even for new versions then LibreSSL 2.0. Tested on OpenBSD -current with LibreSSL 2.4.0.