### PR TITLE
Try to adhere to scheduling deadlines when running callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,16 @@ Other Changes
 - gevent now uses cffi's "extern 'Python'" callbacks. These should be
   faster and more stable. This requires at least cffi 1.4.0. See :issue:`1049`.
 
+- gevent now approximately tries to stick to a scheduling interval
+  when running callbacks, instead of simply running a count of
+  callbacks. The interval is determined by
+  :func:`gevent.getswitchinterval`. On Python 3, this is the same as
+  the thread switch interval. On Python 2, this defaults to 0.005s and
+  can be changed with :func:`gevent.setswitchinterval`. This should
+  result in more fair "scheduling" of greenlets, especially when
+  ``gevent.sleep(0)`` or other busy callbacks are in use. The interval
+  is checked every 50 callbacks to keep overhead low. See
+  :issue:`1072`. With thanks to Arcadiy Ivanov and Antonio Cuni.
 
 libuv
 -----
@@ -238,6 +248,8 @@ libuv
     time updated, without cycling the event loop. See :issue:`1057`.
 
     libev has also been changed to follow this behaviour.
+
+    Also see :issue:`1072`.
 
   - Timers of zero duration do not necessarily cause the event loop to
     cycle, as they do in libev. Instead, they may be called

--- a/src/gevent/__init__.py
+++ b/src/gevent/__init__.py
@@ -22,24 +22,28 @@ version_info = _version_info(1, 3, 0, 'dev', 0)
 __version__ = '1.3.0.dev0'
 
 
-__all__ = ['get_hub',
-           'Greenlet',
-           'GreenletExit',
-           'spawn',
-           'spawn_later',
-           'spawn_raw',
-           'iwait',
-           'wait',
-           'killall',
-           'Timeout',
-           'with_timeout',
-           'getcurrent',
-           'sleep',
-           'idle',
-           'kill',
-           'signal',
-           'fork',
-           'reinit']
+__all__ = [
+    'get_hub',
+    'Greenlet',
+    'GreenletExit',
+    'spawn',
+    'spawn_later',
+    'spawn_raw',
+    'iwait',
+    'wait',
+    'killall',
+    'Timeout',
+    'with_timeout',
+    'getcurrent',
+    'sleep',
+    'idle',
+    'kill',
+    'signal',
+    'fork',
+    'reinit',
+    'getswitchinterval',
+    'setswitchinterval',
+]
 
 
 import sys
@@ -47,6 +51,26 @@ if sys.platform == 'win32':
     # trigger WSAStartup call
     import socket  # pylint:disable=unused-import,useless-suppression
     del socket
+
+try:
+    # Floating point number, in number of seconds,
+    # like time.time
+    getswitchinterval = sys.getswitchinterval
+    setswitchinterval = sys.setswitchinterval
+except AttributeError:
+    # Running on Python 2
+    _switchinterval = 0.005
+
+    def getswitchinterval():
+        return _switchinterval
+
+    def setswitchinterval(interval):
+        # Weed out None and non-numbers. This is not
+        # exactly exception compatible with the Python 3
+        # versions.
+        if interval > 0:
+            global _switchinterval
+            _switchinterval = interval
 
 from gevent.hub import get_hub, iwait, wait
 from gevent.greenlet import Greenlet, joinall, killall

--- a/src/gevent/hub.py
+++ b/src/gevent/hub.py
@@ -157,6 +157,10 @@ def sleep(seconds=0, ref=True):
     If *ref* is False, the greenlet running ``sleep()`` will not prevent :func:`gevent.wait`
     from exiting.
 
