### PR TITLE
Centralize configuration in a ``gevent.config`` object.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,18 @@
   :mod:`time`, much like :mod:`gevent.socket` can be imported instead
   of :mod:`socket`.
 
+- Centralize all gevent configuration in an object at
+  ``gevent.config``, allowing for gevent to be configured through code
+  and not *necessarily* environment variables, and also provide a
+  centralized place for documentation. See :issue:`1090`.
+
+  - The new ``GEVENT_CORE_CFFI_ONLY`` environment variable has been
+    replaced with the pre-existing ``GEVENT_LOOP`` environment
+    variable. That variable may take the values ``libev-cext``,
+    ``libev-cffi``, or ``libuv-cffi``, (or be a list in preference
+    order, or be a dotted name; it may also be assigned to an
+    object in Python code at ``gevent.config.loop``).
+
 1.3a1 (2018-01-27)
 ==================
 

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,6 @@ test_prelim:
 	make bench
 
 # Folding from https://github.com/travis-ci/travis-rubies/blob/9f7962a881c55d32da7c76baefc58b89e3941d91/build.sh#L38-L44
-# 	echo -e "travis_fold:start:${GEVENT_CORE_CFFI_ONLY}\033[33;1m${GEVENT_CORE_CFFI_ONLY}\033[0m"
-# Make calls /bin/echo, which doesn't support the -e option, which is part of the bash builtin.
-# we need a python script to do this, or possible the GNU make shell function
 
 basictest: test_prelim
 	${PYTHON} scripts/travis.py fold_start basictest "Running basic tests"
@@ -83,7 +80,7 @@ threadfiletest:
 
 allbackendtest:
 	${PYTHON} scripts/travis.py fold_start default "Testing default backend"
-	GEVENT_CORE_CFFI_ONLY= GEVENTTEST_COVERAGE=1 make alltest
+	GEVENTTEST_COVERAGE=1 make alltest
 	${PYTHON} scripts/travis.py fold_end default
 	GEVENTTEST_COVERAGE=1 make cffibackendtest
 # because we set parallel=true, each run produces new and different coverage files; they all need
@@ -93,10 +90,10 @@ allbackendtest:
 
 cffibackendtest:
 	${PYTHON} scripts/travis.py fold_start libuv "Testing libuv backend"
-	GEVENT_CORE_CFFI_ONLY=libuv GEVENTTEST_COVERAGE=1 make alltest
+	GEVENT_LOOP=libuv GEVENTTEST_COVERAGE=1 make alltest
 	${PYTHON} scripts/travis.py fold_end libuv
 	${PYTHON} scripts/travis.py fold_start libev "Testing libev CFFI backend"
-	GEVENT_CORE_CFFI_ONLY=libev make alltest
+	GEVENT_LOOP=libev-cffi make alltest
 	${PYTHON} scripts/travis.py fold_end libev
 
 leaktest: test_prelim
@@ -203,4 +200,4 @@ test-py27-noembed: $(PY27)
 	cd deps/libev && ./configure --disable-dependency-tracking && make
 	cd deps/c-ares && ./configure --disable-dependency-tracking && make
 	cd deps/libuv && ./autogen.sh && ./configure --disable-static && make
-	CPPFLAGS="-Ideps/libev -Ideps/c-ares -Ideps/libuv/include" LDFLAGS="-Ldeps/libev/.libs -Ldeps/c-ares/.libs -Ldeps/libuv/.libs" LD_LIBRARY_PATH="$(PWD)/deps/libev/.libs:$(PWD)/deps/c-ares/.libs:$(PWD)/deps/libuv/.libs" EMBED=0 GEVENT_CORE_CEXT_ONLY=1 PYTHON=python2.7.14 PATH=$(BUILD_RUNTIMES)/versions/python2.7.14/bin:$(PATH) make develop basictest
+	CPPFLAGS="-Ideps/libev -Ideps/c-ares -Ideps/libuv/include" LDFLAGS="-Ldeps/libev/.libs -Ldeps/c-ares/.libs -Ldeps/libuv/.libs" LD_LIBRARY_PATH="$(PWD)/deps/libev/.libs:$(PWD)/deps/c-ares/.libs:$(PWD)/deps/libuv/.libs" EMBED=0 GEVENT_LOOP=libev-cext PYTHON=python2.7.14 PATH=$(BUILD_RUNTIMES)/versions/python2.7.14/bin:$(PATH) make develop basictest

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,8 @@ $(PYPY3):
 
 
 develop:
-	${PYTHON} scripts/travis.py fold_start install "Installing gevent"
-	echo python is at `which $(PYTHON)`
+	@${PYTHON} scripts/travis.py fold_start install "Installing gevent"
+	@echo python is at `which $(PYTHON)`
 # First install a newer pip so that it can use the wheel cache
 # (only needed until travis upgrades pip to 7.x; note that the 3.5
 # environment uses pip 7.1 by default)
@@ -173,7 +173,7 @@ develop:
 # disables the cache.
 # We need wheel>=0.26 on Python 3.5. See previous revisions.
 	GEVENTSETUP_EV_VERIFY=3 ${PYTHON} -m pip install -U -r dev-requirements.txt
-	${PYTHON} scripts/travis.py fold_end install
+	@${PYTHON} scripts/travis.py fold_end install
 
 test-py27: $(PY27)
 	PYTHON=python2.7.14 PATH=$(BUILD_RUNTIMES)/versions/python2.7.14/bin:$(PATH) make develop lint leaktest allbackendtest
@@ -197,13 +197,13 @@ test-pypy3: $(PYPY3)
 	PYTHON=$(PYPY3) PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_5101/bin:$(PATH) make develop basictest
 
 test-py27-noembed: $(PY27)
-	@${PYTHON} scripts/travis.py fold_start conf_libev "Configuring libev"
+	@python2.7.14 scripts/travis.py fold_start conf_libev "Configuring libev"
 	cd deps/libev && ./configure --disable-dependency-tracking && make
-	@${PYTHON} scripts/travis.py fold_end conf_libev
-	@${PYTHON} scripts/travis.py fold_start conf_cares "Configuring cares"
+	@python2.7.14 scripts/travis.py fold_end conf_libev
+	@python2.7.14 scripts/travis.py fold_start conf_cares "Configuring cares"
 	cd deps/c-ares && ./configure --disable-dependency-tracking && make
-	@${PYTHON} scripts/travis.py fold_end conf_cares
-	@${PYTHON} scripts/travis.py fold_start conf_libuv "Configuring libuv"
+	@python2.7.14 scripts/travis.py fold_end conf_cares
+	@python2.7.14 scripts/travis.py fold_start conf_libuv "Configuring libuv"
 	cd deps/libuv && ./autogen.sh && ./configure --disable-static && make
-	@${PYTHON} scripts/travis.py fold_end conf_libuv
+	@python2.7.14 scripts/travis.py fold_end conf_libuv
 	CPPFLAGS="-Ideps/libev -Ideps/c-ares -Ideps/libuv/include" LDFLAGS="-Ldeps/libev/.libs -Ldeps/c-ares/.libs -Ldeps/libuv/.libs" LD_LIBRARY_PATH="$(PWD)/deps/libev/.libs:$(PWD)/deps/c-ares/.libs:$(PWD)/deps/libuv/.libs" EMBED=0 GEVENT_LOOP=libev-cext PYTHON=python2.7.14 PATH=$(BUILD_RUNTIMES)/versions/python2.7.14/bin:$(PATH) make develop basictest

--- a/Makefile
+++ b/Makefile
@@ -45,43 +45,43 @@ prospector:
 lint: prospector
 
 test_prelim:
-	which ${PYTHON}
-	${PYTHON} --version
-	${PYTHON} -c 'import greenlet; print(greenlet, greenlet.__version__)'
-	${PYTHON} -c 'import gevent.core; print(gevent.core.loop)'
-	${PYTHON} -c 'import gevent.ares; print(gevent.ares)'
-	make bench
+	@which ${PYTHON}
+	@${PYTHON} --version
+	@${PYTHON} -c 'import greenlet; print(greenlet, greenlet.__version__)'
+	@${PYTHON} -c 'import gevent.core; print(gevent.core.loop)'
+	@${PYTHON} -c 'import gevent.ares; print(gevent.ares)'
+	@make bench
 
 # Folding from https://github.com/travis-ci/travis-rubies/blob/9f7962a881c55d32da7c76baefc58b89e3941d91/build.sh#L38-L44
 
 basictest: test_prelim
-	${PYTHON} scripts/travis.py fold_start basictest "Running basic tests"
+	@${PYTHON} scripts/travis.py fold_start basictest "Running basic tests"
 	cd src/greentest && GEVENT_RESOLVER=thread ${PYTHON} testrunner.py --config known_failures.py --quiet
-	${PYTHON} scripts/travis.py fold_end basictest
+	@${PYTHON} scripts/travis.py fold_end basictest
 
 alltest: basictest
-	${PYTHON} scripts/travis.py fold_start ares "Running c-ares tests"
+	@${PYTHON} scripts/travis.py fold_start ares "Running c-ares tests"
 	cd src/greentest && GEVENT_RESOLVER=ares GEVENTARES_SERVERS=8.8.8.8 ${PYTHON} testrunner.py --config known_failures.py --ignore tests_that_dont_use_resolver.txt --quiet
-	${PYTHON} scripts/travis.py fold_end ares
-	${PYTHON} scripts/travis.py fold_start dnspython "Running dnspython tests"
+	@${PYTHON} scripts/travis.py fold_end ares
+	@${PYTHON} scripts/travis.py fold_start dnspython "Running dnspython tests"
 	cd src/greentest && GEVENT_RESOLVER=dnspython ${PYTHON} testrunner.py --config known_failures.py --ignore tests_that_dont_use_resolver.txt --quiet
