### PR TITLE
Pypy2 5.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ env:
     matrix:
       # These are ordered to get as much diversity in the
       # first group of parallel runs (4) as posible
-      #- TASK=test-py27-noembed
+      - TASK=test-py27-noembed
       - TASK=test-pypy
-      #- TASK=test-py36
-      #- TASK=lint-py27
+      - TASK=test-py36
+      - TASK=lint-py27
       - TASK=test-pypy3
-      #- TASK=test-py35
-      #- TASK=test-py278
-      #- TASK=test-py27
-      #- TASK=test-py34
-      #- TASK=test-py27-cffi
+      - TASK=test-py35
+      - TASK=test-py278
+      - TASK=test-py27
+      - TASK=test-py34
+      - TASK=test-py27-cffi
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # .travis.yml based on https://github.com/DRMacIver/hypothesis/blob/master/.travis.yml
 language: c
 sudo: false
+dist: trusty
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ env:
     matrix:
       # These are ordered to get as much diversity in the
       # first group of parallel runs (4) as posible
-      - TASK=test-py27-noembed
+      #- TASK=test-py27-noembed
       - TASK=test-pypy
-      - TASK=test-py36
-      - TASK=lint-py27
+      #- TASK=test-py36
+      #- TASK=lint-py27
       - TASK=test-pypy3
-      - TASK=test-py35
-      - TASK=test-py278
-      - TASK=test-py27
-      - TASK=test-py34
-      - TASK=test-py27-cffi
+      #- TASK=test-py35
+      #- TASK=test-py278
+      #- TASK=test-py27
+      #- TASK=test-py34
+      #- TASK=test-py27-cffi
 
 matrix:
   fast_finish: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Testing on Python 3.5 now uses Python 3.5.3 due to SSL changes. See
   :issue:`943`.
+- Linux CI has been updated from Ubuntu 12.04 to Ubuntu 14.04 since
+  the former has reached EOL.
+- Linux CI now tests on PyPy2 5.7.1, updated from PyPy2 5.6.0.
 - Python 2 sockets are compatible with the ``SOCK_CLOEXEC`` flag found
   on Linux. They no longer pass the socket type or protocol to
   ``getaddrinfo`` when ``connect`` is called. Reported in :issue:`944`

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ PY34=$(BUILD_RUNTIMES)/snakepit/python3.4.5
 PY35=$(BUILD_RUNTIMES)/snakepit/python3.5.3
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6.0
 PYPY=$(BUILD_RUNTIMES)/snakepit/pypy571
-PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.5_571
+PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.3_5.5
 
 TOOLS=$(BUILD_RUNTIMES)/tools
 
@@ -181,7 +181,7 @@ test-pypy: $(PYPY)
 	PYTHON=$(PYPY) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy571/bin:$(PATH) make develop toxtest
 
 test-pypy3: $(PYPY3)
-	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_571/bin:$(PATH) make develop toxtest
+	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.3_5.5/bin:$(PATH) make develop toxtest
 
 test-py27-cffi: $(PY27)
 	GEVENT_CORE_CFFI_ONLY=1 PYTHON=python2.7.13 PATH=$(BUILD_RUNTIMES)/versions/python2.7.13/bin:$(PATH) make develop toxtest

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ PY27=$(BUILD_RUNTIMES)/snakepit/python2.7.13
 PY34=$(BUILD_RUNTIMES)/snakepit/python3.4.5
 PY35=$(BUILD_RUNTIMES)/snakepit/python3.5.3
 PY36=$(BUILD_RUNTIMES)/snakepit/python3.6.0
-PYPY=$(BUILD_RUNTIMES)/snakepit/pypy56
-PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.3_5.5
+PYPY=$(BUILD_RUNTIMES)/snakepit/pypy571
+PYPY3=$(BUILD_RUNTIMES)/snakepit/pypy3.5_571
 
 TOOLS=$(BUILD_RUNTIMES)/tools
 
