### PR TITLE
Explicitly close IO watchers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
       # first group of parallel runs (4) as posible
       - TASK=test-py27-libuv
       - TASK=test-py36-libuv
+      - TASK=test-pypy-libuv
       - TASK=test-py27-noembed
       - TASK=test-pypy
       - TASK=test-py36

--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,10 @@ test-py36-libuv: $(PY36)
 	GEVENT_CORE_CFFI_ONLY=libuv make test-py36
 
 test-pypy: $(PYPY)
-	ls $(BUILD_RUNTIMES)/versions/pypy590/bin/
 	PYTHON=$(PYPY) PATH=$(BUILD_RUNTIMES)/versions/pypy590/bin:$(PATH) make develop toxtest
+
+test-pypy-libuv: $(PY36)
+	GEVENT_CORE_CFFI_ONLY=libuv make test-pypy
 
 test-pypy3: $(PYPY3)
 	PYTHON=$(PYPY3) PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_590/bin:$(PATH) make develop toxtest

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ test-py36-libuv: $(PY36)
 test-pypy: $(PYPY)
 	PYTHON=$(PYPY) PATH=$(BUILD_RUNTIMES)/versions/pypy590/bin:$(PATH) make develop toxtest
 
-test-pypy-libuv: $(PY36)
+test-pypy-libuv: $(PYPY)
 	GEVENT_CORE_CFFI_ONLY=libuv make test-pypy
 
 test-pypy3: $(PYPY3)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,11 @@ environment:
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
 
-    # We're not quite ready for PyPy+libuv, it doesn't even
-    # work correctly on Posix.
-    # - PYTHON: "C:\\pypy2-v5.9.0-win32"
-    #   PYTHON_ID: "pypy"
-    #   PYTHON_EXE: pypy
-    #   PYTHON_VERSION: "2.7.x"
-    #   PYTHON_ARCH: "32"
+    - PYTHON: "C:\\pypy2-v5.9.0-win32"
+      PYTHON_ID: "pypy"
+      PYTHON_EXE: pypy
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x" # currently 3.6.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,15 @@ environment:
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
 
-    - PYTHON: "C:\\pypy2-v5.9.0-win32"
-      PYTHON_ID: "pypy"
-      PYTHON_EXE: pypy
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
+    # We're not quite ready for PyPy+libuv.
+    # It works correctly on POSIX (linux and darwin),
+    # but has some strange errors and many timeouts on Windows.
+    # Most recent build: https://ci.appveyor.com/project/denik/gevent/build/1.0.1174/job/cv63181yj3ebb9cs
+    # - PYTHON: "C:\\pypy2-v5.9.0-win32"
+    #   PYTHON_ID: "pypy"
+    #   PYTHON_EXE: pypy
+    #   PYTHON_VERSION: "2.7.x"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x" # currently 3.6.0

--- a/src/gevent/_ffi/loop.py
+++ b/src/gevent/_ffi/loop.py
@@ -144,7 +144,7 @@ class _Callbacks(object):
                 # The normal, expected scenario when we find the watcher still
                 # in the keepaliveset is that it is still active at the event loop
                 # level, so we don't expect that python_stop gets called.
-                _dbg("The watcher has not stopped itself, possibly still active", the_watcher)
+                #_dbg("The watcher has not stopped itself, possibly still active", the_watcher)
                 return 1
             return 2 # it stopped itself
 

--- a/src/gevent/_ffi/loop.py
+++ b/src/gevent/_ffi/loop.py
@@ -296,10 +296,11 @@ class AbstractLoop(object):
 
 
     @classmethod
-    def __make_watcher_ref_callback(cls, typ, active_watchers, ffi_watcher):
+    def __make_watcher_ref_callback(cls, typ, active_watchers, ffi_watcher, debug):
         # separate method to make sure we have no ref to the watcher
         def callback(_):
             active_watchers.pop(ffi_watcher)
+            _dbg("Python weakref callback closing", debug)
             typ._watcher_ffi_close(ffi_watcher)
 
         return callback