-	${PYTHON} scripts/travis.py fold_end dnspython
+	@${PYTHON} scripts/travis.py fold_end dnspython
 # In the past, we included all test files that had a reference to 'subprocess'' somewhere in their
 # text. The monkey-patched stdlib tests were specifically included here.
 # However, we now always also test on AppVeyor (Windows) which only has GEVENT_FILE=thread,
 # so we can save a lot of CI time by reducing the set and excluding the stdlib tests without
 # losing any coverage. See the `threadfiletest` for what command used to run.
-	${PYTHON} scripts/travis.py fold_start thread "Running GEVENT_FILE=thread tests"
+	@${PYTHON} scripts/travis.py fold_start thread "Running GEVENT_FILE=thread tests"
 	cd src/greentest && GEVENT_FILE=thread ${PYTHON} testrunner.py --config known_failures.py test__*subprocess*.py --quiet
-	${PYTHON} scripts/travis.py fold_end thread
+	@${PYTHON} scripts/travis.py fold_end thread
 
 threadfiletest:
 	cd src/greentest && GEVENT_FILE=thread ${PYTHON} testrunner.py --config known_failures.py `grep -l subprocess test_*.py` --quiet
 
 allbackendtest:
-	${PYTHON} scripts/travis.py fold_start default "Testing default backend"
+	@${PYTHON} scripts/travis.py fold_start default "Testing default backend"
 	GEVENTTEST_COVERAGE=1 make alltest
-	${PYTHON} scripts/travis.py fold_end default
+	@${PYTHON} scripts/travis.py fold_end default
 	GEVENTTEST_COVERAGE=1 make cffibackendtest
 # because we set parallel=true, each run produces new and different coverage files; they all need
 # to be combined
@@ -89,17 +89,17 @@ allbackendtest:
 
 
 cffibackendtest:
-	${PYTHON} scripts/travis.py fold_start libuv "Testing libuv backend"
+	@${PYTHON} scripts/travis.py fold_start libuv "Testing libuv backend"
 	GEVENT_LOOP=libuv GEVENTTEST_COVERAGE=1 make alltest
-	${PYTHON} scripts/travis.py fold_end libuv
-	${PYTHON} scripts/travis.py fold_start libev "Testing libev CFFI backend"
+	@${PYTHON} scripts/travis.py fold_end libuv
+	@${PYTHON} scripts/travis.py fold_start libev "Testing libev CFFI backend"
 	GEVENT_LOOP=libev-cffi make alltest
-	${PYTHON} scripts/travis.py fold_end libev
+	@${PYTHON} scripts/travis.py fold_end libev
 
 leaktest: test_prelim
-	${PYTHON} scripts/travis.py fold_start leaktest "Running leak tests"
+	@${PYTHON} scripts/travis.py fold_start leaktest "Running leak tests"
 	cd src/greentest && GEVENT_RESOLVER=thread GEVENTTEST_LEAKCHECK=1 ${PYTHON} testrunner.py --config known_failures.py --quiet --ignore tests_that_dont_do_leakchecks.txt
-	${PYTHON} scripts/travis.py fold_end leaktest
+	@${PYTHON} scripts/travis.py fold_end leaktest
 
 bench:
 	${PYTHON} src/greentest/bench_sendall.py
@@ -197,7 +197,13 @@ test-pypy3: $(PYPY3)
 	PYTHON=$(PYPY3) PATH=$(BUILD_RUNTIMES)/versions/pypy3.5_5101/bin:$(PATH) make develop basictest
 
 test-py27-noembed: $(PY27)
+	@${PYTHON} scripts/travis.py fold_start conf_libev "Configuring libev"
 	cd deps/libev && ./configure --disable-dependency-tracking && make
+	@${PYTHON} scripts/travis.py fold_end conf_libev
+	@${PYTHON} scripts/travis.py fold_start conf_cares "Configuring cares"
 	cd deps/c-ares && ./configure --disable-dependency-tracking && make
+	@${PYTHON} scripts/travis.py fold_end conf_cares
+	@${PYTHON} scripts/travis.py fold_start conf_libuv "Configuring libuv"
 	cd deps/libuv && ./autogen.sh && ./configure --disable-static && make
+	@${PYTHON} scripts/travis.py fold_end conf_libuv
 	CPPFLAGS="-Ideps/libev -Ideps/c-ares -Ideps/libuv/include" LDFLAGS="-Ldeps/libev/.libs -Ldeps/c-ares/.libs -Ldeps/libuv/.libs" LD_LIBRARY_PATH="$(PWD)/deps/libev/.libs:$(PWD)/deps/c-ares/.libs:$(PWD)/deps/libuv/.libs" EMBED=0 GEVENT_LOOP=libev-cext PYTHON=python2.7.14 PATH=$(BUILD_RUNTIMES)/versions/python2.7.14/bin:$(PATH) make develop basictest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
       PYTHON_VERSION: "3.6.x" # currently 3.6.0
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
-      GEVENT_CORE_CFFI_ONLY: libuv
+      GEVENT_LOOP: libuv
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x" # currently 2.7.13

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,7 +87,7 @@ release = version
 exclude_trees = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True

--- a/doc/gevent.rst
+++ b/doc/gevent.rst
@@ -191,3 +191,9 @@ Timeouts
     :special-members: __enter__, __exit__
 
 .. autofunction:: with_timeout
+
+
+Configuration
+=============
+
+.. autoclass:: gevent._config.Config

--- a/src/gevent/__init__.py
+++ b/src/gevent/__init__.py
@@ -4,6 +4,9 @@ gevent is a coroutine-based Python networking library that uses greenlet
 to provide a high-level synchronous API on top of libev event loop.
 
 See http://www.gevent.org/ for the documentation.
