### PR TITLE
More tests for #879

### DIFF
--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -97,6 +97,16 @@ if hasattr(os, 'fork_and_watch'):
                 gevent.sleep(2)
                 os._exit(0)
 
+        def test_waitpid(self):
+            pid = os.fork_and_watch()
+            if pid:
+                pid_, stat = os.waitpid(pid, 0)
+                assert pid_ == pid
+                os._reap_children(0)
+            else:
+                gevent.sleep(2)
+                os._exit(0)
+
         def test_waitpid_wrong_neg(self):
             self.assertRaises(OSError, os.waitpid, -2, 0)
 


### PR DESCRIPTION
@jamadden Thank you for #879.  I read your work, then I thought we need more test cases for `gevent.os.waitpid`.  So I added such test cases for `waitpid`.

- `test_waitpid` is same with `test_waitpid_all` but it sets specific pid instead of `0`.
- `test_waitpid_timeout` tests cooperativity of `waitpid` using `gevent.Timeout`.