@@ -309,7 +310,8 @@ class AbstractLoop(object):
                                                      self.__make_watcher_ref_callback(
                                                          type(python_watcher),
                                                          self._active_watchers,
-                                                         ffi_watcher))
+                                                         ffi_watcher,
+                                                         repr(python_watcher)))
 
     def _init_loop_and_aux_watchers(self, flags=None, default=None):
 

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -410,6 +410,9 @@ class IoMixin(object):
             args = (GEVENT_CORE_EVENTS, ) + args
         super(IoMixin, self).start(callback, *args)
 
+    def close(self):
+        pass
+
 
 class TimerMixin(object):
     _watcher_type = 'timer'

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -208,9 +208,11 @@ class socket(object):
 
         if self._read_event is not None:
             self.hub.cancel_wait(self._read_event, cancel_wait_ex)
+            self._read_event.close()
             self._read_event = None
         if self._write_event is not None:
             self.hub.cancel_wait(self._write_event, cancel_wait_ex)
+            self._write_event.close()
             self._write_event = None
         s = self._sock
         self._sock = _closedsocket()

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -252,9 +252,11 @@ class socket(object):
 
         if self._read_event is not None:
             self.hub.cancel_wait(self._read_event, cancel_wait_ex)
+            self._read_event.close()
             self._read_event = None
         if self._write_event is not None:
             self.hub.cancel_wait(self._write_event, cancel_wait_ex)
+            self._write_event.close()
             self._write_event = None
         _ss.close(self._sock)
 

--- a/src/gevent/_socketcommon.py
+++ b/src/gevent/_socketcommon.py
@@ -179,7 +179,10 @@ def wait_read(fileno, timeout=None, timeout_exc=_NONE):
     .. seealso:: :func:`cancel_wait`
      """
     io = get_hub().loop.io(fileno, 1)
-    return wait(io, timeout, timeout_exc)
+    try:
+        return wait(io, timeout, timeout_exc)
+    finally:
+        io.close()
 
 
 def wait_write(fileno, timeout=None, timeout_exc=_NONE, event=_NONE):
@@ -196,7 +199,10 @@ def wait_write(fileno, timeout=None, timeout_exc=_NONE, event=_NONE):
     """
     # pylint:disable=unused-argument
     io = get_hub().loop.io(fileno, 2)
-    return wait(io, timeout, timeout_exc)
+    try:
+        return wait(io, timeout, timeout_exc)
+    finally:
+        io.close()
 
 
 def wait_readwrite(fileno, timeout=None, timeout_exc=_NONE, event=_NONE):
