### PR TITLE
monkey: exec scripts in global scope

### DIFF
--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -672,8 +672,10 @@ def main():
         __package__ = None
         assert __package__ is None
         globals()['__file__'] = sys.argv[0]  # issue #302
+        # Clear package so exec'd script doesn't appear in gevent package
+        globals()['__package__'] = None
         with open(sys.argv[0]) as f:
-            exec(f.read())
+            exec(f.read(), globals())
     else:
         print(script_help)
 

--- a/src/greentest/test__monkey_scope.py
+++ b/src/greentest/test__monkey_scope.py
@@ -1,0 +1,17 @@
+import sys
+
+
+if 'gevent' not in sys.modules:
+    from subprocess import Popen
+    args = [sys.executable, '-m', 'gevent.monkey', __file__]
+    p = Popen(args)
+    code = p.wait()
+    assert code == 0, code
+
+else:
+    from textwrap import dedent
+
+    def use_import():
+        dedent("    text")
+
+    use_import()


### PR DESCRIPTION
Commit 59581a8a3b7b0a4722fb3f7074fce6cd4c700bfd "Add python 3.5
selectors test, and remove the devpoll selector under 3.5. also update
the monkey documentation." Introduced a regression by moving the exec of
scripts into a main() function. If the script being run with exec has
import statements those are now locally scoped to the main() function
which can break the script.

It does not appear that this local scoping was intentional so the fix is
to exec the script in the global scope, returning the previous behavior.