### PR TITLE
Fix #878

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -159,6 +159,8 @@ Other Changes
 
   .. note:: Writing to the *io* property of a FileObject should be
             considered deprecated after it is constructed.
+- The :func:`gevent.os.waitpid` function is cooperative in more
+  circumstances. Reported in :issue:`878` by Heungsub Lee.
 
 1.1.2 (Jul 21, 2016)
 ====================

--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -1,18 +1,10 @@
 import sys
 import _six as six
 from os import pipe
+import gevent
 from gevent import os
 from greentest import TestCase, main
 from gevent import Greenlet, joinall
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
-
-try:
-    import errno
-except ImportError:
-    errno = None
 
 
 class TestOS_tp(TestCase):
@@ -91,13 +83,17 @@ if hasattr(os, 'fork_and_watch'):
 
     class TestForkAndWatch(TestCase):
 
+        __timeout__ = 5
+
         def test_waitpid_all(self):
             # Cover this specific case.
             pid = os.fork_and_watch()
             if pid:
-                x, _ = os.waitpid(-1, 0)
-                self.assertEqual(x, pid)
+                os.waitpid(-1, 0)
+                # Can't assert on what the pid actually was,
+                # our testrunner may have spawned multiple children.
             else:
+                gevent.sleep(2)
                 os._exit(0)
 
         def test_waitpid_wrong_neg(self):

--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -92,6 +92,7 @@ if hasattr(os, 'fork_and_watch'):
                 os.waitpid(-1, 0)
                 # Can't assert on what the pid actually was,
                 # our testrunner may have spawned multiple children.
+                os._reap_children(0) # make the leakchecker happy
             else:
                 gevent.sleep(2)
                 os._exit(0)

--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -87,5 +87,24 @@ if hasattr(os, 'make_nonblocking'):
             return os.nb_write(*args)
 
 
+if hasattr(os, 'fork_and_watch'):
+
+    class TestForkAndWatch(TestCase):
+
+        def test_waitpid_all(self):
+            # Cover this specific case.
+            pid = os.fork_and_watch()
+            if pid:
+                x, _ = os.waitpid(-1, 0)
+                self.assertEqual(x, pid)
+            else:
+                os._exit(0)
+
+        def test_waitpid_wrong_neg(self):
+            self.assertRaises(OSError, os.waitpid, -2, 0)
+
+        def test_waitpid_wrong_pos(self):
+            self.assertRaises(OSError, os.waitpid, 1, 0)
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
We can use multiple watchers to avoid any race conditions. 

I believe it's no more racy than before (and in fact may be less racy since we're calling `waitpid` less often).  