@@ -214,7 +220,10 @@ def wait_readwrite(fileno, timeout=None, timeout_exc=_NONE, event=_NONE):
     """
     # pylint:disable=unused-argument
     io = get_hub().loop.io(fileno, 3)
-    return wait(io, timeout, timeout_exc)
+    try:
+        return wait(io, timeout, timeout_exc)
+    finally:
+        io.close()
 
 #: The exception raised by default on a call to :func:`cancel_wait`
 class cancel_wait_ex(error): # pylint: disable=undefined-variable

--- a/src/gevent/ares.pyx
+++ b/src/gevent/ares.pyx
@@ -381,6 +381,7 @@ cdef public class channel [object PyGeventAresChannelObject, type PyGeventAresCh
             watcher.events = events
         else:
             watcher.stop()
+            watcher.close()
             self._watchers.pop(socket, None)
             if not self._watchers:
                 self._timer.stop()

--- a/src/gevent/libev/corecext.ppyx
+++ b/src/gevent/libev/corecext.ppyx
@@ -808,6 +808,9 @@ cdef public class io(watcher) [object PyGeventIOObject, type PyGeventIO_Type]:
 
     PENDING
 
+    def close(self):
+        pass
+
 #ifdef _WIN32
 
     def __init__(self, loop loop, libev.vfd_socket_t fd, int events, ref=True, priority=None):

--- a/src/gevent/libuv/_corecffi_cdef.c
+++ b/src/gevent/libuv/_corecffi_cdef.c
@@ -41,7 +41,9 @@ enum uv_poll_event {
 	UV_READABLE = 1,
 	UV_WRITABLE = 2,
 	/* new in 1.9 */
-	UV_DISCONNECT = 4
+	UV_DISCONNECT = 4,
+	/* new in 1.14.0 */
+	UV_PRIORITIZED = 8,
 };
 
 enum uv_fs_event {

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -352,14 +352,9 @@ class loop(AbstractLoop):
 
     @gcBefore
     def io(self, fd, events, ref=True, priority=None):
-        # We don't keep a hard ref to the root object;
-        # the caller must keep the multiplexed watcher
-        # alive as long as its in use.
-
-        # We go to great pains to avoid GC cycles here, otherwise
-        # CPython tests (e.g., test_asyncore) fail on Windows.
-        # For PyPy, though, avoiding cycles isn't enough and we must
-        # do a GC to force cleaning up old objects.
+        # We rely on hard references here and explicit calls to
+        # close() on the returned object to correctly manage
+        # the watcher lifetimes.
 
         io_watchers = self._io_watchers
         try:

--- a/src/gevent/libuv/watcher.py
+++ b/src/gevent/libuv/watcher.py
@@ -340,9 +340,9 @@ class io(_base.IoMixin, watcher):
             # has also gone away.
             self._watcher_ref = watcher
 
-        @property
-        def events(self):
-            return self._events
+        events = property(
+            lambda self: self._events,
+            _base.not_while_active(lambda self, nv: setattr(self, '_events', nv)))
 
         def start(self, callback, *args, **kwargs):
             _dbg("Starting IO multiplex watcher for", self.fd,
@@ -364,7 +364,8 @@ class io(_base.IoMixin, watcher):
             self.pass_events = None
             self.args = None
             watcher = self._watcher_ref
-            watcher._io_maybe_stop()
+            if watcher is not None:
+                watcher._io_maybe_stop()
 
         def close(self):
             if self._watcher_ref is not None:
@@ -382,7 +383,7 @@ class io(_base.IoMixin, watcher):
 
         # ares.pyx depends on this property,
         # and test__core uses it too
-        fd = property(lambda self: self._watcher_ref._fd,
+        fd = property(lambda self: getattr(self._watcher_ref, '_fd', -1),
                       lambda self, nv: self._watcher_ref._set_fd(nv))
 
     def _io_maybe_stop(self):

--- a/src/gevent/os.py
+++ b/src/gevent/os.py
@@ -90,7 +90,10 @@ if fcntl:
         hub, event = None, None
         while True:
             try:
-                return _read(fd, n)
+                result = _read(fd, n)
+                if event is not None:
+                    event.close()
+                return result
             except OSError as e:
                 if e.errno not in ignored_errors:
                     raise
@@ -101,6 +104,7 @@ if fcntl:
                 event = hub.loop.io(fd, 1)
             hub.wait(event)
 
+
     def nb_write(fd, buf):
         """Write bytes from buffer `buf` to file descriptor `fd`. Return the
         number of bytes written.
@@ -110,7 +114,10 @@ if fcntl:
         hub, event = None, None
         while True:
             try:
-                return _write(fd, buf)
+                result = _write(fd, buf)
+                if event is not None:
+                    event.close()
+                return result
             except OSError as e:
                 if e.errno not in ignored_errors:
                     raise

--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -101,6 +101,7 @@ class SelectResult(object):
     def _closeall(self, watchers):
         for watcher in watchers:
             watcher.stop()
+            watcher.close()
         del watchers[:]
 
     def select(self, rlist, wlist, timeout):
@@ -208,6 +209,9 @@ if original_poll is not None:
                 # that. Should we raise an error?
 
             fileno = get_fileno(fd)
+            if fileno in self.fds:
+                self.fds[fileno].close()
+
             watcher = self.loop.io(fileno, flags)
             watcher.priority = self.loop.MAXPRI
             self.fds[fileno] = watcher
