### PR TITLE
Attempt to fix (or workaround) test__socket.py on Windows

### DIFF
--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -254,8 +254,10 @@ def wrap_refcount(method):
                 d = sum(hist_before.values())
 
                 self.setUp()
-                method(self, *args, **kwargs)
-                self.tearDown()
+                try:
+                    method(self, *args, **kwargs)
+                finally:
+                    self.tearDown()
 
                 # Grab post snapshot
                 if 'urlparse' in sys.modules:

--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -422,6 +422,10 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
             self.switch_expected = get_switch_expected(self.fullname)
         return BaseTestCase.run(self, *args, **kwargs)
 
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.close_on_teardown = []
+
     def tearDown(self):
         if getattr(self, 'skipTearDown', False):
             return
@@ -429,10 +433,7 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
             self.cleanup()
         self._error = self._none
         self._tearDownCloseOnTearDown()
-        try:
-            del self.close_on_teardown
-        except AttributeError:
-            pass
+        self.close_on_teardown = []
         super(TestCase, self).tearDown()
 
     def _tearDownCloseOnTearDown(self):
@@ -443,7 +444,6 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
                 close()
             except Exception:
                 pass
-
 
     @classmethod
     def setUpClass(cls):
@@ -464,8 +464,6 @@ class TestCase(TestCaseMetaClass("NewBase", (BaseTestCase,), {})):
         *resource* either has a ``close`` method, or is a
         callable.
         """
-        if 'close_on_teardown' not in self.__dict__:
-            self.close_on_teardown = []
         self.close_on_teardown.append(resource)
         return resource
 

--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -97,6 +97,9 @@ if WIN:
     NON_APPLICABLE_SUFFIXES.append("posix")
     # This is intimately tied to FileObjectPosix
     NON_APPLICABLE_SUFFIXES.append("fileobject2")
+    SHARED_OBJECT_EXTENSION = ".pyd"
+else:
+    SHARED_OBJECT_EXTENSION = ".so"
 
 
 RUNNING_ON_TRAVIS = os.environ.get('TRAVIS')
@@ -762,7 +765,7 @@ def walk_modules(basedir=None, modpath=None, include_so=False, recursive=False):
                 except ImportError:
                     continue
             yield path, modpath + x
-        elif include_so and fn.endswith('.so'):
+        elif include_so and fn.endswith(SHARED_OBJECT_EXTENSION):
             if '.pypy-' in fn:
                 continue
             if fn.endswith('_d.so'):

--- a/src/greentest/known_failures.py
+++ b/src/greentest/known_failures.py
@@ -72,15 +72,6 @@ if sys.platform == 'win32':
             'FLAKY test__fileobject.py',
         ]
 
-        FAILING_TESTS += [
-            # This sometimes fails with a timeout, meaning
-            # one of the tests hangs (test_fullduplex, maybe?).
-            # But only sometimes, and only seen on Py2.7, beginning
-            # ~2016-02-24.
-            # Beginning Apr 2016 sometimes also seen with Py 3.5
-            'FLAKY test__socket.py',
-        ]
-
         if PY3:
             FAILING_TESTS += [
                 # test_set_and_clear in Py3 relies on 5 threads all starting and

--- a/src/greentest/test__makefile_ref.py
+++ b/src/greentest/test__makefile_ref.py
@@ -119,15 +119,12 @@ class Test(greentest.TestCase):
         # Keeping raw sockets alive keeps SSL sockets
         # from being closed too, at least on CPython, so we
         # need to use weakrefs
-        if 'close_on_teardown' not in self.__dict__:
-            self.close_on_teardown = []
         self.close_on_teardown.append(weakref.ref(resource))
         return resource
 
     def _tearDownCloseOnTearDown(self):
         self.close_on_teardown = [r() for r in self.close_on_teardown if r() is not None]
         super(Test, self)._tearDownCloseOnTearDown()
-        self.close_on_teardown = []
 
 class TestSocket(Test):
 

--- a/src/greentest/test__socket.py
+++ b/src/greentest/test__socket.py
@@ -47,8 +47,8 @@ class TestTCP(greentest.TestCase):
 
     def setUp(self):
         super(TestTCP, self).setUp()
-        listener = socket.socket()
-        self._close_on_teardown(listener)
+        self.listener = self._close_on_teardown(self._setup_listener())
+
         # XXX: On Windows (at least with libev), if we have a cleanup/tearDown method
         # that does 'del self.listener' AND we haven't sometime
         # previously closed the listener (while the test body was executing)
@@ -64,10 +64,12 @@ class TestTCP(greentest.TestCase):
 
         # Perhaps our logic is wrong in libev_vfd in the way we use
         # _open_osfhandle and determine we can close it?
-        greentest.bind_and_listen(listener, ('127.0.0.1', 0))
-        self.listener = listener
-        self.port = listener.getsockname()[1]
+        self.port = self.listener.getsockname()[1]
 
+    def _setup_listener(self):
+        listener = socket.socket()
+        greentest.bind_and_listen(listener, ('127.0.0.1', 0))
+        return listener
 
     def create_connection(self, host='127.0.0.1', port=None, timeout=None,
                           blocking=None):


### PR DESCRIPTION
It (now) runs locally for me on Win10/Py3.6 with both libev and libuv.

It had been sometimes failing since 2016-02 for 2.7 and 2016-04 for
3.5.

Here's the comment in the code indicating what I tracked down. Note
that the changes are more of a workaround than a true fix:

XXX: On Windows (at least with libev), if we have a cleanup/tearDown
method that does 'del self.listener' AND we haven't sometime
previously closed the listener (while the test body was executing) we
tend to sometimes see hangs when tests run in succession; notably
test_empty_send followed by test_makefile produces a hang in
test_makefile when it tries to read from the client_file, because the
accept() call in accept_once has not yet returned a new socket to
write to.

The cause *seems* to be that the listener socket in both tests gets
the same fileno(); or, at least, if we don't del the listener object,
we get a different fileno, and that scenario works.

Perhaps our logic is wrong in libev_vfd in the way we use
_open_osfhandle and determine we can close it?

Additional note:

Possibly libuv doesn't suffer from this since it takes the SOCKET
object directly? I didn't fully test that situation, but libuv tests
were failing and are now passing.