### PR TITLE
lock: add an RWLock class for RW/RO locks.

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -211,10 +211,10 @@ I/O functions that bypass the libev event loop.
 Synchronizing access to objects shared across the greenlets is
 unnecessary in most cases (because yielding control is usually
 explict), thus traditional synchronization devices like the
-:class:`~lock.BoundedSemaphore`, :class:`~lock.RLock` and
-:class:`~lock.Semaphore` classes, although present, aren't used very
-often. Other abstractions from threading and multiprocessing remain
-useful in the cooperative world:
+:class:`~lock.BoundedSemaphore`, :class:`~lock.RLock`,
+:class:`~lock.RWLock`, and :class:`~lock.Semaphore` classes, although
+present, aren't used very often. Other abstractions from threading and
+multiprocessing remain useful in the cooperative world:
 
 - :class:`~event.Event` allows one to wake up a number of greenlets that are calling :meth:`~event.Event.wait` method.
 - :class:`~event.AsyncResult` is similar to :class:`~event.Event` but allows passing a value or an exception to the waiters.

--- a/src/greentest/lock_tests.py
+++ b/src/greentest/lock_tests.py
@@ -242,6 +242,26 @@ class RLockTests(BaseLockTests):
         self.assertFalse(lock._is_owned())
 
 
+class RWLockTests(BaseLockTests):
+    """
+    Tests for RW/RO locks.
+    """
+    def test_recursive_ro_locks(self):
+        lock = self.locktype()
+        # It's possible to acquire multiple RO locks
+        lock.acquire_ro()
+        lock.acquire_ro()
+        lock.acquire_ro()
+
+        # We need to release all of them before the RW lock can be acquired
+        lock.release_ro()
+        lock.release_ro()
+        lock.release_ro()
+
+        lock.acquire()
+        lock.release()
+
+
 class EventTests(BaseTestCase):
     """
     Tests for Event objects.

--- a/src/greentest/test_threading_2.py
+++ b/src/greentest/test_threading_2.py
@@ -529,6 +529,9 @@ class LockTests(lock_tests.LockTests):
 class RLockTests(lock_tests.RLockTests):
     locktype = staticmethod(threading.RLock)
 
+class RWLockTests(lock_tests.RWLockTests):
+    locktype = staticmethod(threading.RWLock)
+
 class NativeRLockTests(lock_tests.RLockTests):
     # See comments at the top of the file for the difference
     # between this and RLockTests, and why they both matter
@@ -556,7 +559,7 @@ class BoundedSemaphoreTests(lock_tests.BoundedSemaphoreTests):
 
 
 def main():
-    support.run_unittest(LockTests, RLockTests, EventTests,
+    support.run_unittest(LockTests, RLockTests, RWLockTests, EventTests,
                          ConditionAsRLockTests, ConditionTests,
                          SemaphoreTests, BoundedSemaphoreTests,
                          ThreadTests,


### PR DESCRIPTION
This lets an object have multiple kind of locks: read-write and
read-only. The idea is that an object can have multiple read-only locks,
but only a single read-write should be acquired. These locks are
mutually exclusive.