+
+.. versionchanged:: 1.3a2
+   Add the `config` object.
 """
 
 from __future__ import absolute_import
@@ -43,6 +46,8 @@ __all__ = [
     'reinit',
     'getswitchinterval',
     'setswitchinterval',
+    # Added in 1.3a2
+    'config',
 ]
 
 
@@ -72,11 +77,14 @@ except AttributeError:
             global _switchinterval
             _switchinterval = interval
 
+from gevent._config import config
 from gevent.hub import get_hub, iwait, wait
 from gevent.greenlet import Greenlet, joinall, killall
 joinall = joinall # export for pylint
 spawn = Greenlet.spawn
 spawn_later = Greenlet.spawn_later
+#: The singleton configuration object for gevent.
+config = config
 
 from gevent.timeout import Timeout, with_timeout
 from gevent.hub import getcurrent, GreenletExit, spawn_raw, sleep, idle, kill, reinit

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -247,7 +247,7 @@ class ImportableSetting(object):
                 raise ImportError('Cannot import %r from %r' % (item, module))
             return x
         finally:
-            if '/' in path:
+            if package_path:
                 try:
                     sys.path.remove(package_path)
                 except ValueError:

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -1,0 +1,463 @@
+# Copyright (c) 2018 gevent. See LICENSE for details.
+"""
+gevent tunables.
+
+This should be used as ``from gevent import config``. That variable
+is an object of :class:`Config`.
+
+.. versionadded:: 1.3a2
+"""
+
+from __future__ import print_function, absolute_import, division
+
+import importlib
+import os
+import sys
+import textwrap
+
+from gevent._compat import string_types
+
+__all__ = [
+    'config',
+]
+
+ALL_SETTINGS = []
+
+class SettingType(type):
+    # pylint:disable=bad-mcs-classmethod-argument
+
+    def __new__(cls, name, bases, cls_dict):
+        if name == 'Setting':
+            return type.__new__(cls, name, bases, cls_dict)
+
+        cls_dict["order"] = len(ALL_SETTINGS)
+        if 'name' not in cls_dict:
+            cls_dict['name'] = name.lower()
+
+        if 'environment_key' not in cls_dict:
+            cls_dict['environment_key'] = 'GEVENT_' + cls_dict['name'].upper()
+
+
+        new_class = type.__new__(cls, name, bases, cls_dict)
+        new_class.fmt_desc(cls_dict.get("desc", ""))
+        new_class.__doc__ = new_class.desc
+        ALL_SETTINGS.append(new_class)
+
+        if new_class.document:
+            setting_name = cls_dict['name']
+
+            def getter(self):
+                return self.settings[setting_name].get()
+
+            def setter(self, value):
+                self.settings[setting_name].set(value)
+
+            prop = property(getter, setter, doc=new_class.__doc__)
+
+            setattr(Config, cls_dict['name'], prop)
+        return new_class
+
+    def fmt_desc(cls, desc):
+        desc = textwrap.dedent(desc).strip()
+        if hasattr(cls, 'shortname_map'):
+            desc += (
+                "\n\nThis is an importable value. It can be "
+                "given as a string naming an importable object, "
+                "or a list of strings in preference order and the first "
+                "successfully importable object will be used. (Separate values "
+                "in the environment variable with commas.) "
+                "It can also be given as the callable object itself (in code). "
+            )
+            if cls.shortname_map:
+                desc += "Shorthand names for default objects are %r" % (list(cls.shortname_map),)
+        if getattr(cls.validate, '__doc__'):
+            desc += '\n\n' + textwrap.dedent(cls.validate.__doc__).strip()
+        if isinstance(cls.default, str) and hasattr(cls, 'shortname_map'):
+            default = "`%s`" % (cls.default,)
+        else:
+            default = "`%r`" % (cls.default,)
+        desc += "\n\nThe default value is %s" % (default,)
+        desc += ("\n\nThe environment variable ``%s`` "
+                 "can be used to control this." % (cls.environment_key,))
+        setattr(cls, "desc", desc)
+        return desc
+
+def validate_invalid(value):
+    raise ValueError("Not a valid value: %r" % (value,))
+
+def validate_bool(value):
+    """
+    This is a boolean value.
+
+    In the environment variable, it may be given as ``1``, ``true``,
+    ``on`` or ``yes`` for `True`, or ``0``, ``false``, ``off``, or
+    ``no`` for `False`.
+    """
+    if isinstance(value, string_types):
+        value = value.lower().strip()
+        if value in ('1', 'true', 'on', 'yes'):
+            value = True
+        elif value in ('0', 'false', 'off', 'no') or not value:
+            value = False
+        else:
+            raise ValueError("Invalid boolean string: %r" % (value,))
+    return bool(value)
+
+def validate_anything(value):
+    return value
+
+class Setting(object):
+    name = None
+    value = None
+    validate = staticmethod(validate_invalid)
+    default = None
+    environment_key = None
+    document = True
+
+    desc = """\
+
+    A long ReST description.
+
+    The first line should be a single sentence.
+
+    """
+
+    def _convert(self, value):
+        if isinstance(value, string_types):
+            return value.split(',')
+        return value
+
+    def _default(self):
+        result = os.environ.get(self.environment_key, self.default)
+        result = self._convert(result)
+        return result
+
+    def get(self):
+        # If we've been specifically set, return it
+        if 'value' in self.__dict__:
+            return self.value
+        # Otherwise, read from the environment and reify
+        # so we return consistent results.
+        self.value = self.validate(self._default())
+        return self.value
+
+    def set(self, val):
+        self.value = self.validate(self._convert(val))
+
+
+Setting = SettingType('Setting', (Setting,), dict(Setting.__dict__))
+
+def make_settings():
+    """
+    Return fresh instances of all classes defined in `ALL_SETTINGS`.
+    """
+    settings = {}
+    for setting_kind in ALL_SETTINGS:
+        setting = setting_kind()
+        assert setting.name not in settings
+        settings[setting.name] = setting
+    return settings
+
+
+class Config(object):
+    """
+    Global configuration for gevent.
+
+    There is one instance of this object at ``gevent.config``. If you
+    are going to make changes in code, instead of using the documented
+    environment variables, you need to make the changes before using
+    any parts of gevent that might need those settings. For example::
+
+        >>> from gevent import config
+        >>> config.fileobject = 'thread'
+
+        >>> from gevent import fileobject
+        >>> fileobject.FileObject.__name__
+        'FileObjectThread'
+
+    .. versionadded:: 1.3a2
+
+    """
+
+    def __init__(self):
+        self.settings = make_settings()
+
+    def __getattr__(self, name):
+        if name not in self.settings:
+            raise AttributeError("No configuration setting for: %r" % name)
+        return self.settings[name].get()
+
+    def __setattr__(self, name, value):
+        if name != "settings" and name in self.settings:
+            self.set(name, value)
+        else:
+            super(Config, self).__setattr__(name, value)
+
+    def set(self, name, value):
+        if name not in self.settings:
+            raise AttributeError("No configuration setting for: %r" % name)
+        self.settings[name].set(value)
+
+    def __dir__(self):
+        return list(self.settings)
+
+
+class ImportableSetting(object):
+
+    def _import(self, path, _NONE=object):
+        # pylint:disable=too-many-branches
+        if isinstance(path, list):
+            if not path:
+                raise ImportError('Cannot import from empty list: %r' % (path, ))
+
+            for item in path[:-1]:
+                try:
+                    return self._import(item)
+                except ImportError:
+                    pass
+
+            return self._import(path[-1])
+
+        if not isinstance(path, string_types):
+            return path
+
+        if '.' not in path:
+            raise ImportError("Cannot import %r. "
+                              "Required format: [path/][package.]module.class. "
+                              "Or choice from %r"
+                              % (path, list(self.shortname_map)))
+
+        if '/' in path:
+            # This is dangerous, subject to race conditions, and
+            # may not work properly for things like namespace packages
+            import warnings
+            warnings.warn("Absolute paths are deprecated and will be removed in 1.4."
+                          "Please put the package on sys.path first",
+                          DeprecationWarning)
+            package_path, path = path.rsplit('/', 1)
+            sys.path = [package_path] + sys.path
+        else:
+            package_path = None
+
+        try:
+            module, item = path.rsplit('.', 1)
+            module = importlib.import_module(module)
+            x = getattr(module, item, _NONE)
+            if x is _NONE:
+                raise ImportError('Cannot import %r from %r' % (item, module))
+            return x
+        finally:
+            if '/' in path:
+                try:
+                    sys.path.remove(package_path)
+                except ValueError:
+                    pass
+
+    shortname_map = {}
+
+    def validate(self, value):
+        if isinstance(value, type):
+            return value
+        return self._import([self.shortname_map.get(x, x) for x in value])
+
+
+class Resolver(ImportableSetting, Setting):
+
+    desc = """\
+    The callable that will be used to create
+    :attr:`gevent.hub.Hub.resolver`.
+
+    See :doc:`dns` for more information.
+    """
+
+    default = [
+        'thread',
+        'dnspython',
+        'ares',
+        'block',
+    ]
+
+    shortname_map = {
+        'ares': 'gevent.resolver.ares.Resolver',
+        'thread': 'gevent.resolver.thread.Resolver',
+        'block': 'gevent.resolver.blocking.Resolver',
+        'dnspython': 'gevent.resolver.dnspython.Resolver',
+    }
+
+
+
+class Threadpool(ImportableSetting, Setting):
+
+    desc = """\
+    The kind of threadpool we use.
+    """
+
+    default = 'gevent.threadpool.ThreadPool'
+
+
+class Loop(ImportableSetting, Setting):
+
+    desc = """\
+    The kind of the loop we use.
+
+    """
+
+    default = [
+        'libev-cext',
+        'libev-cffi',
+        'libuv-cffi',
+    ]
+
+    shortname_map = {
+        'libev-cext': 'gevent.libev.corecext.loop',
+        'libev-cffi': 'gevent.libev.corecffi.loop',
+        'libuv-cffi': 'gevent.libuv.loop.loop',
+    }
+
+    shortname_map['libuv'] = shortname_map['libuv-cffi']
+
+
+class FormatContext(ImportableSetting, Setting):
+    name = 'format_context'
+
+    # using pprint.pformat can override custom __repr__ methods on dict/list
+    # subclasses, which can be a security concern
+    default = 'pprint.saferepr'
+
+
+class LibevBackend(Setting):
+    name = 'libev_backend'
+    environment_key = 'GEVENT_BACKEND'
+
+    desc = """\
+    The backend for libev, such as 'select'
+    """
+
+    default = None
+
+    validate = staticmethod(validate_anything)
+
+
+class FileObject(ImportableSetting, Setting):
+    desc = """\
+    The kind of ``FileObject`` we will use.
+
+    See :mod:`gevent.fileobject` for a detailed description.
+
+    """
+    environment_key = 'GEVENT_FILE'
+
+    default = [
+        'posix',
+        'thread',
+    ]
+
+    shortname_map = {
+        'thread': 'gevent._fileobjectcommon.FileObjectThread',
+        'posix': 'gevent._fileobjectposix.FileObjectPosix',
+        'block': 'gevent._fileobjectcommon.FileObjectBlock'
+    }
+
+
+class WatchChildren(Setting):
+    desc = """\
+    Should we *not* watch children with the event loop watchers?
+
+    This is an advanced setting.
+
+    See :mod:`gevent.os` for a detailed description.
+    """
+    name = 'disable_watch_children'
+    environment_key = 'GEVENT_NOWAITPID'
+    default = False
+
+    validate = staticmethod(validate_bool)
+
+
+class TraceMalloc(Setting):
+    name = 'trace_malloc'
+    environment_key = 'PYTHONTRACEMALLOC'
+    default = False
+    validate = staticmethod(validate_bool)
+
+    desc = """\
+    Should FFI objects track their allocation?
+
+    This is only useful for low-level debugging.
+
+    On Python 3, this environment variable is built in to the
+    interpreter, and it may also be set with the ``-X
+    tracemalloc`` command line argument.
+
+    On Python 2, gevent interprets this argument and adds extra
+    tracking information for FFI objects.
+    """
+
+# The ares settings are all interpreted by
+# gevent/resolver/ares.pyx, so we don't do
+# any validation here.
+
+class AresSettingMixin(object):
+
+    document = False
+
+    @property
+    def kwarg_name(self):
+        return self.name[5:]
+
+    validate = staticmethod(validate_anything)
+
+    _convert = staticmethod(validate_anything)
+
+class AresFlags(AresSettingMixin, Setting):
+    name = 'ares_flags'
+    default = None
+    environment_key = 'GEVENTARES_FLAGS'
+
+class AresTimeout(AresSettingMixin, Setting):
+    name = 'ares_timeout'
+    default = None
+    environment_key = 'GEVENTARES_TIMEOUT'
+
+class AresTries(AresSettingMixin, Setting):
+    name = 'ares_tries'
+    default = None
+    environment_key = 'GEVENTARES_TRIES'
+
+class AresNdots(AresSettingMixin, Setting):
+    name = 'ares_ndots'
+    default = None
+    environment_key = 'GEVENTARES_NDOTS'
+
+class AresUDPPort(AresSettingMixin, Setting):
+    name = 'ares_udp_port'
+    default = None
+    environment_key = 'GEVENTARES_UDP_PORT'
+
+class AresTCPPort(AresSettingMixin, Setting):
+    name = 'ares_tcp_port'
+    default = None
+    environment_key = 'GEVENTARES_TCP_PORT'
+
+class AresServers(AresSettingMixin, Setting):
+    document = True
+    name = 'ares_servers'
+    default = None
+    environment_key = 'GEVENTARES_SERVERS'
+
+
+config = Config()
+
+# Go ahead and attempt to import the loop when this class is
+# instantiated. The hub won't work if the loop can't be found. This
+# can solve problems with the class being imported from multiple
+# threads at once, leading to one of the imports failing.
+# factories are themselves handled lazily. See #687.
+
+# Don't cache it though, in case the user re-configures through the
+# API.
+
+try:
+    Loop().get()
+except ImportError: # pragma: no cover
+    pass

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -49,7 +49,10 @@ class SettingType(type):
             def getter(self):
                 return self.settings[setting_name].get()
 
-            def setter(self, value):
+            def setter(self, value): # pragma: no cover
+                # The setter should never be hit, Config has a
+                # __setattr__ that would override. But for the sake
+                # of consistency we provide one.
                 self.settings[setting_name].set(value)
 
             prop = property(getter, setter, doc=new_class.__doc__)
@@ -250,7 +253,7 @@ class ImportableSetting(object):
             if package_path:
                 try:
                     sys.path.remove(package_path)
-                except ValueError:
+                except ValueError: # pragma: no cover
                     pass
 
     shortname_map = {}

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -10,14 +10,17 @@ import signal as signalmodule
 import functools
 import warnings
 
+from gevent._config import config
+
 try:
     from tracemalloc import get_object_traceback
 
     def tracemalloc(init):
-        # PYTHONTRACEMALLOC env var controls this.
+        # PYTHONTRACEMALLOC env var controls this on Python 3.
         return init
 except ImportError: # Python < 3.4
-    if os.getenv('PYTHONTRACEMALLOC'):
+
+    if config.trace_malloc:
         # Use the same env var to turn this on for Python 2
         import traceback
 

--- a/src/gevent/_fileobjectcommon.py
+++ b/src/gevent/_fileobjectcommon.py
@@ -1,10 +1,20 @@
+from __future__ import absolute_import, print_function, division
 
 try:
     from errno import EBADF
 except ImportError:
     EBADF = 9
 
+import os
 from io import TextIOWrapper
+import functools
+import sys
+
+
+from gevent.hub import get_hub
+from gevent._compat import integer_types
+from gevent._compat import reraise
+from gevent.lock import Semaphore, DummySemaphore
 
 class cancel_wait_ex(IOError):
 
@@ -136,3 +146,130 @@ class FileObjectBase(object):
 
     def __exit__(self, *args):
         self.close()
+
+class FileObjectBlock(FileObjectBase):
+
+    def __init__(self, fobj, *args, **kwargs):
+        closefd = kwargs.pop('close', True)
+        if kwargs:
+            raise TypeError('Unexpected arguments: %r' % kwargs.keys())
+        if isinstance(fobj, integer_types):
+            if not closefd:
+                # we cannot do this, since fdopen object will close the descriptor
+                raise TypeError('FileObjectBlock does not support close=False on an fd.')
+            fobj = os.fdopen(fobj, *args)
+        super(FileObjectBlock, self).__init__(fobj, closefd)
+
+    def _do_close(self, fobj, closefd):
+        fobj.close()
+
+class FileObjectThread(FileObjectBase):
+    """
+    A file-like object wrapping another file-like object, performing all blocking
+    operations on that object in a background thread.
+
+    .. caution::
+        Attempting to change the threadpool or lock of an existing FileObjectThread
+        has undefined consequences.
+
+    .. versionchanged:: 1.1b1
+       The file object is closed using the threadpool. Note that whether or
+       not this action is synchronous or asynchronous is not documented.
+
+    """
+
+    def __init__(self, fobj, mode=None, bufsize=-1, close=True, threadpool=None, lock=True):
+        """
+        :param fobj: The underlying file-like object to wrap, or an integer fileno
+           that will be pass to :func:`os.fdopen` along with *mode* and *bufsize*.
+        :keyword bool lock: If True (the default) then all operations will
+           be performed one-by-one. Note that this does not guarantee that, if using
+           this file object from multiple threads/greenlets, operations will be performed
+           in any particular order, only that no two operations will be attempted at the
+           same time. You can also pass your own :class:`gevent.lock.Semaphore` to synchronize
+           file operations with an external resource.
+        :keyword bool close: If True (the default) then when this object is closed,
+           the underlying object is closed as well.
+        """
+        closefd = close
+        self.threadpool = threadpool or get_hub().threadpool
+        self.lock = lock
+        if self.lock is True:
+            self.lock = Semaphore()
+        elif not self.lock:
+            self.lock = DummySemaphore()
+        if not hasattr(self.lock, '__enter__'):
+            raise TypeError('Expected a Semaphore or boolean, got %r' % type(self.lock))
+        if isinstance(fobj, integer_types):
+            if not closefd:
+                # we cannot do this, since fdopen object will close the descriptor
+                raise TypeError('FileObjectThread does not support close=False on an fd.')
+            if mode is None:
+                assert bufsize == -1, "If you use the default mode, you can't choose a bufsize"
+                fobj = os.fdopen(fobj)
+            else:
+                fobj = os.fdopen(fobj, mode, bufsize)
+
+        self.__io_holder = [fobj] # signal for _wrap_method
+        super(FileObjectThread, self).__init__(fobj, closefd)
+
+    def _do_close(self, fobj, closefd):
+        self.__io_holder[0] = None # for _wrap_method
+        try:
+            with self.lock:
+                self.threadpool.apply(fobj.flush)
+        finally:
+            if closefd:
+                # Note that we're not taking the lock; older code
+                # did fobj.close() without going through the threadpool at all,
+                # so acquiring the lock could potentially introduce deadlocks
+                # that weren't present before. Avoiding the lock doesn't make
+                # the existing race condition any worse.
+                # We wrap the close in an exception handler and re-raise directly
+                # to avoid the (common, expected) IOError from being logged by the pool
+                def close():
+                    try:
+                        fobj.close()
+                    except: # pylint:disable=bare-except
+                        return sys.exc_info()
+                exc_info = self.threadpool.apply(close)
+                if exc_info:
+                    reraise(*exc_info)
+
+    def _do_delegate_methods(self):
+        super(FileObjectThread, self)._do_delegate_methods()
+        if not hasattr(self, 'read1') and 'r' in getattr(self._io, 'mode', ''):
+            self.read1 = self.read
+        self.__io_holder[0] = self._io
+
+    def _extra_repr(self):
+        return ' threadpool=%r' % (self.threadpool,)
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        line = self.readline()
+        if line:
+            return line
+        raise StopIteration
+    __next__ = next
+
+    def _wrap_method(self, method):
+        # NOTE: We are careful to avoid introducing a refcycle
+        # within self. Our wrapper cannot refer to self.
+        io_holder = self.__io_holder
+        lock = self.lock
+        threadpool = self.threadpool
+
+        @functools.wraps(method)
+        def thread_method(*args, **kwargs):
+            if io_holder[0] is None:
+                # This is different than FileObjectPosix, etc,
+                # because we want to save the expensive trip through
+                # the threadpool.
+                raise FileObjectClosed()
+            with lock:
+                return threadpool.apply(method, args, kwargs)
+
+        return thread_method

--- a/src/gevent/core.py
+++ b/src/gevent/core.py
@@ -1,28 +1,19 @@
 # Copyright (c) 2009-2015 Denis Bilenko and gevent contributors. See LICENSE for details.
+"""
+Deprecated; this does not reflect all the possible options
+and its interface varies.
+
+.. versionchanged:: 1.3a2
+    Deprecated.
+"""
 from __future__ import absolute_import
 
-import os
+import sys
 
+from gevent._config import config
 from gevent._util import copy_globals
 
-try:
-    if os.environ.get('GEVENT_CORE_CFFI_ONLY'):
-        raise ImportError("Not attempting corecext")
-
-    from gevent.libev import corecext as _core
-except ImportError:
-    if os.environ.get('GEVENT_CORE_CEXT_ONLY'):
-        raise
-
-    # CFFI/PyPy
-    lib = os.environ.get('GEVENT_CORE_CFFI_ONLY')
-    if lib == 'libuv':
-        from gevent.libuv import loop as _core
-    else:
-        try:
-            from gevent.libev import corecffi as _core
-        except ImportError:
-            from gevent.libuv import loop as _core
+_core = sys.modules[config.loop.__module__]
 
 copy_globals(_core, globals())
 

--- a/src/gevent/fileobject.py
+++ b/src/gevent/fileobject.py
@@ -35,31 +35,12 @@ Classes
 """
 from __future__ import absolute_import
 