@@ -178,10 +178,10 @@ test-py36: $(PY36)
 	PYTHON=python3.6.0 PIP=pip PATH=$(BUILD_RUNTIMES)/versions/python3.6.0/bin:$(PATH) make develop toxtest
 
 test-pypy: $(PYPY)
-	PYTHON=$(PYPY) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy56/bin:$(PATH) make develop toxtest
+	PYTHON=$(PYPY) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy571/bin:$(PATH) make develop toxtest
 
 test-pypy3: $(PYPY3)
-	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.3_5.5/bin:$(PATH) make develop toxtest
+	PYTHON=$(PYPY3) PIP=pip PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_571/bin:$(PATH) make develop toxtest
 
 test-py27-cffi: $(PY27)
 	GEVENT_CORE_CFFI_ONLY=1 PYTHON=python2.7.13 PATH=$(BUILD_RUNTIMES)/versions/python2.7.13/bin:$(PATH) make develop toxtest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,7 +106,7 @@ for var in "$@"; do
       install pypy2-5.7.1 pypy571
       ;;
     pypy3)
-      install pypy3.5-5.7.1-beta pypy3.5_571
+      install pypy3.3-5.5-alpha pypy3.3_5.5
       ;;
   esac
 done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,10 +103,10 @@ for var in "$@"; do
       install 3.6.0 python3.6.0
       ;;
     pypy)
-      install pypy2-5.6.0 pypy56
+      install pypy2-5.7.1 pypy571
       ;;
     pypy3)
-      install pypy3.3-5.5-alpha pypy3.3_5.5
+      install pypy3.5-5.7.1-beta pypy3.5_571
       ;;
   esac
 done

--- a/src/greentest/patched_tests_setup.py
+++ b/src/greentest/patched_tests_setup.py
@@ -4,6 +4,8 @@ import sys
 import os
 import re
 
+TRAVIS = os.environ.get("TRAVIS") == "true"
+
 # By default, test cases are expected to switch and emit warnings if there was none
 # If a test is found in this list, it's expected not to switch.
 no_switch_tests = '''test_patched_select.SelectTestCase.test_error_conditions
@@ -356,7 +358,7 @@ if sys.version_info[0] == 3:
         'test_socket.GeneralModuleTests.testGetaddrinfo',
 
     ]
-    if os.environ.get("TRAVIS") == "true":
+    if TRAVIS:
         disabled_tests += [
             # test_cwd_with_relative_executable tends to fail
             # on Travis...it looks like the test processes are stepping
@@ -383,6 +385,15 @@ if hasattr(sys, 'pypy_version_info') and sys.version_info[:2] == (3, 3):
         'test_httplib.HTTPSTest.test_networked_bad_cert',
         'test_httplib.HTTPSTest.test_networked_good_cert',
     ]
+
+    if TRAVIS:
+        disabled_tests += [
+            # When we switched to Ubuntu 14.04 trusty, this started
+            # failing with "_ssl.SSLError: [SSL] dh key too small", but it
+            # was fine on 12.04. But we have to switch to be able to
+            # install PyPy? 5.7.1.
+            'test_ssl.ThreadedTests.test_dh_params',
+        ]
 
     disabled_tests += [
         # This raises 'RuntimeError: reentrant call' when exiting the
@@ -508,7 +519,7 @@ if sys.version_info[:2] >= (3, 4):
             'test_socket.InterruptedSendTimeoutTest.testInterruptedSendmsgTimeout',
         ]
 
-    if os.environ.get('TRAVIS') == 'true':
+    if TRAVIS:
         disabled_tests += [
             'test_subprocess.ProcessTestCase.test_double_close_on_error',
             # This test is racy or OS-dependent. It passes locally (sufficiently fast machine)


### PR DESCRIPTION
* Cannot bump PyPy3 right now due to https://bitbucket.org/pypy/pypy/issues/2532/pypy3-attributeerror-frame-object-has-no
* Had to bump to Ubuntu 14.04 to install PyPy2. This is in beta, according to Travis, but I've been using it successfully for RelStorage for some time. It also probably makes sense, because the older version, 12.04, ends support this month.