### PR TITLE
Invoke 'sh' instead of '/bin/sh' in deps setup

### DIFF
--- a/_setupares.py
+++ b/_setupares.py
@@ -40,7 +40,7 @@ else:
 ares_configure_command = ' '.join([
     "(cd ", quoted_dep_abspath('c-ares'),
     " && if [ -r ares_build.h ]; then cp ares_build.h ares_build.h.orig; fi ",
-    " && /bin/sh ./configure --disable-dependency-tracking " + _m32 + "CONFIG_COMMANDS= ",
+    " && sh ./configure --disable-dependency-tracking " + _m32 + "CONFIG_COMMANDS= ",
     " && cp ares_config.h ares_build.h \"$OLDPWD\" ",
     " && mv ares_build.h.orig ares_build.h)",
     "> configure-output.txt"])

--- a/_setuplibev.py
+++ b/_setuplibev.py
@@ -30,7 +30,7 @@ LIBEV_EMBED = should_embed('libev')
 # and the PyPy branch will clean it up.
 libev_configure_command = ' '.join([
     "(cd ", quoted_dep_abspath('libev'),
-    " && /bin/sh ./configure ",
+    " && sh ./configure ",
     " && cp config.h \"$OLDPWD\"",
     ")",
     '> configure-output.txt'


### PR DESCRIPTION
This makes building work on platforms lacking /bin/sh.

It specifically avoids problems when instaling gevent on [Termux](https://termux.com) where /bin/sh does not exist due to the Android file system layout. Problem reported in https://github.com/termux/termux-packages/issues/283.