### PR TITLE
Don't inherit IMapUnordered from Greenlet

### DIFF
--- a/src/gevent/pool.py
+++ b/src/gevent/pool.py
@@ -52,7 +52,7 @@ class IMapUnordered(object):
             Added the *maxsize* parameter.
         """
         from gevent.queue import Queue
-        self.manager_greenlet
+        self.manager_greenlet = None
         if spawn is not None:
             self.spawn = spawn
         if _zipped:


### PR DESCRIPTION
Instead, use the spawn method provided by the caller to spawn a manager greenlet. This ensures that the manager Greenlet is the same class that the caller uses.