### PR TITLE
Support GEVENT_RESOLVER_SERVERS for configuring dnspython nameservers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,10 @@
   :func:`gevent.subprocess.run`.
 
 - Add the ``dnspython`` resolver as a lightweight alternative to
-  c-ares. See :pr:`1088`.
+  c-ares. See :pr:`1088` and :issue:`1103`.
+
+- The ``GEVENTARES_SERVERS`` environment variable is deprecated in
+  favor of ``GEVENT_RESOLVER_SERVERS``. See :issue:`1103`.
 
 - Fix calling ``shutdown`` on a closed socket. It was raising
   ``AttributeError``, now it once again raises the correct

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CYTHON?=cython
 
 export PATH:=$(BUILD_RUNTIMES)/snakepit:$(TOOLS):$(PATH)
 export LC_ALL=C.UTF-8
+export GEVENT_RESOLVER_NAMESERVERS=8.8.8.8
 
 
 clean:
@@ -61,7 +62,7 @@ basictest: test_prelim
 
 alltest: basictest
 	@${PYTHON} scripts/travis.py fold_start ares "Running c-ares tests"
-	cd src/greentest && GEVENT_RESOLVER=ares GEVENTARES_SERVERS=8.8.8.8 ${PYTHON} testrunner.py --config known_failures.py --ignore tests_that_dont_use_resolver.txt --quiet
+	cd src/greentest && GEVENT_RESOLVER=ares ${PYTHON} testrunner.py --config known_failures.py --ignore tests_that_dont_use_resolver.txt --quiet
 	@${PYTHON} scripts/travis.py fold_end ares
 	@${PYTHON} scripts/travis.py fold_start dnspython "Running dnspython tests"
 	cd src/greentest && GEVENT_RESOLVER=dnspython ${PYTHON} testrunner.py --config known_failures.py --ignore tests_that_dont_use_resolver.txt --quiet

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -447,7 +447,67 @@ class AresServers(AresSettingMixin, Setting):
     name = 'ares_servers'
     default = None
     environment_key = 'GEVENTARES_SERVERS'
+    desc = """\
+    A list of strings giving the IP addresses of nameservers for the ares resolver.
 
+    In the environment variable, these strings are separated by commas.
+
+    .. deprecated:: 1.3a2
+       Prefer the :attr:`resolver_nameservers` setting. If both are set,
+       the results are not defined.
+    """
+
+# Generic nameservers, works for dnspython and ares.
+class ResolverNameservers(AresSettingMixin, Setting):
+    document = True
+    name = 'resolver_nameservers'
+    default = None
+    environment_key = 'GEVENT_RESOLVER_NAMESERVERS'
+    desc = """\
+    A list of strings giving the IP addresses of nameservers for the (non-system) resolver.
+
+    In the environment variable, these strings are separated by commas.
+
+    .. rubric:: Resolver Behaviour
+
+    * blocking
+
+      Ignored
+
+    * Threaded
+
+      Ignored
+
+    * dnspython
+
+      If this setting is not given, the dnspython resolver will
+      load nameservers to use from ``/etc/resolv.conf``
+      or the Windows registry. This setting replaces any nameservers read
+      from those means. Note that the file and registry are still read
+      for other settings.
+
+      .. caution:: dnspython does not validate the members of the list.
+         An improper address (such as a hostname instead of IP) has
+         undefined results, including hanging the process.
+
+    * ares
+
+      Similar to dnspython, but with more platform and compile-time
+      options. ares validates that the members of the list are valid
+      addresses.
+    """
+
+    # Normal string-to-list rules. But still validate_anything.
+    _convert = Setting._convert
+
+    # TODO: In the future, support reading a resolv.conf file
+    # *other* than /etc/resolv.conf, and do that both on Windows
+    # and other platforms. Also offer the option to disable the system
+    # configuration entirely.
+
+    @property
+    def kwarg_name(self):
+        return 'servers'
 
 config = Config()
 

--- a/src/gevent/resolver/dnspython.py
+++ b/src/gevent/resolver/dnspython.py
@@ -81,6 +81,7 @@ from . import hostname_types
 from gevent._compat import string_types
 from gevent._compat import iteritems
 from gevent._patcher import import_patched
+from gevent._config import config
 
 __all__ = [
     'Resolver',
@@ -553,6 +554,8 @@ class Resolver(AbstractResolver):
         self._resolver = _DualResolver()
         if resolver._resolver is None:
             resolver._resolver = self._resolver
+            if config.resolver_nameservers:
+                self._resolver.network_resolver.nameservers[:] = config.resolver_nameservers
         # Different hubs in different threads could be sharing the same
         # resolver.
         assert isinstance(resolver._resolver, _DualResolver)


### PR DESCRIPTION
Also allow this for ares, and deprecate the GEVENTARES_SERVERS environment variable.

Fixes #1103.