### PR TITLE
Defer adjusting the stdlib's list of active threads until threading is monkey-patched

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,20 @@
   locals after the greenlet exited. Introduce a weak reference to
   avoid that. Reported in :issue:`981` by Heungsub Lee.
 
+- Defer adjusting the stdlib's list of active threads until
+  ``threading`` is monkey patched. Previously this was done when
+  :mod:`gevent.threading` was imported. That module is documented to
+  be used as a helper for monkey patching, so this should generally
+  functionally be the same, but some applications ignore the directly
+  import that module anyway.
+
+  A positive consequence is that ``import gevent.threading, threading;
+  threading.current_thread()`` will no longer return a DummyThread
+  before monkey-patching. Another positive consequence is that PyPy
+  will no longer print a ``KeyError`` on exit if
+  :mod:`gevent.threading` was imported *without* monkey-patching.
+
+  See :issue:`984`.
 
 1.2.2 (2017-06-05)
 ==================

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -217,7 +217,7 @@ def _gevent_will_monkey_patch(native_module, items, warn): # pylint:disable=unus
     main_thread = main_native_thread()
     if __threading__.current_thread() != main_thread:
         warn("Monkey-patching outside the main native thread. Some APIs "
-             "will not be available.")
+             "will not be available. Expect a KeyError to be printed at shutdown.")
         return
 
     if _get_ident() not in __threading__._active:

--- a/src/greentest/test__threading_monkey_in_thread.py
+++ b/src/greentest/test__threading_monkey_in_thread.py
@@ -1,0 +1,59 @@
+# We can monkey-patch in a thread, but things don't work as expected.
+import sys
+import threading
+from gevent import monkey
+import greentest
+
+
+class Test(greentest.TestCase):
+
+    def test_patch_in_thread(self):
+        all_warnings = []
+        try:
+            get_ident = threading.get_ident
+        except AttributeError:
+            get_ident = threading._get_ident
+
+        def process_warnings(warnings):
+            all_warnings.extend(warnings)
+        monkey._process_warnings = process_warnings
+
+        current = threading.current_thread()
+        current_id = get_ident()
+
+        def target():
+            tcurrent = threading.current_thread()
+            monkey.patch_all()
+            tcurrent2 = threading.current_thread()
+            self.assertIsNot(tcurrent, current)
+            # We get a dummy thread now
+            self.assertIsNot(tcurrent, tcurrent2)
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+
+        self.assertFalse(isinstance(current, threading._DummyThread))
+        self.assertTrue(isinstance(current, monkey.get_original('threading', 'Thread')))
+
+
+        # We generated some warnings
+        if sys.version_info >= (3, 4):
+            self.assertEqual(all_warnings,
+                             ['Monkey-patching outside the main native thread. Some APIs will not be '
+                              'available. Expect a KeyError to be printed at shutdown.',
+                              'Monkey-patching not on the main thread; threading.main_thread().join() '
+                              'will hang from a greenlet'])
+        else:
+            self.assertEqual(all_warnings,
+                             ['Monkey-patching outside the main native thread. Some APIs will not be '
+                              'available. Expect a KeyError to be printed at shutdown.'])
+
+
+        # Manual clean up so we don't get a KeyError
+        del threading._active[current_id]
+        threading._active[(getattr(threading, 'get_ident', None) or threading._get_ident)()] = current
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/greentest/test__threading_monkey_in_thread.py
+++ b/src/greentest/test__threading_monkey_in_thread.py
@@ -7,6 +7,7 @@ import greentest
 
 class Test(greentest.TestCase):
 
+    @greentest.ignores_leakcheck # can't be run multiple times
     def test_patch_in_thread(self):
         all_warnings = []
         try:


### PR DESCRIPTION
Previously this was done when `gevent.threading` was imported. That module is documented to be used as a helper for monkey patching, so this should generally functionally be the same, but some
applications ignore the directly import that module anyway.

A positive consequence is that ``import gevent.threading, threading; threading.current_thread()`` will no longer return a DummyThread before monkey-patching. Another positive consequence is that PyPy will no longer print a ``KeyError`` on exit if `gevent.threading` was imported *without* monkey-patching.

Fixes #984.