### PR TITLE
Make socket.sendall() fast on PyPy3: 60MB/s -> 600MB/s

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,9 @@
   it will regenerate itself. The default loop is the only one that can
   receive child events.
 
+- Make :meth:`gevent.socket.socket.sendall` up to ten times faster on
+  PyPy3, through the same change that was applied in gevent 1.1b3 for PyPy2.
+
 
 1.3a1 (2018-01-27)
 ==================

--- a/src/greentest/greentest/__init__.py
+++ b/src/greentest/greentest/__init__.py
@@ -52,6 +52,10 @@ from greentest.sysinfo import RUNNING_ON_TRAVIS
 from greentest.sysinfo import RUNNING_ON_APPVEYOR
 from greentest.sysinfo import RUNNING_ON_CI
 
+from greentest.sysinfo import RESOLVER_NOT_SYSTEM
+from greentest.sysinfo import RESOLVER_DNSPYTHON
+from greentest.sysinfo import RESOLVER_ARES
+
 from greentest.sysinfo import EXPECT_POOR_TIMER_RESOLUTION
 
 from greentest.sysinfo import CONN_ABORTED_ERRORS

--- a/src/greentest/greentest/patched_tests_setup.py
+++ b/src/greentest/greentest/patched_tests_setup.py
@@ -630,7 +630,7 @@ if PYPY3:
 
 
 if PYPY and sys.pypy_version_info[:4] in ( # pylint:disable=no-member
-        (5, 8, 0, 'beta'), (5, 9, 0, 'beta'),):
+        (5, 8, 0, 'beta'), (5, 9, 0, 'beta'), (5, 10, 1, 'final')):
     # 3.5 is beta. Hard to say what are real bugs in us vs real bugs in pypy.
     # For that reason, we pin these patches exactly to the version in use.
 