+    .. versionchanged:: 1.3a1
+       Sleeping with a value of 0 will now be bounded to approximately block the
+       loop for no longer than :func:`gevent.getswitchinterval`.
+
     .. seealso:: :func:`idle`
     """
     hub = get_hub()

--- a/src/gevent/libev/corecffi.py
+++ b/src/gevent/libev/corecffi.py
@@ -199,17 +199,6 @@ _default_loop_destroyed = False
 
 from gevent._ffi.loop import AbstractLoop
 
-# from gevent.libev.watcher import watcher
-# from gevent.libev.watcher import io
-# from gevent.libev.watcher import timer
-# from gevent.libev.watcher import signal
-# from gevent.libev.watcher import idle
-# from gevent.libev.watcher import prepare
-# from gevent.libev.watcher import check
-# from gevent.libev.watcher import fork
-# from gevent.libev.watcher import async
-# from gevent.libev.watcher import child
-# from gevent.libev.watcher import stat
 
 from gevent.libev import watcher as _watchers
 _events_to_str = _watchers._events_to_str # exported

--- a/src/gevent/libev/libev.pxd
+++ b/src/gevent/libev/libev.pxd
@@ -146,7 +146,9 @@ cdef extern from "libev.h" nogil:
     unsigned int ev_recommended_backends()
     unsigned int ev_embeddable_backends()
 
-    double ev_time()
+    ctypedef double ev_tstamp
+
+    ev_tstamp ev_time()
     void ev_set_syserr_cb(void *)
 
     int ev_priority(void*)
@@ -209,7 +211,7 @@ cdef extern from "libev.h" nogil:
     void ev_verify(ev_loop*)
     void ev_run(ev_loop*, int flags) nogil
 
-    double ev_now(ev_loop*)
+    ev_tstamp ev_now(ev_loop*)
     void ev_now_update(ev_loop*)
 
     void ev_ref(ev_loop*)

--- a/src/gevent/libev/watcher.py
+++ b/src/gevent/libev/watcher.py
@@ -177,9 +177,6 @@ class io(_base.IoMixin, watcher):
 
 class timer(_base.TimerMixin, watcher):
 
-    def _update_now(self):
-        libev.ev_now_update(self.loop._ptr)
-
     @property
     def at(self):
         return self._watcher.at

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -382,7 +382,11 @@ class loop(AbstractLoop):
         return libuv.uv_run(self._ptr, mode)
 
     def now(self):
-        return libuv.uv_now(self._ptr)
+        # libuv's now is expressed as an integer number of
+        # milliseconds, so to get it compatible with time.time units
+        # that this method is supposed to return, we have to divide by 1000.0
+        now = libuv.uv_now(self._ptr)
+        return now / 1000.0
 
     def update_now(self):
         libuv.uv_update_time(self._ptr)

--- a/src/gevent/libuv/watcher.py
+++ b/src/gevent/libuv/watcher.py
@@ -618,8 +618,6 @@ class timer(_base.TimerMixin, watcher):
     # This ensures the loop cycles. Of course, the 'again' method does
     # nothing on them and doesn't exist. In practice that's not an issue.
 
-    update_loop_time_on_start = False
-
     _again = False
 
     def _watcher_ffi_init(self, args):

--- a/src/greentest/test__os.py
+++ b/src/greentest/test__os.py
@@ -5,6 +5,7 @@ import gevent
 from gevent import os
 from greentest import TestCase, main, LARGE_TIMEOUT
 from gevent import Greenlet, joinall
+from greentest.skipping import skipOnLibuvOnPyPyOnWin
 
 
 class TestOS_tp(TestCase):
@@ -20,6 +21,7 @@ class TestOS_tp(TestCase):
     def write(self, *args):
         return os.tp_write(*args)
 
+    @skipOnLibuvOnPyPyOnWin("Sometimes times out")
     def _test_if_pipe_blocks(self, buffer_class):
         r, w = self.pipe()
         # set nbytes such that for sure it is > maximum pipe buffer

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -295,6 +295,15 @@ def final_sleep():
 TIMEOUT1, TIMEOUT2, TIMEOUT3 = 0.082, 0.035, 0.14
 
 
+SMALL_RANGE = 10
+LARGE_RANGE = 1000
+
+if greentest.PYPY and greentest.WIN:
+    # See comments in test__threadpool.py.
+    LARGE_RANGE = 50
+elif greentest.RUNNING_ON_CI or greentest.EXPECT_POOR_TIMER_RESOLUTION:
+    LARGE_RANGE = 100
+
 class TestPool(greentest.TestCase):
     __timeout__ = greentest.LARGE_TIMEOUT
     size = 1
@@ -313,7 +322,7 @@ class TestPool(greentest.TestCase):
 
     def test_map(self):
         pmap = self.pool.map
-        self.assertEqual(pmap(sqr, range(10)), list(map(squared, range(10))))
+        self.assertEqual(pmap(sqr, range(SMALL_RANGE)), list(map(squared, range(SMALL_RANGE))))
         self.assertEqual(pmap(sqr, range(100)), list(map(squared, range(100))))
 
     def test_async(self):
@@ -328,7 +337,7 @@ class TestPool(greentest.TestCase):
         get = TimingWrapper(res.get)
         self.assertEqual(get(), 49)
         self.assertTimeoutAlmostEqual(get.elapsed, TIMEOUT1, 1)
-        gevent.sleep(0)  # let's the callback run
+        gevent.sleep(0)  # lets the callback run
         assert result == [49], result
 
     def test_async_timeout(self):
@@ -338,34 +347,36 @@ class TestPool(greentest.TestCase):
         self.assertTimeoutAlmostEqual(get.elapsed, TIMEOUT2, 1)
         self.pool.join()
 
-    def test_imap(self):
-        it = self.pool.imap(sqr, range(10))
-        self.assertEqual(list(it), list(map(squared, range(10))))
+    def test_imap_list_small(self):
+        it = self.pool.imap(sqr, range(SMALL_RANGE))
+        self.assertEqual(list(it), list(map(sqr, range(SMALL_RANGE))))
 
-        it = self.pool.imap(sqr, range(10))
-        for i in range(10):
+    def test_imap_it_small(self):
+        it = self.pool.imap(sqr, range(SMALL_RANGE))
+        for i in range(SMALL_RANGE):
             self.assertEqual(six.advance_iterator(it), i * i)
         self.assertRaises(StopIteration, lambda: six.advance_iterator(it))
 
-        it = self.pool.imap(sqr, range(1000))
-        for i in range(1000):
+    def test_imap_it_large(self):
+        it = self.pool.imap(sqr, range(LARGE_RANGE))
+        for i in range(LARGE_RANGE):
             self.assertEqual(six.advance_iterator(it), i * i)
         self.assertRaises(StopIteration, lambda: six.advance_iterator(it))
 
     def test_imap_random(self):
-        it = self.pool.imap(sqr_random_sleep, range(10))
-        self.assertEqual(list(it), list(map(squared, range(10))))
+        it = self.pool.imap(sqr_random_sleep, range(SMALL_RANGE))
+        self.assertEqual(list(it), list(map(squared, range(SMALL_RANGE))))
 
     def test_imap_unordered(self):
-        it = self.pool.imap_unordered(sqr, range(1000))
-        self.assertEqual(sorted(it), list(map(squared, range(1000))))
+        it = self.pool.imap_unordered(sqr, range(LARGE_RANGE))
+        self.assertEqual(sorted(it), list(map(squared, range(LARGE_RANGE))))
 
-        it = self.pool.imap_unordered(sqr, range(1000))
-        self.assertEqual(sorted(it), list(map(squared, range(1000))))
+        it = self.pool.imap_unordered(sqr, range(LARGE_RANGE))
+        self.assertEqual(sorted(it), list(map(squared, range(LARGE_RANGE))))
 
     def test_imap_unordered_random(self):
-        it = self.pool.imap_unordered(sqr_random_sleep, range(10))
-        self.assertEqual(sorted(it), list(map(squared, range(10))))
+        it = self.pool.imap_unordered(sqr_random_sleep, range(SMALL_RANGE))
+        self.assertEqual(sorted(it), list(map(squared, range(SMALL_RANGE))))
 
     def test_empty(self):
         it = self.pool.imap_unordered(sqr, [])


### PR DESCRIPTION
This should result in the loop getting serviced more often when there are many callbacks to run. This is hooked up to `getswitchinterval` to allow control.

We check the interval every 50 callbacks. That's hardcoded, which I don't like, but the 1000 callback number was hardcoded before, so it's not really much of a change. A future extension would be to calculate the check number dynamically based on dividing the switch interval.

I don't have a specific test case for this change because I'm a little fried (burnt out), but all the other tests pass. I did manually verify that the example in #1071 matches expectations---that could probably be turned into a test case with some work.

Fixes #1072
Fixes #1071
Fixes #1068