### PR TITLE
Clean up _DummyThread for greenlet.greenlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ src/greentest/.coverage\.*
 src/greentest/htmlcov
 src/greentest/.coverage
 
-doc/changelog.rst
 doc/_build
 doc/__pycache__
 doc/gevent.*.rst

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@
 
 .. currentmodule:: gevent
 
+1.2.1 (unreleased)
+==================
+
+- The ``_DummyThread`` objects created by calling
+  :func:`threading.current_thread` from inside a raw
+  :class:`greenlet.greenlet` now clean up after themselves when the
+  greenlet dies (:class:`gevent.Greenlet`-based ``_DummyThreads`` have
+  always cleaned up). This requires the use of a :class:`weakref.ref`
+  (and may not be timely on PyPy).
+  Reported in :issue:`918` by frozenoctobeer.
+
 1.2.0 (2016-12-23)
 ==================
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGES.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,15 +19,6 @@ os.system('%s generate_rst.py generate' % sys.executable)
 
 sys.path.append('.')  # for mysphinxext
 
-if not os.path.exists('changelog.rst') and os.path.exists('../changelog.rst'):
-    print('Linking ../changelog.rst to changelog.rst')
-    if hasattr(os, 'symlink'):
-        os.symlink('../changelog.rst', 'changelog.rst')
-    else:
-        import shutil
-        shutil.copyfile('../changelog.rst', 'changelog.rst')
-
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -19,6 +19,7 @@ API reference
    gevent.server
    gevent.subprocess
    gevent.thread
+   gevent.threading
    gevent.threadpool
    gevent.util
    lowlevel

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -568,10 +568,13 @@ class Greenlet(greenlet):
             self._notifier = self.parent.loop.run_callback(self._notify_links)
 
     def link(self, callback, SpawnedLink=SpawnedLink):
-        """Link greenlet's completion to a callable.
+        """
+        Link greenlet's completion to a callable.
 
-        The *callback* will be called with this instance as an argument
-        once this greenlet's dead. A callable is called in its own greenlet.
+        The *callback* will be called with this instance as an
+        argument once this greenlet is dead. A callable is called in
+        its own :class:`greenlet.greenlet` (*not* a
+        :class:`Greenlet`).
         """
         # XXX: Is the redefinition of SpawnedLink supposed to just be an
         # optimization, or do people use it? It's not documented
@@ -586,7 +589,10 @@ class Greenlet(greenlet):
             pass
 
     def link_value(self, callback, SpawnedLink=SuccessSpawnedLink):
-        """Like :meth:`link` but *callback* is only notified when the greenlet has completed successfully."""
+        """
+        Like :meth:`link` but *callback* is only notified when the greenlet
+        has completed successfully.
+        """
         # pylint:disable=redefined-outer-name
         self.link(callback, SpawnedLink=SpawnedLink)
 

--- a/src/gevent/thread.py
+++ b/src/gevent/thread.py
@@ -1,10 +1,12 @@
-"""Implementation of the standard :mod:`thread` module that spawns greenlets.
+"""
+Implementation of the standard :mod:`thread` module that spawns greenlets.
 
 .. note::
 
-    This module is a helper for :mod:`gevent.monkey` and is not intended to be
-    used directly. For spawning greenlets in your applications, prefer
-    :class:`Greenlet` class.
+    This module is a helper for :mod:`gevent.monkey` and is not
+    intended to be used directly. For spawning greenlets in your
+    applications, prefer higher level constructs like
+    :class:`gevent.Greenlet` class or :func:`gevent.spawn`.
 """
 from __future__ import absolute_import
 import sys

--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -96,6 +96,11 @@ RUNNING_ON_TRAVIS = os.environ.get('TRAVIS')
 RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
 RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
 
+def _do_not_skip(reason):
+    def dec(f):
+        return f
+    return dec
+
 if RUNNING_ON_APPVEYOR:
     # See comments scattered around about timeouts and the timer
     # resolution available on appveyor (lots of jitter). this
@@ -110,19 +115,18 @@ if RUNNING_ON_APPVEYOR:
     # 'develop' mode (i.e., we install)
     NON_APPLICABLE_SUFFIXES.append('corecext')
 else:
-    def skipOnAppVeyor(reason):
-        def dec(f):
-            return f
-        return dec
+    skipOnAppVeyor = _do_not_skip
 
 if PYPY3 and RUNNING_ON_CI:
     # Same as above, for PyPy3.3-5.5-alpha
     skipOnPyPy3OnCI = unittest.skip
 else:
-    def skipOnPyPy3OnCI(reason):
-        def dec(f):
-            return f
-        return dec
+    skipOnPyPy3OnCI = _do_not_skip
+
+if PYPY:
+    skipOnPyPy = unittest.skip
+else:
+    skipOnPyPy = _do_not_skip
 
 EXPECT_POOR_TIMER_RESOLUTION = PYPY3 or RUNNING_ON_APPVEYOR
 


### PR DESCRIPTION
This uses a weakref since it doesn't have rowlink.

Fixes #918.