### PR TITLE
Don't run 'test_openssl_version' when ssl is backed with LibreSSL

### DIFF
--- a/src/greentest/patched_tests_setup.py
+++ b/src/greentest/patched_tests_setup.py
@@ -462,6 +462,13 @@ if sys.version_info[:2] >= (3, 5):
 #         'test_socketserver.SocketServerTest.test_ForkingUDPServer',
 #         'test_socketserver.SocketServerTest.test_ForkingUnixStreamServer'])
 
+# LibreSSL reports OPENSSL_VERSION_INFO (2, 0, 0, 0, 0) regardless its version
+from ssl import OPENSSL_VERSION
+if OPENSSL_VERSION.startswith('LibreSSL'):
+    disabled_tests += [
+        'test_ssl.BasicSocketTests.test_openssl_version'
+    ]
+
 
 def disable_tests_in_source(source, name):
     if name.startswith('./'):


### PR DESCRIPTION
On LibreSSL `OPENSSL_VERSION_INFO` is always `(2, 0, 0, 0, 0)`, so the test fails
for all LibreSSL versions after 2.0. In contrast to proper fix in #796, this PR works around the issue by disabling corresponding test in `src/greentest/patched_tests_setup.py` if `OPENSSL_VERSION.startswith('LibreSSL')`.