### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.coverage',
               'sphinx.ext.extlinks']
 
 intersphinx_mapping = {'http://docs.python.org/': None,
-                       'https://greenlet.readthedocs.org/en/latest/': None}
+                       'https://greenlet.readthedocs.io/en/latest/': None}
 
 extlinks = {'issue': ('https://github.com/gevent/gevent/issues/%s',
                       'issue #'),

--- a/doc/gevent.rst
+++ b/doc/gevent.rst
@@ -90,9 +90,9 @@ greenlets that are forever unscheduled. Prefer higher-level safe
 classes, like :class:`Event <gevent.event.Event>` and :class:`Queue
 <gevent.queue.Queue>`, instead.
 
-__ http://greenlet.readthedocs.org/en/latest/#instantiation
-.. _switching: https://greenlet.readthedocs.org/en/latest/#switching
-.. _throw: https://greenlet.readthedocs.org/en/latest/#methods-and-attributes-of-greenlets
+__ https://greenlet.readthedocs.io/en/latest/#instantiation
+.. _switching: https://greenlet.readthedocs.io/en/latest/#switching
+.. _throw: https://greenlet.readthedocs.io/en/latest/#methods-and-attributes-of-greenlets
 
 .. exception:: GreenletExit
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,4 +61,4 @@ Mailing List
 
 .. _coroutine: https://en.wikipedia.org/wiki/Coroutine
 .. _Python: http://python.org
-.. _greenlet: http://greenlet.readthedocs.org
+.. _greenlet: https://greenlet.readthedocs.io

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -59,7 +59,7 @@ __ http://pypi.python.org/pypi/greenlet
 .. _`pip`: https://pip.pypa.io/en/stable/installing/
 .. _`wheels`: http://pythonwheels.com
 .. _`gevent 1.1`: whatsnew_1_1.html
-.. _`cffi`: http://cffi.readthedocs.org
+.. _`cffi`: https://cffi.readthedocs.io
 
 Example
 =======

--- a/doc/whatsnew_1_1.rst
+++ b/doc/whatsnew_1_1.rst
@@ -78,7 +78,7 @@ through 4.0.0 and 4.0.1, and on 32-bit ARM on Raspbian with version 4.0.1.
           exact cause is unknown and is being tracked in :issue:`677`.
 
 .. _cffi 1.3.0: https://bitbucket.org/cffi/cffi/src/ad3140a30a7b0ca912185ef500546a9fb5525ece/doc/source/whatsnew.rst?at=default
-.. _1.2.0: https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-2-0
+.. _1.2.0: https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-2-0
 .. _a bug: https://bitbucket.org/pypy/pypy/issues/2149/memory-leak-for-python-subclass-of-cpyext
 
 Operating Systems

--- a/src/greentest/coveragesite/sitecustomize.py
+++ b/src/greentest/coveragesite/sitecustomize.py
@@ -1,5 +1,5 @@
 # When testrunner.py is invoked with --coverage, it puts this first
-# on the path as per http://coverage.readthedocs.org/en/coverage-4.0b3/subprocess.html.
+# on the path as per https://coverage.readthedocs.io/en/coverage-4.0b3/subprocess.html.
 # Note that this disables other sitecustomize.py files.
 import coverage
 coverage.process_startup()


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.