### PR TITLE
Python 2 sockets don't pass type/protocol to getaddrinfo in connect.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 
 - Testing on Python 3.5 now uses Python 3.5.3 due to SSL changes. See
   :issue:`943`.
+- Python 2 sockets are compatible with the ``SOCK_CLOEXEC`` flag found
+  on Linux. They no longer pass the socket type or protocol to
+  ``getaddrinfo`` when ``connect`` is called. Reported in :issue:`944`
+  by Bernie Hackett.
 
 1.2.1 (2017-01-12)
 ==================

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -218,7 +218,7 @@ class socket(object):
             return self._sock.connect(address)
         sock = self._sock
         if isinstance(address, tuple):
-            r = getaddrinfo(address[0], address[1], sock.family, sock.type, sock.proto)
+            r = getaddrinfo(address[0], address[1], sock.family)
             address = r[0][-1]
         if self.timeout is not None:
             timer = Timeout.start_new(self.timeout, timeout('timed out'))

--- a/src/greentest/test__ssl.py
+++ b/src/greentest/test__ssl.py
@@ -70,6 +70,9 @@ class TestSSL(test__socket.TestTCP):
         # Override; doesn't work with SSL sockets.
         pass
 
+    def test_connect_with_type_flags_ignored(self):
+        # Override; doesn't work with SSL sockets.
+        pass
 
 def ssl_listener(address, private_key, certificate):
     raw_listener = socket.socket()


### PR DESCRIPTION
Fixes #944.