@@ -653,6 +653,35 @@ if PYPY and sys.pypy_version_info[:4] in ( # pylint:disable=no-member
             'test_subprocess.POSIXProcessTestCase.test_pass_fds',
             'test_subprocess.POSIXProcessTestCase.test_pass_fds_inheritable',
             'test_subprocess.POSIXProcessTestCase.test_pipe_cloexec',
+
+            # The below are new with 5.10.1
+            # These fail with 'OSError: received malformed or improperly truncated ancillary data'
+            'test_socket.RecvmsgSCMRightsStreamTest.testCmsgTruncLen0',
+            'test_socket.RecvmsgSCMRightsStreamTest.testCmsgTruncLen0Plus1',
+            'test_socket.RecvmsgSCMRightsStreamTest.testCmsgTruncLen1',
+            'test_socket.RecvmsgSCMRightsStreamTest.testCmsgTruncLen2Minus1',
+
+            # Using the provided High Sierra binary, these fail with
+            # 'ValueError: invalid protocol version _SSLMethod.PROTOCOL_SSLv3'.
+            # gevent code isn't involved and running them unpatched has the same issue.
+            'test_ssl.ContextTests.test_constructor',
+            'test_ssl.ContextTests.test_protocol',
+            'test_ssl.ContextTests.test_session_stats',
+            'test_ssl.ThreadedTests.test_echo',
+            'test_ssl.ThreadedTests.test_protocol_sslv23',
+            'test_ssl.ThreadedTests.test_protocol_sslv3',
+            'test_ssl.ThreadedTests.test_protocol_tlsv1',
+            'test_ssl.ThreadedTests.test_protocol_tlsv1_1',
+
+            # This gets an EOF in violation of protocol; again, even without gevent
+            'test_ssl.NetworkedBIOTests.test_handshake',
+
+            # This gets None instead of http1.1, even without gevent
+            'test_ssl.ThreadedTests.test_npn_protocols',
+
+            # This fails to decode a filename even without gevent,
+            # at least on High Sierarr.
+            'test_httpservers.SimpleHTTPServerTestCase.test_undecodable_filename',
         ]
 
     disabled_tests += [

--- a/src/greentest/greentest/patched_tests_setup.py
+++ b/src/greentest/greentest/patched_tests_setup.py
@@ -643,6 +643,12 @@ if PYPY and sys.pypy_version_info[:4] in ( # pylint:disable=no-member
         # This has the wrong constants in 5.8 (but worked in 5.7), at least on
         # OS X. It finds "zlib compression" but expects "ZLIB".
         'test_ssl.ThreadedTests.test_compression',
+
+        # The below are new with 5.10.1
+        # This gets an EOF in violation of protocol; again, even without gevent
+        # (at least on OS X; it's less consistent about that on travis)
+        'test_ssl.NetworkedBIOTests.test_handshake',
+
     ]
 
     if OSX:
@@ -672,9 +678,6 @@ if PYPY and sys.pypy_version_info[:4] in ( # pylint:disable=no-member
             'test_ssl.ThreadedTests.test_protocol_sslv3',
             'test_ssl.ThreadedTests.test_protocol_tlsv1',
             'test_ssl.ThreadedTests.test_protocol_tlsv1_1',
-
-            # This gets an EOF in violation of protocol; again, even without gevent
-            'test_ssl.NetworkedBIOTests.test_handshake',
 
             # This gets None instead of http1.1, even without gevent
             'test_ssl.ThreadedTests.test_npn_protocols',

--- a/src/greentest/known_failures.py
+++ b/src/greentest/known_failures.py
@@ -176,8 +176,6 @@ if PYPY:
             ## Unknown; can't reproduce locally on OS X
             'FLAKY test_subprocess.py', # timeouts on one test.
 
-            ## PyPy3 5.9.0-beta seems to have dropped recvmsg_into?
-            'test_socket.py',
             'FLAKY test_ssl.py',
         ]
 

--- a/src/greentest/test___example_servers.py
+++ b/src/greentest/test___example_servers.py
@@ -14,7 +14,7 @@ from greentest import DEFAULT_XPC_SOCKET_TIMEOUT
 from greentest import util
 from greentest import params
 
-@greentest.skipOnLibuvOnCIOnPyPy("Timing issues sometimes lead to a connection refused")
+@greentest.skipOnCI("Timing issues sometimes lead to a connection refused")
 class Test_wsgiserver(util.TestServer):
     server = 'wsgiserver.py'
     URL = 'http://%s:8088' % (params.DEFAULT_LOCAL_HOST_ADDR,)

--- a/src/greentest/test__socket_dns.py
+++ b/src/greentest/test__socket_dns.py
@@ -25,7 +25,6 @@ if getattr(resolver, 'pool', None) is not None:
 
 from greentest.sysinfo import RESOLVER_NOT_SYSTEM
 from greentest.sysinfo import RESOLVER_DNSPYTHON
-from greentest.sysinfo import RESOLVER_ARES
 from greentest.sysinfo import PY2
 import greentest.timing
 
@@ -446,8 +445,12 @@ class SanitizedHostsFile(HostsFile):
                 continue
             yield name, addr
 
-@greentest.skipIf(greentest.RUNNING_ON_TRAVIS and RESOLVER_ARES,
-                  "This sometimes randomly fails on Travis with ares, beginning Feb 13, 2018")
+@greentest.skipIf(greentest.RUNNING_ON_CI,
+                  "This sometimes randomly fails on Travis with ares and on appveyor, beginning Feb 13, 2018")
+# Probably due to round-robin DNS,
+# since this is not actually the system's etc hosts file.
+# TODO: Rethink this. We need something reliable. Go back to using
+# the system's etc hosts?
 class TestEtcHosts(TestCase):
 
     MAX_HOSTS = os.getenv('GEVENTTEST_MAX_ETC_HOSTS', 10)

--- a/src/greentest/test_threading_2.py
+++ b/src/greentest/test_threading_2.py
@@ -516,7 +516,7 @@ class ThreadJoinOnShutdown(unittest.TestCase):
             w = threading.Thread(target=worker)
             w.start()
             import sys
-            if sys.version_info[:2] >= (3, 7) or (sys.version_info[:2] >= (3, 5) and hasattr(sys, 'pypy_version_info')):
+            if sys.version_info[:2] >= (3, 7) or (sys.version_info[:2] >= (3, 5) and hasattr(sys, 'pypy_version_info') and sys.platform != 'darwin'):
                 w.join()
             """
         # In PyPy3 5.8.0, if we don't wait on this top-level "thread", 'w',
@@ -526,6 +526,8 @@ class ThreadJoinOnShutdown(unittest.TestCase):
         # the interpreter waiting on thread locks, like the issue described in threading.py
         # for Python 3.4? in any case, it doesn't hang in Python 2.) This changed in
         # 3.7a1 and waiting on it is again necessary and doesn't hang.
+        # PyPy3 5.10.1 is back to the "old" cpython behaviour, and waiting on it
+        # causes the whole process to hang, but apparently only on OS X---linux was fine without it
         self._run_and_join(script)
 
 


### PR DESCRIPTION
Share the chunking code between Python 2 and 3.

Also get the tests passing (read: skip a bunch) with 5.10.1 on OS X,
which is apparently less well tested than Linux.

We don't test pypy3 on appveyor, so:

[skip appveyor]