### PR TITLE
Don't let destroying the default C loop from two different Python loo…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,13 @@
     order, or be a dotted name; it may also be assigned to an
     object in Python code at ``gevent.config.loop``).
 
+- Fix an interpreter crash that could happen if two or more ``loop``
+  objects referenced the default event loop and one of them was
+  destroyed and then the other one destroyed or (in the libev C
+  extension implementation only) deallocated (garbage collected). See
+  :issue:`1098`.
+
+
 1.3a1 (2018-01-27)
 ==================
 

--- a/src/greentest/test__destroy_default_loop.py
+++ b/src/greentest/test__destroy_default_loop.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+import gevent
+
+import unittest
+
+class TestDestroyDefaultLoop(unittest.TestCase):
+
+    def test_destroy_gc(self):
+        # Issue 1098: destroying the default loop
+        # while using the C extension could crash
+        # the interpreter when it exits
+
+        # Create the hub greenlet. This creates one loop
+        # object pointing to the default loop.
+        gevent.get_hub()
+
+        # Get a new loop object, but using the default
+        # C loop
+        loop = gevent.config.loop(default=True)
+        self.assertTrue(loop.default)
+        # Destroy it
+        loop.destroy()
+        # It no longer claims to be the default
+        self.assertFalse(loop.default)
+
+        # Delete it
+        del loop
+        # Delete the hub. This prompts garbage
+        # collection of it and its loop object.
+        # (making this test more repeatable; the exit
+        # crash only happened when that greenlet object
+        # was collected at exit time, which was most common
+        # in CPython 3.5)
+        del gevent.hub._threadlocal.hub
+
+
+    def test_destroy_two(self):
+        # Get two new loop object, but using the default
+        # C loop
+        loop1 = gevent.config.loop(default=True)
+        loop2 = gevent.config.loop(default=True)
+        self.assertTrue(loop1.default)
+        self.assertTrue(loop2.default)
+        # Destroy the first
+        loop1.destroy()
+        # It no longer claims to be the default
+        self.assertFalse(loop1.default)
+
+        # Destroy the second. This doesn't crash.
+        loop2.destroy()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/greentest/tests_that_dont_use_resolver.txt
+++ b/src/greentest/tests_that_dont_use_resolver.txt
@@ -125,3 +125,4 @@ test_timeout.py
 test_asyncore.py
 
 test___config.py
+test__destroy_default_loop.py


### PR DESCRIPTION
…p objects crash the process. Fixes #1098 

This will be the first of two PRs: as far as I can tell, nowadays (since 4.0) libev correctly handles getting the default loop after it has been destroyed (re-initializes it), just like libuv. So we can probably simplify that whole situation.