### PR TITLE
FileObjectClosed is an exception object

### DIFF
--- a/src/gevent/fileobject.py
+++ b/src/gevent/fileobject.py
@@ -175,7 +175,7 @@ class FileObjectThread(FileObjectBase):
                 # This is different than FileObjectPosix, etc,
                 # because we want to save the expensive trip through
                 # the threadpool.
-                raise FileObjectClosed()
+                raise FileObjectClosed
             with lock:
                 return threadpool.apply(method, args, kwargs)
 


### PR DESCRIPTION
So, raise it directly, instead of trying to use it as a callable.