### PR TITLE
Bump PyPy version to 5.7 for both PyPy2 and PyPy3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ PY27=$(BUILD_RUNTIMES)/snakepit/python2.7.13
 PY34=$(BUILD_RUNTIMES)/snakepit/python3.4.5
 PY35=$(BUILD_RUNTIMES)/snakepit/python3.5.3
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6.0
-PYPY=$(BUILD_RUNTIMES)/snakepit/pypy56
-PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.3_5.5
+PYPY=$(BUILD_RUNTIMES)/snakepit/pypy57
+PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.5_5.7
 
 TOOLS=$(BUILD_RUNTIMES)/tools
 
@@ -178,10 +178,10 @@ test-py36: $(PY36)
 	PYTHON=python3.6.0 PIP=pip PATH=$(BUILD_RUNTIMES)/versions/python3.6.0/bin:$(PATH) make develop toxtest
 
 test-pypy: $(PYPY)
-	PYTHON=$(PYPY) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy56/bin:$(PATH) make develop toxtest
+	PYTHON=$(PYPY) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy57/bin:$(PATH) make develop toxtest
 
 test-pypy3: $(PYPY3)
-	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.3_5.5/bin:$(PATH) make develop toxtest
+	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_5.7/bin:$(PATH) make develop toxtest
 
 test-py27-cffi: $(PY27)
 	GEVENT_CORE_CFFI_ONLY=1 PYTHON=python2.7.13 PATH=$(BUILD_RUNTIMES)/versions/python2.7.13/bin:$(PATH) make develop toxtest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,10 +103,10 @@ for var in "$@"; do
       install 3.6.0 python3.6.0
       ;;
     pypy)
-      install pypy2-5.6.0 pypy56
+      install pypy2-5.7.0 pypy57
       ;;
     pypy3)
-      install pypy3.3-5.5-alpha pypy3.3_5.5
+      install pypy3.5-5.7-beta pypy3.5_5.7
       ;;
   esac
 done


### PR DESCRIPTION
Note that there is a regression discovered with PyPy 5.7 that will be fixed soon.
Maybe we should hold off merging this until the patch version is released.