### PR TITLE
More safely terminate process on Windows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@
   total speed up of about 35 times. It is now in the same ball park as
   the native :class:`threading.local` class. See :pr:`1024`.
 
+- More safely terminate process on Windows. Reported in :issue:`1023`
+  by Giacomo Debidda.
+
 1.2.2 (2017-06-05)
 ==================
 

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -108,7 +108,6 @@ __extra__ = [
     'CreateProcess',
     'INFINITE',
     'TerminateProcess',
-    'GetExitCodeProcess',
     'STILL_ACTIVE',
 
     # These were added for 3.5, but we make them available everywhere.
@@ -1011,6 +1010,7 @@ class Popen(object):
                 if rc == STILL_ACTIVE:
                     raise
                 self.returncode = rc
+                self.result.set(self.returncode)
 
         kill = terminate
 

--- a/src/greentest/patched_tests_setup.py
+++ b/src/greentest/patched_tests_setup.py
@@ -521,16 +521,6 @@ if sys.version_info[:2] >= (3, 4):
         # In any event, this test hangs forever
 
 
-        'test_subprocess.POSIXProcessTestCase.test_terminate_dead',
-        'test_subprocess.POSIXProcessTestCase.test_send_signal_dead',
-        'test_subprocess.POSIXProcessTestCase.test_kill_dead',
-        # With our monkey patch in place,
-        # they fail because the process they're looking for has been allowed to exit.
-        # Our monkey patch waits for the process with a watcher and so detects
-        # the exit before the normal polling mechanism would
-
-
-
         'test_subprocess.POSIXProcessTestCase.test_preexec_errpipe_does_not_double_close_pipes',
         # Subclasses Popen, and overrides _execute_child. Expects things to be done
         # in a particular order in an exception case, but we don't follow that

--- a/src/greentest/patched_tests_setup.py
+++ b/src/greentest/patched_tests_setup.py
@@ -171,14 +171,6 @@ disabled_tests = [
     'test_thread.TestForkInThread.test_forkinthread',
     # XXX needs investigating
 
-    'test_subprocess.POSIXProcessTestCase.test_terminate_dead',
-    'test_subprocess.POSIXProcessTestCase.test_send_signal_dead',
-    'test_subprocess.POSIXProcessTestCase.test_kill_dead',
-    # Don't exist in the test suite until 2.7.4+; with our monkey patch in place,
-    # they fail because the process they're looking for has been allowed to exit.
-    # Our monkey patch waits for the process with a watcher and so detects
-    # the exit before the normal polling mechanism would
-
     'test_subprocess.POSIXProcessTestCase.test_preexec_errpipe_does_not_double_close_pipes',
     # Does not exist in the test suite until 2.7.4+. Subclasses Popen, and overrides
     # _execute_child. But our version has a different parameter list than the


### PR DESCRIPTION
Fixes #1023

Also re-enable the POSIX version of those tests. They should (and do) pass, at least locally.