### PR TITLE
always obey GEVENT_NO_CFFI_BUILD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,16 +90,17 @@ try:
 except ImportError:
     pass
 else:
-    if IGNORE_CFFI and not PYPY:
-        # Allow distributors to turn off CFFI builds
-        # even if it's available, because CFFI always embeds
-        # our copy of libev and they may not want that.
-        del cffi_modules[:]
     # Note that we don't add cffi to install_requires, it's
     # optional. We tend to build and distribute wheels with the CFFI
     # modules built and they can be imported if CFFI is installed.
     # install_requires.append('cffi >= 1.3.0')
+    pass
 
+if IGNORE_CFFI and not PYPY:
+    # Allow distributors to turn off CFFI builds
+    # even if it's available, because CFFI always embeds
+    # our copy of libev and they may not want that.
+    del cffi_modules[:]
 
 # If we are running info / help commands, or we're being imported by
 # tools like pyroma, we don't need to build anything


### PR DESCRIPTION
With `LIBEV_EMBED=0`, `GEVENT_NO_CFFI_BUILD=1`, and the `cffi` module absent, every invocation of setup.py *still* tries to configure the embedded copy of libev. Looks like the test for `IGNORE_CFFI` is just in the wrong place, should be outside the try: else: block. This patch moves it around.