### PR TITLE
Build OS X wheels with -D_DARWIN_FEATURE_CLOCK_GETTIME=0 for compatib…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,11 +9,15 @@
 
 - The ``_DummyThread`` objects created by calling
   :func:`threading.current_thread` from inside a raw
-  :class:`greenlet.greenlet` now clean up after themselves when the
+  :class:`greenlet.greenlet` in a system with monkey-patched
+  ``threading`` now clean up after themselves when the
   greenlet dies (:class:`gevent.Greenlet`-based ``_DummyThreads`` have
   always cleaned up). This requires the use of a :class:`weakref.ref`
   (and may not be timely on PyPy).
   Reported in :issue:`918` by frozenoctobeer.
+- Build OS X wheels with ``-D_DARWIN_FEATURE_CLOCK_GETTIME=0`` for
+  compatibility with OS X releases before 10.12 Sierra. Reported by
+  Ned Batchelder in :issue:`916`.
 
 1.2.0 (2016-12-23)
 ==================

--- a/scripts/releases/geventrel.sh
+++ b/scripts/releases/geventrel.sh
@@ -15,6 +15,12 @@ unset CFLAGS
 unset CXXFLAGS
 unset CPPFLAGS
 
+# If we're building on 10.12, we have to exclude clock_gettime
+# because it's not available on earlier releases and leads to
+# segfaults because the symbol clock_gettime is NULL.
+# See https://github.com/gevent/gevent/issues/916
+export CPPFLAGS="-D_DARWIN_FEATURE_CLOCK_GETTIME=0"
+
 BASE=`pwd`/../../
 BASE=`greadlink -f $BASE`
 

--- a/src/gevent/__init__.py
+++ b/src/gevent/__init__.py
@@ -16,10 +16,10 @@ _version_info = namedtuple('version_info',
 #: The programatic version identifier. The fields have (roughly) the
 #: same meaning as :data:`sys.version_info`
 #: Deprecated in 1.2.
-version_info = _version_info(1, 2, 0, 'final', 1)
+version_info = _version_info(1, 2, 1, 'final', 1)
 
 #: The human-readable PEP 440 version identifier
-__version__ = '1.2.0'
+__version__ = '1.2.1dev0'
 
 
 __all__ = ['get_hub',


### PR DESCRIPTION
…ility with pre-10.12 releases. Fixes #916. [skip ci]