### PR TITLE
subprocess: restore backwards-compatibility with python2

### DIFF
--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -419,7 +419,10 @@ class Popen(object):
             raise TypeError("Got unexpected keyword arguments", kwargs)
         pass_fds = kwargs.pop('pass_fds', ())
         start_new_session = kwargs.pop('start_new_session', False)
-        restore_signals = kwargs.pop('restore_signals', True)
+        if PY3:
+            restore_signals = kwargs.pop('restore_signals', True)
+        else:
+            restore_signals = False
         # Added in 3.6. These are kept as ivars
         encoding = self.encoding = kwargs.pop('encoding', None)
         errors = self.errors = kwargs.pop('errors', None)


### PR DESCRIPTION
In python2, restore_signals doesn't exist, and the default behavior is
to not restore the signals. (This can be done with preexec_fn, if
wanted.) By setting the option to True by default, and not allowing it
to be changed, the behavior becomes mandatory, and is a change from
cpython's behavior on python 2.7.

This change sets the correct default option for py2, and leaves the
py3 version still customizable, maintaining compatibility in both
versions.