### PR TITLE
Encode c-ares/acountry.c in utf-8

### DIFF
--- a/deps/c-ares/acountry.c
+++ b/deps/c-ares/acountry.c
@@ -273,7 +273,7 @@ static const struct search_list *list_lookup(int number, const struct search_lis
  */
 static const struct search_list country_list[] = {
        {   4, "af", "Afghanistan"                          },
-       { 248, "ax", "Åland Island"                         },
+       { 248, "ax", "Ã…land Island"                         },
        {   8, "al", "Albania"                              },
        {  12, "dz", "Algeria"                              },
        {  16, "as", "American Samoa"                       },


### PR DESCRIPTION
Not in iso-8859 which is what it was identified as. There were
characters in a string constant that couldn't be decoded using utf-8. I
believe this will be a basically compatible change due to the nature of
the two encoding systems.

Workaround for https://github.com/landscapeio/dodgy/pull/7