### PR TITLE
Add blocking and timeout params to Pool.add

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ and the contributors (ordered by the date of first contribution):
   陈小玉
   Philip Conrad
   Heungsub Lee
+  Ron Rothman
 
   See https://github.com/gevent/gevent/graphs/contributors for more info.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 1.3.0 (unreleased)
 ==================
 
+- ``Pool.add`` now accepts ``blocking`` and ``timeout`` parameters,
+  which function similarly to their counterparts in ``Semaphore``.
+  See :pr:`1032` by Ron Rothman.
+
 - If a single greenlet created and destroyed many
   :class:`gevent.local.local` objects without ever exiting, there
   would be a leak of the function objects intended to clean up the

--- a/src/gevent/pool.py
+++ b/src/gevent/pool.py
@@ -734,8 +734,8 @@ class Pool(Group):
         :keyword float timeout: The maximum number of seconds this method will
         block, if ``blocking`` is True. (Ignored if ``blocking`` is False.)
 
-        Raises ``Timeout`` on timeout, or `PoolFull` if ``blocking`` is False and
-        the pool is full.
+        Raises `PoolFull` if either ``blocking`` is False and the pool was full,
+        or if ``blocking`` is True and ``timeout`` was exceeded.
 
         .. seealso:: :meth:`Group.add`
 
@@ -745,8 +745,8 @@ class Pool(Group):
         if not self._semaphore.acquire(blocking=blocking, timeout=timeout):
             # We failed to acquire the semaphore.
             # If blocking was True, then there was a timeout. If blocking was
-            # False, then there was no capacity.
-            raise Timeout() if blocking else PoolFull()
+            # False, then there was no capacity. Either way, raise PoolFull.
+            raise PoolFull()
 
         try:
             Group.add(self, greenlet)

--- a/src/gevent/pool.py
+++ b/src/gevent/pool.py
@@ -23,6 +23,7 @@ except ImportError:
 
 from gevent.hub import GreenletExit, getcurrent, kill as _kill
 from gevent.greenlet import joinall, Greenlet
+from gevent.queue import Full as QueueFull
 from gevent.timeout import Timeout
 from gevent.event import Event
 from gevent.lock import Semaphore, DummySemaphore
@@ -646,7 +647,7 @@ class Failure(object):
             raise self.exc
 
 
-class Full(Exception):
+class PoolFull(QueueFull):
     """
     Raised when a Pool is full and an attempt was made to
     add a new greenlet to it.
@@ -733,7 +734,7 @@ class Pool(Group):
         :keyword float timeout: The maximum number of seconds this method will
         block, if ``blocking`` is True. (Ignored if ``blocking`` is False.)
 
-        Raises ``Timeout`` on timeout, or `Full` if ``blocking`` is False and
+        Raises ``Timeout`` on timeout, or `PoolFull` if ``blocking`` is False and
         the pool is full.
 
         .. seealso:: :meth:`Group.add`
@@ -745,7 +746,7 @@ class Pool(Group):
             # We failed to acquire the semaphore.
             # If blocking was True, then there was a timeout. If blocking was
             # False, then there was no capacity.
-            raise Timeout() if blocking else Full()
+            raise Timeout() if blocking else PoolFull()
 
         try:
             Group.add(self, greenlet)

--- a/src/gevent/pool.py
+++ b/src/gevent/pool.py
@@ -742,9 +742,10 @@ class Pool(Group):
             Added the ``blocking`` and ```timeout`` parameters.
         """
         if not self._semaphore.acquire(blocking=blocking, timeout=timeout):
-            # We failed to acquire the semaphore. Presumably, blocking was False, because had it
-            # been True, we would have either acquired the semaphore or encountered a Timeout.
-            raise Full
+            # We failed to acquire the semaphore.
+            # If blocking was True, then there was a timeout. If blocking was
+            # False, then there was no capacity.
+            raise Timeout() if blocking else Full()
 
         try:
             Group.add(self, greenlet)

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -226,7 +226,7 @@ class PoolBasicTests(greentest.TestCase):
             second = gevent.spawn(gevent.sleep, 1000)
             try:
                 p.add(first)
-                with self.assertRaises(Timeout):
+                with self.assertRaises(pool.PoolFull):
                     p.add(second, timeout=0.100)
             finally:
                 second.kill()

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -212,7 +212,7 @@ class PoolBasicTests(greentest.TestCase):
             second = gevent.spawn(gevent.sleep, 1000)
             try:
                 p.add(first)
-                with self.assertRaises(pool.Full):
+                with self.assertRaises(pool.PoolFull):
                     p.add(second, blocking=False)
             finally:
                 second.kill()

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -3,6 +3,7 @@ import gevent
 from gevent import pool
 from gevent.event import Event
 from gevent.queue import Queue
+from gevent.timeout import Timeout
 import greentest
 import random
 from greentest import ExpectedException
@@ -199,6 +200,46 @@ class PoolBasicTests(greentest.TestCase):
                     timeout.cancel()
                 self.assertEqual(p.free_count(), 0)
                 self.assertEqual(len(p), 1)
+            finally:
+                second.kill()
+        finally:
+            first.kill()
+
+    def test_add_method_non_blocking(self):
+        p = self.klass(size=1)
+        first = gevent.spawn(gevent.sleep, 1000)
+        try:
+            second = gevent.spawn(gevent.sleep, 1000)
+            try:
+                p.add(first)
+                try:
+                    p.add(second, blocking=False)
+                except pool.Full:
+                    pass  # expected
+                except Exception:
+                    raise AssertionError('Expected pool.Full')
+                else:
+                    raise AssertionError('Expected pool.Full')
+            finally:
+                second.kill()
+        finally:
+            first.kill()
+
+    def test_add_method_timeout(self):
+        p = self.klass(size=1)
+        first = gevent.spawn(gevent.sleep, 1000)
+        try:
+            second = gevent.spawn(gevent.sleep, 1000)
+            try:
+                p.add(first)
+                try:
+                    p.add(second, timeout=0.100)
+                except Timeout:
+                    pass  # expected
+                except Exception:
+                    raise AssertionError('expected Timeout')
+                else:
+                    raise AssertionError('expected Timeout')
             finally:
                 second.kill()
         finally:

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -212,14 +212,8 @@ class PoolBasicTests(greentest.TestCase):
             second = gevent.spawn(gevent.sleep, 1000)
             try:
                 p.add(first)
-                try:
+                with self.assertRaises(pool.Full):
                     p.add(second, blocking=False)
-                except pool.Full:
-                    pass  # expected
-                except Exception:
-                    raise AssertionError('Expected pool.Full')
-                else:
-                    raise AssertionError('Expected pool.Full')
             finally:
                 second.kill()
         finally:
@@ -232,14 +226,8 @@ class PoolBasicTests(greentest.TestCase):
             second = gevent.spawn(gevent.sleep, 1000)
             try:
                 p.add(first)
-                try:
+                with self.assertRaises(Timeout):
                     p.add(second, timeout=0.100)
-                except Timeout:
-                    pass  # expected
-                except Exception:
-                    raise AssertionError('expected Timeout')
-                else:
-                    raise AssertionError('expected Timeout')
             finally:
                 second.kill()
         finally:


### PR DESCRIPTION
This PR adds a `timeout` (and `blocking`) parameter to `Pool.add`.

This allows clients of `Pool` to decide whether they want to fail if a pool is at capacity, and (for example) apply some backpressure to whomever is, in turn, calling them.

Notes:
* I've tried running `tox` but I wasn't able to get it working reliably, so apologies in advance if I've missed some tests that should have been run.