-import functools
-import sys
-import os
-
-from gevent._fileobjectcommon import FileObjectClosed
-from gevent._fileobjectcommon import FileObjectBase
-from gevent.hub import get_hub
-from gevent._compat import integer_types
-from gevent._compat import reraise
-from gevent.lock import Semaphore, DummySemaphore
-
-
-PYPY = hasattr(sys, 'pypy_version_info')
-
-if hasattr(sys, 'exc_clear'):
-    def _exc_clear():
-        sys.exc_clear()
-else:
-    def _exc_clear():
-        return
-
+from gevent._config import config
 
 __all__ = [
     'FileObjectPosix',
     'FileObjectThread',
+    'FileObjectBlock',
     'FileObject',
 ]
 
@@ -71,149 +52,10 @@ else:
     del fcntl
     from gevent._fileobjectposix import FileObjectPosix
 
-
-class FileObjectThread(FileObjectBase):
-    """
-    A file-like object wrapping another file-like object, performing all blocking
-    operations on that object in a background thread.
-
-    .. caution::
-        Attempting to change the threadpool or lock of an existing FileObjectThread
-        has undefined consequences.
-
-    .. versionchanged:: 1.1b1
-       The file object is closed using the threadpool. Note that whether or
-       not this action is synchronous or asynchronous is not documented.
-
-    """
-
-    def __init__(self, fobj, mode=None, bufsize=-1, close=True, threadpool=None, lock=True):
-        """
-        :param fobj: The underlying file-like object to wrap, or an integer fileno
-           that will be pass to :func:`os.fdopen` along with *mode* and *bufsize*.
-        :keyword bool lock: If True (the default) then all operations will
-           be performed one-by-one. Note that this does not guarantee that, if using
-           this file object from multiple threads/greenlets, operations will be performed
-           in any particular order, only that no two operations will be attempted at the
-           same time. You can also pass your own :class:`gevent.lock.Semaphore` to synchronize
-           file operations with an external resource.
-        :keyword bool close: If True (the default) then when this object is closed,
-           the underlying object is closed as well.
-        """
-        closefd = close
-        self.threadpool = threadpool or get_hub().threadpool
-        self.lock = lock
-        if self.lock is True:
-            self.lock = Semaphore()
-        elif not self.lock:
-            self.lock = DummySemaphore()
-        if not hasattr(self.lock, '__enter__'):
-            raise TypeError('Expected a Semaphore or boolean, got %r' % type(self.lock))
-        if isinstance(fobj, integer_types):
-            if not closefd:
-                # we cannot do this, since fdopen object will close the descriptor
-                raise TypeError('FileObjectThread does not support close=False on an fd.')
-            if mode is None:
-                assert bufsize == -1, "If you use the default mode, you can't choose a bufsize"
-                fobj = os.fdopen(fobj)
-            else:
-                fobj = os.fdopen(fobj, mode, bufsize)
-
-        self.__io_holder = [fobj] # signal for _wrap_method
-        super(FileObjectThread, self).__init__(fobj, closefd)
-
-    def _do_close(self, fobj, closefd):
-        self.__io_holder[0] = None # for _wrap_method
-        try:
-            with self.lock:
-                self.threadpool.apply(fobj.flush)
-        finally:
-            if closefd:
-                # Note that we're not taking the lock; older code
-                # did fobj.close() without going through the threadpool at all,
-                # so acquiring the lock could potentially introduce deadlocks
-                # that weren't present before. Avoiding the lock doesn't make
-                # the existing race condition any worse.
-                # We wrap the close in an exception handler and re-raise directly
-                # to avoid the (common, expected) IOError from being logged by the pool
-                def close():
-                    try:
-                        fobj.close()
-                    except: # pylint:disable=bare-except
-                        return sys.exc_info()
-                exc_info = self.threadpool.apply(close)
-                if exc_info:
-                    reraise(*exc_info)
-
-    def _do_delegate_methods(self):
-        super(FileObjectThread, self)._do_delegate_methods()
-        if not hasattr(self, 'read1') and 'r' in getattr(self._io, 'mode', ''):
-            self.read1 = self.read
-        self.__io_holder[0] = self._io
-
-    def _extra_repr(self):
-        return ' threadpool=%r' % (self.threadpool,)
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        line = self.readline()
-        if line:
-            return line
-        raise StopIteration
-    __next__ = next
-
-    def _wrap_method(self, method):
-        # NOTE: We are careful to avoid introducing a refcycle
-        # within self. Our wrapper cannot refer to self.
-        io_holder = self.__io_holder
-        lock = self.lock
-        threadpool = self.threadpool
-
-        @functools.wraps(method)
-        def thread_method(*args, **kwargs):
-            if io_holder[0] is None:
-                # This is different than FileObjectPosix, etc,
-                # because we want to save the expensive trip through
-                # the threadpool.
-                raise FileObjectClosed()
-            with lock:
-                return threadpool.apply(method, args, kwargs)
-
-        return thread_method
+from gevent._fileobjectcommon import FileObjectThread
+from gevent._fileobjectcommon import FileObjectBlock
 
 
-try:
-    FileObject = FileObjectPosix
-except NameError:
-    FileObject = FileObjectThread
-
-
-class FileObjectBlock(FileObjectBase):
-
-    def __init__(self, fobj, *args, **kwargs):
-        closefd = kwargs.pop('close', True)
-        if kwargs:
-            raise TypeError('Unexpected arguments: %r' % kwargs.keys())
-        if isinstance(fobj, integer_types):
-            if not closefd:
-                # we cannot do this, since fdopen object will close the descriptor
-                raise TypeError('FileObjectBlock does not support close=False on an fd.')
-            fobj = os.fdopen(fobj, *args)
-        super(FileObjectBlock, self).__init__(fobj, closefd)
-
-    def _do_close(self, fobj, closefd):
-        fobj.close()
-
-config = os.environ.get('GEVENT_FILE')
-if config:
-    klass = {'thread': 'gevent.fileobject.FileObjectThread',
-             'posix': 'gevent.fileobject.FileObjectPosix',
-             'block': 'gevent.fileobject.FileObjectBlock'}.get(config, config)
-    if klass.startswith('gevent.fileobject.'):
-        FileObject = globals()[klass.split('.', 2)[-1]]
-    else:
-        from gevent.hub import _import
-        FileObject = _import(klass)
-    del klass
+# None of the possible objects can live in this module because
+# we would get an import cycle and the config couldn't be set from code.
+FileObject = config.fileobject

