### PR TITLE
Patch existing locks

### DIFF
--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -272,7 +272,7 @@ def _patch_existing_locks(threading):
                     isinstance(o._RLock__block, lock_type)):
                 _fix_py2_rlock(o, tid)
             elif (sys.version_info[0] >= 3 and
-                    not isinstance(o, pyrlock_type)):
+                  not isinstance(o, pyrlock_type)):
                 _fix_py3_rlock(o)
         elif isinstance(o, _ModuleLock):
             if o.owner is not None:

--- a/src/greentest/test__monkey_oldlocks_early.py
+++ b/src/greentest/test__monkey_oldlocks_early.py
@@ -1,0 +1,26 @@
+def aaa(lock, e1, e2):
+    print("aaa")
+    e1.set()
+    with lock:
+        e2.wait()
+
+
+def bbb(lock, e1, e2):
+    print("bbb")
+    e1.wait()
+    e2.set()
+    with lock:
+        pass
+
+
+import threading
+test_lock = threading.RLock()
+import gevent
+import gevent.monkey
+gevent.monkey.patch_all()
+
+e1, e2 = threading.Event(), threading.Event()
+a = gevent.spawn(aaa, test_lock, e1, e2)
+b = gevent.spawn(bbb, test_lock, e1, e2)
+a.join()
+b.join()

--- a/src/greentest/test__monkey_oldlocks_late.py
+++ b/src/greentest/test__monkey_oldlocks_late.py
@@ -1,0 +1,24 @@
+def aaa(lock, e1, e2):
+    e1.set()
+    with lock:
+        e2.wait()
+
+
+def bbb(lock, e1, e2):
+    e1.wait()
+    e2.set()
+    with lock:
+        pass
+
+
+import threading
+import gevent
+import gevent.monkey
+gevent.monkey.patch_all()
+test_lock = threading.RLock()
+
+e1, e2 = threading.Event(), threading.Event()
+a = gevent.spawn(aaa, test_lock, e1, e2)
+b = gevent.spawn(bbb, test_lock, e1, e2)
+a.join()
+b.join()

--- a/src/greentest/test__monkey_oldlocks_locked.py
+++ b/src/greentest/test__monkey_oldlocks_locked.py
@@ -1,0 +1,37 @@
+def take(lock, sync1, sync2):
+    sync2.acquire()
+    sync1.release()
+    with lock:
+        sync2.release()
+
+
+import sys
+import threading
+lock = threading.RLock()
+lock.acquire()
+import gevent
+import gevent.monkey
+gevent.monkey.patch_all()
+
+lock.release()
+try:
+    lock.release()
+except RuntimeError as e:
+    assert e.args == ('cannot release un-acquired lock',)
+lock.acquire()
+
+sync1 = threading.Lock()
+sync2 = threading.Lock()
+sync1.acquire()
+gevent.spawn(take, lock, sync1, sync2)
+# Ensure sync2 has been taken
+with sync1:
+    pass
+
+# an RLock should be reentrant
+lock.acquire()
+lock.release()
+lock.release()
+# To acquire sync2, 'take' must have acquired lock, which has been locked
+# until now
+sync2.acquire()

--- a/src/greentest/test__threading_holding_lock_while_monkey.py
+++ b/src/greentest/test__threading_holding_lock_while_monkey.py
@@ -1,8 +1,0 @@
-from gevent import monkey
-import threading
-# Make sure that we can patch gevent while holding
-# a threading lock. Under Python2, where RLock is implemented
-# in python code, this used to throw RuntimeErro("Cannot release un-acquired lock")
-# See https://github.com/gevent/gevent/issues/615
-with threading.RLock():
-    monkey.patch_all()


### PR DESCRIPTION
In projects which dynamically determine whether to activate gevent,
it can be hard not to import a low level module like logging before
gevent. When logging is imported it initialises a threading.RLock
which it uses to protect the logging configuration. If two
greenthreads attempt to claim this lock, the second one will block the
/native/ thread not just itself. As green systems usually only have
one native thread, this will freeze the whole system.

While searching the GC for unsafe RLocks, replace their internal Lock
with a safe one. Or on Python3, where the default RLock implementation
is in C, swap the whole RLock out with a safe Python version.