@@ -243,6 +247,8 @@ if original_poll is not None:
                library. Previously gevent did nothing.
             """
             fileno = get_fileno(fd)
+            io = self.fds[fileno]
+            io.close()
             del self.fds[fileno]
 
 del original_poll

--- a/src/greentest/greentest.py
+++ b/src/greentest/greentest.py
@@ -390,7 +390,7 @@ if (PY3 and PYPY) or (PYPY and WIN and LIBUV):
     # pypy3 is very slow right now,
     # as is PyPy2 on windows (which only has libuv)
     CI_TIMEOUT = 15
-if PYPY and WIN and LIBUV:
+if PYPY and LIBUV:
     # slow and flaky timeouts
     LOCAL_TIMEOUT = CI_TIMEOUT
 else:

--- a/src/greentest/patched_tests_setup.py
+++ b/src/greentest/patched_tests_setup.py
@@ -158,6 +158,14 @@ disabled_tests = [
     'test_subprocess.ProcessTestCase.test_zombie_fast_process_del',
     # relies on subprocess._active which we don't use
 
+    # Very slow, tries to open lots and lots of subprocess and files,
+    # tends to timeout on CI.
+    'test_subprocess.ProcessTestCase.test_no_leaking',
+
+    # This test is also very slow, and has been timing out on Travis
+    # since November of 2016 on Python 3, but now also seen on Python 2/Pypy.
+    'test_subprocess.ProcessTestCase.test_leaking_fds_on_error',
+
     'test_ssl.ThreadedTests.test_default_ciphers',
     'test_ssl.ThreadedTests.test_empty_cert',
     'test_ssl.ThreadedTests.test_malformed_cert',
@@ -558,8 +566,6 @@ if sys.version_info[0] == 3:
             'test_subprocess.ProcessTestCaseNoPoll.test_cwd_with_relative_arg',
             'test_subprocess.ProcessTestCase.test_cwd_with_relative_executable',
 
-            # This test tends to timeout, starting at the end of November 2016
-            'test_subprocess.ProcessTestCase.test_leaking_fds_on_error',
         ]
 
     wrapped_tests.update({

--- a/src/greentest/test__core.py
+++ b/src/greentest/test__core.py
@@ -22,7 +22,7 @@ class TestWatchers(unittest.TestCase):
     def test_io(self):
         if sys.platform == 'win32':
             # libev raises IOError, libuv raises ValueError
-            Error = (IOError,ValueError)
+            Error = (IOError, ValueError)
             win32 = True
         else:
             Error = ValueError
@@ -47,6 +47,7 @@ class TestWatchers(unittest.TestCase):
                 self.assertEqual(core._events_to_str(io.events), 'WRITE|_IOFDSET')
             else:
                 self.assertEqual(core._events_to_str(io.events), 'WRITE')
+            io.close()
 
     def test_timer_constructor(self):
         with self.assertRaises(ValueError):

--- a/src/greentest/test__core_watcher.py
+++ b/src/greentest/test__core_watcher.py
@@ -73,10 +73,10 @@ class Test(greentest.TestCase):
         loop = core.loop(default=False)
 
         # Watchers aren't reused once all outstanding
-        # refs go away
+        # refs go away BUT THEY MUST BE CLOSED
         tty_watcher = loop.io(1, core.WRITE)
         watcher_handle = tty_watcher._watcher if IS_CFFI else tty_watcher
-
+        tty_watcher.close()
         del tty_watcher
         # XXX: Note there is a cycle in the CFFI code
         # from watcher_handle._handle -> watcher_handle.
@@ -86,7 +86,7 @@ class Test(greentest.TestCase):
 
         tty_watcher = loop.io(1, core.WRITE)
         self.assertIsNot(tty_watcher._watcher if IS_CFFI else tty_watcher, watcher_handle)
-
+        tty_watcher.close()
         loop.destroy()
 
 def reset(watcher, lst):

--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -67,7 +67,7 @@ if hasattr(os, 'make_nonblocking'):
     class TestOS_nb(TestOS_tp):
 
         def pipe(self):
-            r, w = pipe()
+            r, w = super(TestOS_nb, self).pipe()
             os.make_nonblocking(r)
             os.make_nonblocking(w)
             return r, w


### PR DESCRIPTION
This gets libuv+PyPy working for POSIX platforms (or indeed, gets CPython working when there are unexpected calls to GC resulting in weakrefs with callbacks being cleaned up). 

Moreover, this fixes the same Windows problems that the earlier patch was doing, but in a cleaner way. Unfortunately, PyPy still doesn't work on Windows.

There are still some cleanups and nice-to-haves for this approach, but I'll wait on any larger scale changes until I have a chance to look at PyPy+Windows again.