--- a/src/gevent/os.py
+++ b/src/gevent/os.py
@@ -46,6 +46,7 @@ from __future__ import absolute_import
 import os
 import sys
 from gevent.hub import get_hub, reinit
+from gevent._config import config
 from gevent._compat import PY3
 from gevent._util import copy_globals
 import errno
@@ -418,7 +419,7 @@ if hasattr(os, 'fork'):
             __extensions__.append('forkpty_and_watch')
 
         # Watch children by default
-        if not os.getenv('GEVENT_NOWAITPID'):
+        if not config.disable_watch_children:
             # Broken out into separate functions instead of simple name aliases
             # for documentation purposes.
             def fork(*args, **kwargs):

--- a/src/gevent/resolver/ares.py
+++ b/src/gevent/resolver/ares.py
@@ -27,6 +27,9 @@ from gevent.socket import SOCK_DGRAM
 from gevent.socket import SOCK_RAW
 from gevent.socket import AI_NUMERICHOST
 
+from gevent._config import config
+from gevent._config import AresSettingMixin
+
 from .cares import channel, InvalidIP # pylint:disable=import-error,no-name-in-module
 from . import _lookup_port as lookup_port
 from . import _resolve_special
@@ -84,12 +87,11 @@ class Resolver(AbstractResolver):
             hub = get_hub()
         self.hub = hub
         if use_environ:
-            for key in os.environ:
-                if key.startswith('GEVENTARES_'):
-                    name = key[11:].lower()
-                    if name:
-                        value = os.environ[key]
-                        kwargs.setdefault(name, value)
+            for setting in config.settings.values():
+                if isinstance(setting, AresSettingMixin):
+                    value = setting.get()
+                    if value is not None:
+                        kwargs.setdefault(setting.kwarg_name, value)
         self.ares = self.ares_class(hub.loop, **kwargs)
         self.pid = os.getpid()
         self.params = kwargs

--- a/src/gevent/resolver/dnspython.py
+++ b/src/gevent/resolver/dnspython.py
@@ -253,7 +253,9 @@ _is_ipv4_addr = _is_addr
 
 def _is_ipv6_addr(host):
     # Return True if host is a valid IPv6 address
-    host = host.split('%', 1)[0] if host else host
+    if host:
+        s = '%' if isinstance(host, str) else b'%'
+        host = host.split(s, 1)[0]
     return _is_addr(host, dns.ipv6.inet_aton)
 
 class HostsFile(object):

--- a/src/greentest/greentest/__init__.py
+++ b/src/greentest/greentest/__init__.py
@@ -101,8 +101,6 @@ from greentest.openfiles import get_number_open_files
 from greentest.openfiles import get_open_files
 
 from greentest.testcase import TestCase
-from greentest.timing import AbstractGenericGetTestCase as GenericGetTestCase
-from greentest.timing import AbstractGenericWaitTestCase as GenericWaitTestCase
 
 from greentest.modules import walk_modules
 

--- a/src/greentest/greentest/__init__.py
+++ b/src/greentest/greentest/__init__.py
@@ -58,6 +58,7 @@ from greentest.sysinfo import CONN_ABORTED_ERRORS
 
 from greentest.skipping import skipOnWindows
 from greentest.skipping import skipOnAppVeyor
+from greentest.skipping import skipOnCI
 from greentest.skipping import skipOnPyPy3OnCI
 from greentest.skipping import skipOnPyPy
 from greentest.skipping import skipOnPyPy3

--- a/src/greentest/greentest/leakcheck.py
+++ b/src/greentest/greentest/leakcheck.py
@@ -32,43 +32,44 @@ def ignores_leakcheck(func):
     func.ignore_leakcheck = True
     return func
 
+# Some builtin things that we ignore
+IGNORED_TYPES = (tuple, dict, types.FrameType, types.TracebackType)
+try:
+    callback_kind = gevent.core.callback
+except AttributeError:
+    # Must be using FFI.
+    from gevent._ffi.callback import callback as callback_kind
+
+def _type_hist():
+    d = collections.defaultdict(int)
+    for x in gc.get_objects():
+        k = type(x)
+        if k in IGNORED_TYPES:
+            continue
+        if k == callback_kind and x.callback is None and x.args is None:
+            # these represent callbacks that have been stopped, but
+            # the event loop hasn't cycled around to run them. The only
+            # known cause of this is killing greenlets before they get a chance
+            # to run for the first time.
+            continue
+        d[k] += 1
+    return d
+
+def _report_diff(a, b):
+    diff_lines = []
+    for k, v in sorted(a.items(), key=lambda i: i[0].__name__):
+        if b[k] != v:
+            diff_lines.append("%s: %s != %s" % (k, v, b[k]))
+
+    if not diff_lines:
+        return None
+    diff = '\n'.join(diff_lines)
+    return diff
+
 def wrap_refcount(method):
     if getattr(method, 'ignore_leakcheck', False):
         return method
 
-    # Some builtin things that we ignore
-    IGNORED_TYPES = (tuple, dict, types.FrameType, types.TracebackType)
-    try:
-        callback_kind = gevent.core.callback
-    except AttributeError:
-        # Must be using FFI.
-        from gevent._ffi.callback import callback as callback_kind
-
-    def type_hist():
-        d = collections.defaultdict(int)
-        for x in gc.get_objects():
-            k = type(x)
-            if k in IGNORED_TYPES:
-                continue
-            if k == callback_kind and x.callback is None and x.args is None:
-                # these represent callbacks that have been stopped, but
-                # the event loop hasn't cycled around to run them. The only
-                # known cause of this is killing greenlets before they get a chance
-                # to run for the first time.
-                continue
-            d[k] += 1
-        return d
-
-    def report_diff(a, b):
-        diff_lines = []
-        for k, v in sorted(a.items(), key=lambda i: i[0].__name__):
-            if b[k] != v:
-                diff_lines.append("%s: %s != %s" % (k, v, b[k]))
-
-        if not diff_lines:
-            return None
-        diff = '\n'.join(diff_lines)
-        return diff
 
     @wraps(method)
     def wrapper(self, *args, **kwargs): # pylint:disable=too-many-branches
