### PR TITLE
Backdoor crash fix

### DIFF
--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -39,6 +39,11 @@ class _Greenlet_stdreplace(Greenlet):
             self.switch_in()
         Greenlet.switch(self, *args, **kw)
 
+    def throw(self, *args):
+        if self._fileobj is not None:
+            self.switch_in()
+        Greenlet.throw(self, *args)
+
     def switch_in(self):
         self.saved = sys.stdin, sys.stderr, sys.stdout
         sys.stdin = sys.stdout = sys.stderr = self._fileobj

--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -37,7 +37,7 @@ class _Greenlet_stdreplace(Greenlet):
     def switch(self, *args, **kw):
         if self._fileobj is not None:
             self.switch_in()
-        Greenlet.switch(self, *args, **kw) # pylint:disable=no-member
+        Greenlet.switch(self, *args, **kw)
 
     def switch_in(self):
         self.saved = sys.stdin, sys.stderr, sys.stdout


### PR DESCRIPTION
Gevent's backdoor has a `switch_in` callback, used to overwrite stdin/stdout/stderr whenever the repl is active. However, it does not get called if the greenlet becomes active as a result of an exception being raised.  

Repro:
```python
from gevent import spawn, sleep
from gevent.queue import Queue
from gevent.backdoor import BackdoorServer

def bad():
    q = Queue()
    print('switching out, then throwing in')
    try:
        q.get(block=True, timeout=0.1)
    except:
        pass
    print('switching out')
    sleep(0.1)
    print('switched in')

def spawn_server():
	BackdoorServer(('127.0.0.1', 1234), locals=dict(bad=bad)).serve_forever()

def dummy():
	while True:
		sleep(0.0)

spawn(spawn_server)
spawn(dummy).join()
```

Doing `echo 'bad()'|nc 0 1234` in a separate shell results in:
```
$ python gevent_repro.py
switching out
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "gevent_repro.py", line 13, in bad
    sleep(0.1)
  File "/usr/local/lib/python2.7/dist-packages/gevent/hub.py", line 194, in sleep
    hub.wait(loop.timer(seconds, ref=ref))
  File "/usr/local/lib/python2.7/dist-packages/gevent/hub.py", line 630, in wait
    result = waiter.get()
  File "/usr/local/lib/python2.7/dist-packages/gevent/hub.py", line 878, in get
    return self.hub.switch()
  File "/usr/local/lib/python2.7/dist-packages/gevent/hub.py", line 608, in switch
    switch_out()
  File "/usr/local/lib/python2.7/dist-packages/gevent/backdoor.py", line 46, in switch_out
    sys.stdin, sys.stderr, sys.stdout = self.saved
TypeError: 'NoneType' object is not iterable
>>>   
```