### PR TITLE
Make callbacks.c stop relying on implementation details of Cython and Python

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,7 +81,6 @@ Build Changes
   one pointer less memory per object, and one pointer less memory per
   greenlet. See :pr:`1024`.
 
-
 - The Cython ares 'channel' class is no longer declared to be publicly
   accessible from a named C structure. Doing so caused a conflict with
   the c-ares header files.
@@ -288,6 +287,11 @@ libev
     or have a negative value when not available. In general these
     attributes are not portable and not implemented by libuv or the
     CFFI backend. See :issue:`1076`.
+
+  - Certain private helper functions (``gevent_handle_error``, part of
+    ``gevent_call``) are now implemented in Cython instead of C. This
+    reduces our reliance on internal undocumented implementation
+    details of Cython and Python that could change.
 
 
 1.2.2 (2017-06-05)

--- a/_setuplibev.py
+++ b/_setuplibev.py
@@ -61,7 +61,10 @@ def configure_libev(bext, ext):
         os.chdir(cwd)
 
 CORE = Extension(name='gevent.libev.corecext',
-                 sources=['src/gevent/libev/corecext.pyx'],
+                 sources=[
+                     'src/gevent/libev/corecext.pyx',
+                     'src/gevent/libev/callbacks.c',
+                 ],
                  include_dirs=['src/gevent/libev'] + [dep_abspath('libev')] if LIBEV_EMBED else [],
                  libraries=list(LIBRARIES),
                  define_macros=list(DEFINE_MACROS),
@@ -89,13 +92,3 @@ else:
     CORE.libraries.append('ev')
 
 CORE = cythonize1(CORE)
-
-# XXX The include of callbacks.c must go at the end of the
-# file because it references things cython generates.
-# How can we do this automatically, or relax that restriction?
-with open(CORE.sources[0]) as f:
-    core_data = f.read()
-
-if '#include "callbacks.c"' not in core_data:
-    with open(CORE.sources[0], 'a') as f:
-        f.write('\n#include "callbacks.c"\n')

--- a/src/gevent/libev/callbacks.h
+++ b/src/gevent/libev/callbacks.h
@@ -1,5 +1,9 @@
+struct ev_loop;
+struct PyGeventLoopObject;
+struct PyGeventCallbackObject;
+
 #define DEFINE_CALLBACK(WATCHER_LC, WATCHER_TYPE) \
-    static void gevent_callback_##WATCHER_LC(struct ev_loop *, void *, int);
+    void gevent_callback_##WATCHER_LC(struct ev_loop *, void *, int);
 
 
 #define DEFINE_CALLBACKS0              \
@@ -21,14 +25,14 @@
 DEFINE_CALLBACKS
 
 
-static void gevent_run_callbacks(struct ev_loop *, void *, int);
-struct PyGeventLoopObject;
-static void gevent_handle_error(struct PyGeventLoopObject* loop, PyObject* context);
-struct PyGeventCallbackObject;
-static void gevent_call(struct PyGeventLoopObject* loop, struct PyGeventCallbackObject* cb);
+void gevent_run_callbacks(struct ev_loop *, void *, int);
+
+
+
+void gevent_call(struct PyGeventLoopObject* loop, struct PyGeventCallbackObject* cb);
 
 static void gevent_noop(struct ev_loop *_loop, void *watcher, int revents) {
 }
 
 /* Only used on Win32 */
-static void gevent_periodic_signal_check(struct ev_loop *, void *, int);
+void gevent_periodic_signal_check(struct ev_loop *, void *, int);


### PR DESCRIPTION
Instead use documented ways to interact.

This gets rid of the callbacks.c hack, our reliance on private vtables, and our reliance on undocumented members of PyThreadState. The functions compile to essentially the same C code.