@@ -78,25 +79,33 @@ def wrap_refcount(method):
         deltas = []
         d = None
         gc.disable()
+
+        # The very first time we are called, we have already been
+        # self.setUp() by the test runner, so we don't need to do it again.
+        needs_setUp = False
+
         try:
             while True:
-
                 # Grab current snapshot
-                hist_before = type_hist()
+                hist_before = _type_hist()
                 d = sum(hist_before.values())
 
-                self.setUp()
+                if needs_setUp:
+                    self.setUp()
+                    self.skipTearDown = False
                 try:
                     method(self, *args, **kwargs)
                 finally:
                     self.tearDown()
+                    self.skipTearDown = True
+                    needs_setUp = True
 
                 # Grab post snapshot
                 if 'urlparse' in sys.modules:
                     sys.modules['urlparse'].clear_cache()
                 if 'urllib.parse' in sys.modules:
                     sys.modules['urllib.parse'].clear_cache()
-                hist_after = type_hist()
+                hist_after = _type_hist()
                 d = sum(hist_after.values()) - d
                 deltas.append(d)
 
@@ -119,7 +128,7 @@ def wrap_refcount(method):
                 elif len(deltas) >= 4 and sum(deltas[-4:]) == 0:
                     break
                 elif len(deltas) >= 3 and deltas[-1] > 0 and deltas[-1] == deltas[-2] and deltas[-2] == deltas[-3]:
-                    diff = report_diff(hist_before, hist_after)
+                    diff = _report_diff(hist_before, hist_after)
                     raise AssertionError('refcount increased by %r\n%s' % (deltas, diff))
                 # OK, we don't know for sure yet. Let's search for more
                 if sum(deltas[-3:]) <= 0 or sum(deltas[-4:]) <= 0 or deltas[-4:].count(0) >= 2:
@@ -128,9 +137,10 @@ def wrap_refcount(method):
                 else:
                     limit = 7
                 if len(deltas) >= limit:
-                    raise AssertionError('refcount increased by %r\n%s' % (deltas, report_diff(hist_before, hist_after)))
+                    raise AssertionError('refcount increased by %r\n%s'
+                                         % (deltas,
+                                            _report_diff(hist_before, hist_after)))
         finally:
             gc.enable()
-        self.skipTearDown = True
 
     return wrapper

--- a/src/greentest/greentest/params.py
+++ b/src/greentest/greentest/params.py
@@ -23,9 +23,11 @@ from greentest.sysinfo import PY3
 from greentest.sysinfo import PYPY
 from greentest.sysinfo import WIN
 from greentest.sysinfo import LIBUV
+from greentest.sysinfo import OSX
 
 from greentest.sysinfo import RUNNING_ON_TRAVIS
 from greentest.sysinfo import EXPECT_POOR_TIMER_RESOLUTION
+from greentest.sysinfo import RESOLVER_ARES
 
 
 # Travis is slow and overloaded; Appveyor used to be faster, but
@@ -58,6 +60,11 @@ if RUNNING_ON_TRAVIS:
     DEFAULT_LOCAL_HOST_ADDR6 = '::1'
     # Likewise, binding to '' appears to work, but it cannot be
     # connected to with the same error.
+    DEFAULT_BIND_ADDR = '127.0.0.1'
+
+if RESOLVER_ARES and OSX:
+    # Ares likes to raise "malformed domain name" on '', at least
+    # on OS X
     DEFAULT_BIND_ADDR = '127.0.0.1'
 
 # For in-process sockets

--- a/src/greentest/greentest/skipping.py
+++ b/src/greentest/greentest/skipping.py
@@ -23,13 +23,12 @@ import unittest
 
 from greentest import sysinfo
 
+def _identity(f):
+    return f
 
 def _do_not_skip(reason):
     assert reason
-
-    def dec(f):
-        return f
-    return dec
+    return _identity
 
 
 if sysinfo.WIN:
@@ -49,6 +48,11 @@ if sysinfo.RUNNING_ON_APPVEYOR:
 
 else:
     skipOnAppVeyor = _do_not_skip
+
+if sysinfo.RUNNING_ON_CI:
+    skipOnCI = unittest.skip
+else:
+    skipOnCI = _do_not_skip
 
 if sysinfo.PYPY3 and sysinfo.RUNNING_ON_CI:
     # Same as above, for PyPy3.3-5.5-alpha and 3.5-5.7.1-beta and 3.5-5.8

--- a/src/greentest/greentest/sysinfo.py
+++ b/src/greentest/greentest/sysinfo.py
@@ -30,7 +30,7 @@ LINUX = sys.platform.startswith('linux')
 OSX = sys.platform == 'darwin'
 
 # XXX: Formalize this better
-LIBUV = os.getenv('GEVENT_CORE_CFFI_ONLY') == 'libuv' or (PYPY and WIN) or hasattr(gevent.core, 'libuv')
+LIBUV = 'libuv' in gevent.core.loop.__module__ # pylint:disable=no-member
 CFFI_BACKEND = bool(os.getenv('GEVENT_CORE_CFFI_ONLY')) or PYPY
 
 if '--debug-greentest' in sys.argv:

--- a/src/greentest/greentest/sysinfo.py
+++ b/src/greentest/greentest/sysinfo.py
@@ -31,7 +31,7 @@ OSX = sys.platform == 'darwin'
 
 # XXX: Formalize this better
 LIBUV = 'libuv' in gevent.core.loop.__module__ # pylint:disable=no-member
-CFFI_BACKEND = bool(os.getenv('GEVENT_CORE_CFFI_ONLY')) or PYPY
+CFFI_BACKEND = PYPY or LIBUV or 'cffi' in os.getenv('GEVENT_LOOP', '')
 
 if '--debug-greentest' in sys.argv:
     sys.argv.remove('--debug-greentest')

--- a/src/greentest/greentest/testcase.py
+++ b/src/greentest/greentest/testcase.py
@@ -95,7 +95,9 @@ class TestCaseMetaClass(type):
             if sysinfo.RUN_LEAKCHECKS and timeout is not None:
                 timeout *= 6
         check_totalrefcount = _get_class_attr(classDict, bases, 'check_totalrefcount', True)
+
         error_fatal = _get_class_attr(classDict, bases, 'error_fatal', True)
+        uses_handle_error = _get_class_attr(classDict, bases, 'uses_handle_error', True)
         # Python 3: must copy, we mutate the classDict. Interestingly enough,
         # it doesn't actually error out, but under 3.6 we wind up wrapping
         # and re-wrapping the same items over and over and over.
@@ -108,7 +110,8 @@ class TestCaseMetaClass(type):
                 error_fatal = getattr(value, 'error_fatal', error_fatal)
                 if error_fatal:
                     value = errorhandler.wrap_error_fatal(value)
-                value = errorhandler.wrap_restore_handle_error(value)
+                if uses_handle_error:
+                    value = errorhandler.wrap_restore_handle_error(value)
                 if check_totalrefcount and sysinfo.RUN_LEAKCHECKS:
                     value = leakcheck.wrap_refcount(value)
                 classDict[key] = value
