### PR TITLE
Return the correct value from Popen.communicate() on Py3/text mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,11 @@
 - Linux CI now tests on PyPy3 3.5-5.8.0, updated from PyPy3 3.5-5.7.1.
   See :issue:`1001`.
 
+- :meth:`gevent.subprocess.Popen.communicate` returns the correct type
+  of str (not bytes) in universal newline mode under Python 3, or when
+  an encoding has been specified. Initial patch in :pr:`939` by
+  William Grzybowski.
+
 1.2.2 (2017-06-05)
 ==================
 

--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -133,6 +133,8 @@ if PYPY3:
 else:
     skipOnPyPy3 = _do_not_skip
 
+skipIf = unittest.skipIf
+
 EXPECT_POOR_TIMER_RESOLUTION = PYPY3 or RUNNING_ON_APPVEYOR
 
 class ExpectedException(Exception):


### PR DESCRIPTION
With tests, verified against the stdlib.

Fixes a todo, and fixes #939. Also cleans up some of the duplicate code from that method (we could probably do a little better if we were willing to pay for two new empty lists for `_stdout`/`_stderr_buffer` at `Popen` construction time).

Lets watch appveyor closely on this one.