### PR TITLE
gevent.queue.__all__ to include Full and Empty

### DIFF
--- a/src/gevent/queue.py
+++ b/src/gevent/queue.py
@@ -42,7 +42,7 @@ from gevent.hub import get_hub, Waiter, getcurrent
 from gevent.hub import InvalidSwitchError
 
 
-__all__ = ['Queue', 'PriorityQueue', 'LifoQueue', 'JoinableQueue', 'Channel']
+__all__ = ['Empty', 'Full', 'Queue', 'PriorityQueue', 'LifoQueue', 'JoinableQueue', 'Channel']
 
 
 def _safe_remove(deq, item):


### PR DESCRIPTION
A one-line PR that adds exceptions `Full` and `Empty` to `gevent.queue.__all__`.

I understand that `Full` and `Empty` are merely aliases, and that clients of `gevent.queue` may very well import them from their "native" stdlib locations, but it makes sense to me to expose them as first-class attributes of `gevent.queue` as well. Merge iff you agree. :)