@@ -122,6 +125,7 @@ class TestCase(TestCaseMetaClass("NewBase", (TimeAssertMixin, BaseTestCase,), {}
 
     switch_expected = 'default'
     error_fatal = True
+    uses_handle_error = True
     close_on_teardown = ()
 
     def run(self, *args, **kwargs):

--- a/src/greentest/greentest/timing.py
+++ b/src/greentest/greentest/timing.py
@@ -58,6 +58,7 @@ class _DelayWaitMixin(object):
         # otherwise it's the raw number
         seconds = getattr(timeout, 'seconds', timeout)
 
+        gevent.get_hub().loop.update_now()
         start = time.time()
         try:
             result = self.wait(timeout)

--- a/src/greentest/test___config.py
+++ b/src/greentest/test___config.py
@@ -1,0 +1,81 @@
+# Copyright 2018 gevent contributors. See LICENSE for details.
+
+import os
+import unittest
+
+from gevent import _config
+
+class TestResolver(unittest.TestCase):
+
+    old_resolver = None
+
+    def setUp(self):
+        if 'GEVENT_RESOLVER' in os.environ:
+            self.old_resolver = os.environ['GEVENT_RESOLVER']
+            del os.environ['GEVENT_RESOLVER']
+
+    def tearDown(self):
+        if self.old_resolver:
+            os.environ['GEVENT_RESOLVER'] = self.old_resolver
+
+    def test_key(self):
+        self.assertEqual(_config.Resolver.environment_key, 'GEVENT_RESOLVER')
+
+    def test_default(self):
+        from gevent.resolver.thread import Resolver
+
+        conf = _config.Resolver()
+        self.assertEqual(conf.get(), Resolver)
+
+    def test_env(self):
+        from gevent.resolver.blocking import Resolver
+
+        os.environ['GEVENT_RESOLVER'] = 'foo,bar,block,dnspython'
+
+        conf = _config.Resolver()
+        self.assertEqual(conf.get(), Resolver)
+
+        os.environ['GEVENT_RESOLVER'] = 'dnspython'
+
+        # The existing value is unchanged
+        self.assertEqual(conf.get(), Resolver)
+
+        # A new object reflects it
+        conf = _config.Resolver()
+        from gevent.resolver.dnspython import Resolver as DResolver
+        self.assertEqual(conf.get(), DResolver)
+
+    def test_set_str_long(self):
+        from gevent.resolver.blocking import Resolver
+        conf = _config.Resolver()
+        conf.set('gevent.resolver.blocking.Resolver')
+
+        self.assertEqual(conf.get(), Resolver)
+
+    def test_set_str_short(self):
+        from gevent.resolver.blocking import Resolver
+        conf = _config.Resolver()
+        conf.set('block')
+
+        self.assertEqual(conf.get(), Resolver)
+
+    def test_set_class(self):
+        from gevent.resolver.blocking import Resolver
+        conf = _config.Resolver()
+        conf.set(Resolver)
+
+        self.assertEqual(conf.get(), Resolver)
+
+
+    def test_set_through_config(self):
+        from gevent.resolver.thread import Resolver as Default
+        from gevent.resolver.blocking import Resolver
+
+        conf = _config.Config()
+        self.assertEqual(conf.resolver, Default)
+
+        conf.resolver = 'block'
+        self.assertEqual(conf.resolver, Resolver)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/greentest/test___config.py
+++ b/src/greentest/test___config.py
@@ -100,6 +100,10 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(sorted(_config.config.settings),
                          sorted(dir(_config.config)))
 
+    def test_getattr(self):
+        # Bypass the property that might be set here
+        self.assertIsNotNone(_config.config.__getattr__('resolver'))
+
     def test__getattr__invalid(self):
         with self.assertRaises(AttributeError):
             getattr(_config.config, 'no_such_setting')
@@ -134,6 +138,10 @@ class TestImportableSetting(unittest.TestCase):
         self.assertEqual(len(w), 1)
         self.assertEqual(w[0].category, DeprecationWarning)
         self.assertIn('Absolute paths', str(w[0].message))
+
+    def test_non_string(self):
+        i = _config.ImportableSetting()
+        self.assertIs(i._import(self), self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/greentest/test___example_servers.py
+++ b/src/greentest/test___example_servers.py
@@ -101,7 +101,7 @@ class Test_wsgiserver_ssl(Test_wsgiserver):
         ssl_ctx = ssl._create_unverified_context()
 
 
-@greentest.skipOnLibuvOnCIOnPyPy("Timing issues sometimes lead to a connection refused")
+@greentest.skipOnCI("Timing issues sometimes lead to a connection refused")
 class Test_webproxy(Test_wsgiserver):
     server = 'webproxy.py'
 

--- a/src/greentest/test___example_servers.py
+++ b/src/greentest/test___example_servers.py
@@ -9,8 +9,8 @@ from unittest import SkipTest
 import socket
 import ssl
 
+import greentest
 from greentest import DEFAULT_XPC_SOCKET_TIMEOUT
-from greentest import main
 from greentest import util
 from greentest import params
 
@@ -101,6 +101,7 @@ class Test_wsgiserver_ssl(Test_wsgiserver):
         ssl_ctx = ssl._create_unverified_context()
 
 
+@greentest.skipOnLibuvOnCIOnPyPy("Timing issues sometimes lead to a connection refused")
 class Test_webproxy(Test_wsgiserver):
     server = 'webproxy.py'
 
@@ -136,4 +137,4 @@ class Test_webproxy(Test_wsgiserver):
 
 
 if __name__ == '__main__':
-    main()
+    greentest.main()

--- a/src/greentest/test__api.py
+++ b/src/greentest/test__api.py
@@ -105,9 +105,10 @@ class TestTimers(greentest.TestCase):
             gevent.sleep(0.02)
 
         gevent.spawn(func)
-        assert lst == [1], lst
-        gevent.sleep(0.03)
-        assert lst == [], lst
+        self.assertEqual(lst, [1])
+        gevent.sleep(0.1)
+        self.assertEqual(lst, [])
+
 
     def test_spawn_is_not_cancelled(self):
         lst = [1]
@@ -116,8 +117,8 @@ class TestTimers(greentest.TestCase):
             gevent.spawn(lst.pop)
             # exiting immediately, but self.lst.pop must be called
         gevent.spawn(func)
-        gevent.sleep(0.01)
-        assert lst == [], lst
+        gevent.sleep(0.1)
+        self.assertEqual(lst, [])
 
 
 if __name__ == '__main__':

--- a/src/greentest/test__core_timer.py
+++ b/src/greentest/test__core_timer.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from gevent import core
+from gevent import config
 
 from greentest import TestCase
 from greentest import main
@@ -13,11 +13,14 @@ class Test(TestCase):
 
     def setUp(self):
         self.called = []
-        self.loop = core.loop(default=True)
+        self.loop = config.loop(default=True)
         self.timer = self.loop.timer(0.001, repeat=self.repeat)
 
     def tearDown(self):
         self.timer.close()
+        self.loop.destroy()
+        self.timer = None
+        self.loop = None
 
     def f(self, x=None):
         self.called.append(1)

--- a/src/greentest/test__core_timer.py
+++ b/src/greentest/test__core_timer.py
@@ -16,11 +16,15 @@ class Test(TestCase):
         self.loop = config.loop(default=True)
         self.timer = self.loop.timer(0.001, repeat=self.repeat)
 
-    def tearDown(self):
+    def cleanup(self):
+        # cleanup instead of tearDown to cooperate well with
+        # leakcheck.py
         self.timer.close()
+        # cycle the loop so libuv close callbacks fire
+        self.loop.run()
         self.loop.destroy()
-        self.timer = None
         self.loop = None
+        self.timer = None
 
     def f(self, x=None):
         self.called.append(1)

--- a/src/greentest/test__core_timer.py
+++ b/src/greentest/test__core_timer.py
@@ -9,11 +9,12 @@ from greentest.sysinfo import CFFI_BACKEND
 
 class Test(TestCase):
     __timeout__ = LARGE_TIMEOUT
+
     repeat = 0
 
     def setUp(self):
         self.called = []
-        self.loop = config.loop(default=True)
+        self.loop = config.loop(default=False)
         self.timer = self.loop.timer(0.001, repeat=self.repeat)
 
     def cleanup(self):
@@ -74,6 +75,8 @@ class TestAgain(Test):
 
         self.assertEqual(x.args, (x,))
 
+        # XXX: On libev, this takes 1 second. On libuv,
+        # it takes the expected time.
         self.loop.run()
 
         self.assertEqual(self.called, [1])

--- a/src/greentest/test__event.py
+++ b/src/greentest/test__event.py
@@ -6,11 +6,13 @@ from gevent.event import Event, AsyncResult
 import greentest
 from greentest.skipping import skipUnderCoverage
 from greentest.six import xrange
+from greentest.timing import AbstractGenericGetTestCase
+from greentest.timing import AbstractGenericWaitTestCase
 
 DELAY = 0.01
 
 
-class TestEventWait(greentest.GenericWaitTestCase):
+class TestEventWait(AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         Event().wait(timeout=timeout)
@@ -19,7 +21,7 @@ class TestEventWait(greentest.GenericWaitTestCase):
         str(Event())
 
 
-class TestWaitEvent(greentest.GenericWaitTestCase):
+class TestWaitEvent(AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         gevent.wait([Event()], timeout=timeout)
@@ -58,19 +60,19 @@ class TestWaitEvent(greentest.GenericWaitTestCase):
         gevent.spawn(waiter).join()
 
 
-class TestAsyncResultWait(greentest.GenericWaitTestCase):
+class TestAsyncResultWait(AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         AsyncResult().wait(timeout=timeout)
 
 
-class TestWaitAsyncResult(greentest.GenericWaitTestCase):
+class TestWaitAsyncResult(AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         gevent.wait([AsyncResult()], timeout=timeout)
 
 
-class TestAsyncResultGet(greentest.GenericGetTestCase):
+class TestAsyncResultGet(AbstractGenericGetTestCase):
 
     def wait(self, timeout):
         AsyncResult().get(timeout=timeout)
@@ -231,6 +233,9 @@ class TestWait_count1(TestWait):
 class TestWait_count2(TestWait):
     count = 2
 
+
+del AbstractGenericGetTestCase
+del AbstractGenericWaitTestCase
 
 if __name__ == '__main__':
     greentest.main()

--- a/src/greentest/test__hub.py
+++ b/src/greentest/test__hub.py
@@ -20,6 +20,7 @@
 # THE SOFTWARE.
 
 import greentest
+import greentest.timing
 import time
 import re
 import gevent
@@ -71,7 +72,7 @@ class TestExceptionInMainloop(greentest.TestCase):
 
 
 
-class TestSleep(greentest.GenericWaitTestCase):
+class TestSleep(greentest.timing.AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         gevent.sleep(timeout)
@@ -80,7 +81,7 @@ class TestSleep(greentest.GenericWaitTestCase):
         gevent.sleep(0)
 
 
-class TestWaiterGet(greentest.GenericWaitTestCase):
+class TestWaiterGet(greentest.timing.AbstractGenericWaitTestCase):
 
     def setUp(self):
         super(TestWaiterGet, self).setUp()

--- a/src/greentest/test__queue.py
+++ b/src/greentest/test__queue.py
@@ -1,12 +1,14 @@
 import greentest
-from greentest import TestCase, main, GenericGetTestCase
+from greentest import TestCase, main
 import gevent
 from gevent.hub import get_hub, LoopExit
 from gevent import util
 from gevent import queue
 from gevent.queue import Empty, Full
 from gevent.event import AsyncResult
+from greentest.timing import AbstractGenericGetTestCase
 
+# pylint:disable=too-many-ancestors
 
 class TestQueue(TestCase):
 
@@ -372,7 +374,7 @@ class TestJoinEmpty(TestCase):
         q.join()
 
 
-class TestGetInterrupt(GenericGetTestCase):
+class TestGetInterrupt(AbstractGenericGetTestCase):
 
     Timeout = Empty
 
@@ -397,7 +399,7 @@ class TestGetInterruptChannel(TestGetInterrupt):
     kind = queue.Channel
 
 
-class TestPutInterrupt(GenericGetTestCase):
+class TestPutInterrupt(AbstractGenericGetTestCase):
     kind = queue.Queue
     Timeout = Full
 
@@ -430,7 +432,7 @@ class TestPutInterruptChannel(TestPutInterrupt):
         return self.kind()
 
 
-del GenericGetTestCase
+del AbstractGenericGetTestCase
 
 
 if __name__ == '__main__':

--- a/src/greentest/test__select.py
+++ b/src/greentest/test__select.py
@@ -5,86 +5,87 @@ import errno
 from gevent import select, socket
 import gevent.core
 import greentest
+import greentest.timing
 import unittest
 
 
-class TestSelect(greentest.GenericWaitTestCase):
+class TestSelect(greentest.timing.AbstractGenericWaitTestCase):
 
     def wait(self, timeout):
         select.select([], [], [], timeout)
 
 
-if sys.platform != 'win32':
 
-    class TestSelectRead(greentest.GenericWaitTestCase):
+@greentest.skipOnWindows("Cant select on files")
+class TestSelectRead(greentest.timing.AbstractGenericWaitTestCase):
 
-        def wait(self, timeout):
-            r, w = os.pipe()
+    def wait(self, timeout):
+        r, w = os.pipe()
+        try:
+            select.select([r], [], [], timeout)
+        finally:
+            os.close(r)
+            os.close(w)
+
+    # Issue #12367: http://www.freebsd.org/cgi/query-pr.cgi?pr=kern/155606
+    @unittest.skipIf(sys.platform.startswith('freebsd'),
+                     'skip because of a FreeBSD bug: kern/155606')
+    def test_errno(self):
+        # Backported from test_select.py in 3.4
+        with open(__file__, 'rb') as fp:
+            fd = fp.fileno()
+            fp.close()
             try:
-                select.select([r], [], [], timeout)
-            finally:
-                os.close(r)
-                os.close(w)
-
-        # Issue #12367: http://www.freebsd.org/cgi/query-pr.cgi?pr=kern/155606
-        @unittest.skipIf(sys.platform.startswith('freebsd'),
-                         'skip because of a FreeBSD bug: kern/155606')
-        def test_errno(self):
-            # Backported from test_select.py in 3.4
-            with open(__file__, 'rb') as fp:
-                fd = fp.fileno()
-                fp.close()
-                try:
-                    select.select([fd], [], [], 0)
-                except OSError as err:
-                    # Python 3
-                    self.assertEqual(err.errno, errno.EBADF)
-                except select.error as err: # pylint:disable=duplicate-except
-                    # Python 2 (select.error is OSError on py3)
-                    self.assertEqual(err.args[0], errno.EBADF)
-                else:
-                    self.fail("exception not raised")
+                select.select([fd], [], [], 0)
+            except OSError as err:
+                # Python 3
+                self.assertEqual(err.errno, errno.EBADF)
+            except select.error as err: # pylint:disable=duplicate-except
+                # Python 2 (select.error is OSError on py3)
+                self.assertEqual(err.args[0], errno.EBADF)
+            else:
+                self.fail("exception not raised")
 
 
-    if hasattr(select, 'poll'):
+@unittest.skipUnless(hasattr(select, 'poll'), "Needs poll")
+@greentest.skipOnWindows("Cant poll on files")
+class TestPollRead(greentest.timing.AbstractGenericWaitTestCase):
+    def wait(self, timeout):
+        # On darwin, the read pipe is reported as writable
+        # immediately, for some reason. So we carefully register
+        # it only for read events (the default is read and write)
+        r, w = os.pipe()
+        try:
+            poll = select.poll()
+            poll.register(r, select.POLLIN)
+            poll.poll(timeout * 1000)
+        finally:
+            poll.unregister(r)
+            os.close(r)
+            os.close(w)
 
-        class TestPollRead(greentest.GenericWaitTestCase):
-            def wait(self, timeout):
-                # On darwin, the read pipe is reported as writable
-                # immediately, for some reason. So we carefully register
-                # it only for read events (the default is read and write)
-                r, w = os.pipe()
-                try:
-                    poll = select.poll()
-                    poll.register(r, select.POLLIN)
-                    poll.poll(timeout * 1000)
-                finally:
-                    poll.unregister(r)
-                    os.close(r)
-                    os.close(w)
+    def test_unregister_never_registered(self):
+        # "Attempting to remove a file descriptor that was
+        # never registered causes a KeyError exception to be
+        # raised."
+        poll = select.poll()
+        self.assertRaises(KeyError, poll.unregister, 5)
 
-            def test_unregister_never_registered(self):
-                # "Attempting to remove a file descriptor that was
-                # never registered causes a KeyError exception to be
-                # raised."
-                poll = select.poll()
-                self.assertRaises(KeyError, poll.unregister, 5)
+    @unittest.skipIf(hasattr(gevent.core, 'libuv'),
+                     "Depending on whether the fileno is reused or not this either crashes or does nothing."
+                     "libuv won't open a watcher for a closed file on linux.")
+    def test_poll_invalid(self):
+        with open(__file__, 'rb') as fp:
+            fd = fp.fileno()
 
-            @unittest.skipIf(hasattr(gevent.core, 'libuv'),
-                             "Depending on whether the fileno is reused or not this either crashes or does nothing."
-                             "libuv won't open a watcher for a closed file on linux.")
-            def test_poll_invalid(self):
-                with open(__file__, 'rb') as fp:
-                    fd = fp.fileno()
-
-                    poll = select.poll()
-                    poll.register(fd, select.POLLIN)
-                    # Close after registering; libuv refuses to even
-                    # create a watcher if it would get EBADF (so this turns into
-                    # a test of whether or not we successfully initted the watcher).
-                    fp.close()
-                    result = poll.poll(0)
-                    self.assertEqual(result, [(fd, select.POLLNVAL)]) # pylint:disable=no-member
+            poll = select.poll()
+            poll.register(fd, select.POLLIN)
+            # Close after registering; libuv refuses to even
+            # create a watcher if it would get EBADF (so this turns into
+            # a test of whether or not we successfully initted the watcher).
+            fp.close()
+            result = poll.poll(0)
+            self.assertEqual(result, [(fd, select.POLLNVAL)]) # pylint:disable=no-member
 
 class TestSelectTypes(greentest.TestCase):
 

--- a/src/greentest/test__socket.py
+++ b/src/greentest/test__socket.py
@@ -9,6 +9,7 @@ import unittest
 import greentest
 from functools import wraps
 from greentest import six
+from greentest import LARGE_TIMEOUT
 
 # we use threading on purpose so that we can test both regular and gevent sockets with the same code
 from threading import Thread as _Thread
@@ -42,7 +43,7 @@ class TestTCP(greentest.TestCase):
     __timeout__ = None
     TIMEOUT_ERROR = socket.timeout
     long_data = ", ".join([str(x) for x in range(20000)])
-    if six.PY3:
+    if not isinstance(long_data, bytes):
         long_data = long_data.encode('ascii')
 
     def setUp(self):
@@ -341,7 +342,7 @@ def get_port():
 
 class TestCreateConnection(greentest.TestCase):
 
-    __timeout__ = 5
+    __timeout__ = LARGE_TIMEOUT
 
     def test_refuses(self):
         with self.assertRaises(socket.error) as cm:

--- a/src/greentest/test__socket_dns.py
+++ b/src/greentest/test__socket_dns.py
@@ -25,6 +25,7 @@ if getattr(resolver, 'pool', None) is not None:
 
 from greentest.sysinfo import RESOLVER_NOT_SYSTEM
 from greentest.sysinfo import RESOLVER_DNSPYTHON
+from greentest.sysinfo import RESOLVER_ARES
 from greentest.sysinfo import PY2
 
 
@@ -444,6 +445,8 @@ class SanitizedHostsFile(HostsFile):
                 continue
             yield name, addr
 
+@greentest.skipIf(greentest.RUNNING_ON_TRAVIS and RESOLVER_ARES,
+                  "This sometimes randomly fails on Travis with ares, beginning Feb 13, 2018")
 class TestEtcHosts(TestCase):
 
     MAX_HOSTS = os.getenv('GEVENTTEST_MAX_ETC_HOSTS', 10)

--- a/src/greentest/test__socket_dns.py
+++ b/src/greentest/test__socket_dns.py
@@ -27,6 +27,7 @@ from greentest.sysinfo import RESOLVER_NOT_SYSTEM
 from greentest.sysinfo import RESOLVER_DNSPYTHON
 from greentest.sysinfo import RESOLVER_ARES
 from greentest.sysinfo import PY2
+import greentest.timing
 
 
 assert gevent_socket.gaierror is socket.gaierror
@@ -570,7 +571,7 @@ add(TestInternational, u'президент.рф', 'russian',
 add(TestInternational, u'президент.рф'.encode('idna'), 'idna')
 
 
-class TestInterrupted_gethostbyname(greentest.GenericWaitTestCase):
+class TestInterrupted_gethostbyname(greentest.timing.AbstractGenericWaitTestCase):
 
     # There are refs to a Waiter in the C code that don't go
     # away yet; one gc may or may not do it.

--- a/src/greentest/tests_that_dont_use_resolver.txt
+++ b/src/greentest/tests_that_dont_use_resolver.txt
@@ -123,3 +123,5 @@ test_timeout.py
 # implicitly for localhost, which is covered well enough
 # elsewhere that we don't need to spend the 20s (*2)
 test_asyncore.py
+
+test___config.py

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 basepython =
     python2.7
 setenv =
-	GEVENT_CORE_CFFI_ONLY=1
+	GEVENT_LOOP=libev-cffi
 commands =
     make basictest
 
@@ -44,7 +44,7 @@ commands =
 basepython =
     python2.7
 setenv =
-	GEVENT_CORE_CFFI_ONLY=libuv
+	GEVENT_LOOP=libuv-cffi
 commands =
     make basictest
 


### PR DESCRIPTION
This lets us document things more clearly, and, with care, allows configuring gevent from Python code without any environment varibles.

All the fileobject implementations needed to be moved out of the ``gevent.fileobject`` module so as not to introduce import cycles that made configuring from code impossible.

Fixes #1090