### PR TITLE
Add spawn_tree_locals, spawning_greenlet and spawning_stack to gevent.greenlet.Greenlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gevent.*.[ch]
 src/gevent/__pycache__
 src/gevent/_semaphore.c
 src/gevent/local.c
+src/gevent/greenlet.c
 src/gevent/libev/corecext.c
 src/gevent/libev/corecext.h
 src/gevent/libev/_corecffi.c

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,9 @@
   a "spawn tree local" mapping. Based on a proposal from PayPal and
   comments by Mahmoud Hashemi and Kurt Rose. See :issue:`755`.
 
+- The :mod:`gevent.greenlet` module is now compiled with Cython to
+  offset any performance loss due to :issue:`755`.
+
 1.3a1 (2018-01-27)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,10 +88,12 @@
 - Greenlet objects now keep track of their spawning parent greenlet
   and the code location that spawned them, in addition to maintaining
   a "spawn tree local" mapping. Based on a proposal from PayPal and
-  comments by Mahmoud Hashemi and Kurt Rose. See :issue:`755`.
+  comments by Mahmoud Hashemi and Kurt Rose. See :issue:`755` and
+  :pr:`1115`.
 
 - The :mod:`gevent.greenlet` module is now compiled with Cython to
-  offset any performance loss due to :issue:`755`.
+  offset any performance decrease due to :issue:`755`. Please open
+  issues for any compatibility concerns. See :pr:`1115`.
 
 1.3a1 (2018-01-27)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,10 @@
 - Signal handling under PyPy with libuv is more reliable. See
   :issue:`1112`.
 
+- Greenlet objects now keep track of their spawning parent greenlet
+  and the code location that spawned them, in addition to maintaining
+  a "spawn tree local" mapping. Based on a proposal from PayPal and
+  comments by Mahmoud Hashemi and Kurt Rose. See :issue:`755`.
 
 1.3a1 (2018-01-27)
 ==================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -223,7 +223,6 @@ latex_documents = [
 # prevent some stuff from showing up in docs
 import socket
 import gevent.socket
-del gevent.Greenlet.throw
 for item in gevent.socket.__all__[:]:
     if getattr(gevent.socket, item) is getattr(socket, item, None):
         gevent.socket.__all__.remove(item)

--- a/doc/gevent.rst
+++ b/doc/gevent.rst
@@ -47,6 +47,13 @@ generated.
              its value.
 
 .. autoattribute:: Greenlet.exception
+.. autoattribute:: Greenlet.spawn_tree_locals
+   :annotation: = {}
+.. autoattribute:: Greenlet.spawning_greenlet
+   :annotation: = weakref.ref()
+.. autoattribute:: Greenlet.spawning_stack
+   :annotation: = <Frame>
+.. autoattribute:: Greenlet.spawning_stack_limit
 
 .. automethod:: Greenlet.ready
 .. automethod:: Greenlet.successful
@@ -113,6 +120,8 @@ Spawn helpers
 
 Useful general functions
 ========================
+
+.. seealso:: :mod:`gevent.util`
 
 .. function:: getcurrent()
 

--- a/doc/gevent.rst
+++ b/doc/gevent.rst
@@ -36,25 +36,7 @@ generated.
 
 .. automethod:: Greenlet.__init__
 
-.. attribute:: Greenlet.value
-
-    Holds the value returned by the function if the greenlet has
-    finished successfully. Until then, or if it finished in error, ``None``.
-
-    .. tip:: Recall that a greenlet killed with the default
-             :class:`GreenletExit` is considered to have finished
-             successfully, and the ``GreenletExit`` exception will be
-             its value.
-
 .. autoattribute:: Greenlet.exception
-.. autoattribute:: Greenlet.spawn_tree_locals
-   :annotation: = {}
-.. autoattribute:: Greenlet.spawning_greenlet
-   :annotation: = weakref.ref()
-.. autoattribute:: Greenlet.spawning_stack
-   :annotation: = <Frame>
-.. autoattribute:: Greenlet.spawning_stack_limit
-
 .. automethod:: Greenlet.ready
 .. automethod:: Greenlet.successful
 .. automethod:: Greenlet.start

--- a/src/gevent/greenlet.pxd
+++ b/src/gevent/greenlet.pxd
@@ -36,11 +36,11 @@ cdef class Greenlet(greenlet):
     cdef public dict spawn_tree_locals
 
     cdef readonly _Frame spawning_stack
-    # A test case reads these, otherwise they would
+    # A test case reads this, otherwise they would
     # be private
-    cdef readonly tuple _exc_info
     cdef readonly list _links
 
+    cdef object tuple _exc_info
     cdef object _notifier
     cdef object _start_event
     cdef dict _kwargs

--- a/src/gevent/greenlet.pxd
+++ b/src/gevent/greenlet.pxd
@@ -36,15 +36,14 @@ cdef class Greenlet(greenlet):
     cdef public dict spawn_tree_locals
 
     cdef readonly _Frame spawning_stack
-    # A test case reads this, otherwise they would
-    # be private
-    cdef readonly list _links
 
-    cdef object tuple _exc_info
+    cdef list _links
+    cdef tuple _exc_info
     cdef object _notifier
     cdef object _start_event
     cdef dict _kwargs
 
+    cpdef bint has_links(self)
 
     cdef bint __started_but_aborted(self)
     cdef bint __start_cancelled_by_kill(self)

--- a/src/gevent/greenlet.pxd
+++ b/src/gevent/greenlet.pxd
@@ -49,12 +49,14 @@ cdef class Greenlet(greenlet):
     cdef object _notifier
     cdef object _start_event
     cdef dict _kwargs
+    cdef str _formatted_info
 
     cpdef bint has_links(self)
     cpdef join(self, timeout=*)
     cpdef bint ready(self)
     cpdef bint successful(self)
     cpdef rawlink(self, object callback)
+    cpdef str _formatinfo(self)
 
     cdef bint __started_but_aborted(self)
     cdef bint __start_cancelled_by_kill(self)

--- a/src/gevent/greenlet.pxd
+++ b/src/gevent/greenlet.pxd
@@ -1,0 +1,80 @@
+# cython: auto_pickle=False
+
+cimport cython
+
+
+cdef extern from "greenlet/greenlet.h":
+
+  ctypedef class greenlet.greenlet [object PyGreenlet]:
+      pass
+
+
+cdef class SpawnedLink:
+    cdef public object callback
+
+
+@cython.final
+cdef class SuccessSpawnedLink(SpawnedLink):
+    pass
+
+@cython.final
+cdef class FailureSpawnedLink(SpawnedLink):
+    pass
+
+@cython.final
+@cython.internal
+cdef class _Frame:
+    cdef readonly object f_code
+    cdef readonly int f_lineno
+    cdef public _Frame f_back
+
+
+cdef class Greenlet(greenlet):
+    cdef readonly object value
+    cdef readonly args
+    cdef readonly object spawning_greenlet
+    cdef public dict spawn_tree_locals
+
+    cdef readonly _Frame spawning_stack
+    # A test case reads these, otherwise they would
+    # be private
+    cdef readonly tuple _exc_info
+    cdef readonly list _links
+
+    cdef object _notifier
+    cdef object _start_event
+    cdef dict _kwargs
+
+
+    cdef bint __started_but_aborted(self)
+    cdef bint __start_cancelled_by_kill(self)
+    cdef bint __start_pending(self)
+    cdef bint __never_started_or_killed(self)
+    cdef bint __start_completed(self)
+
+    cdef __cancel_start(self)
+
+    cdef _report_result(self, object result)
+    cdef _report_error(self, tuple exc_info)
+
+
+@cython.final
+@cython.internal
+cdef class _dummy_event:
+    cdef readonly bint pending
+    cdef readonly bint active
+
+    cpdef stop(self)
+    cpdef start(self, cb)
+    cpdef close(self)
+
+cdef _dummy_event _cancelled_start_event
+cdef _dummy_event _start_completed_event
+
+
+@cython.locals(diehards=list)
+cdef _killall3(list greenlets, object exception, object waiter)
+cdef _killall(list greenlets, object exception)
+
+@cython.locals(done=list)
+cpdef joinall(greenlets, timeout=*, raise_error=*, count=*)

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -132,7 +132,8 @@ class Greenlet(greenlet):
 
     spawning_stack_limit = 10
 
-    def __init__(self, run=None, *args, **kwargs): # pylint:disable=keyword-arg-before-vararg
+    # pylint:disable=keyword-arg-before-vararg,super-init-not-called
+    def __init__(self, run=None, *args, **kwargs):
         """
         Greenlet(run=None, *args, **kwargs) -> Greenlet
 

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2012 Denis Bilenko. See LICENSE for details.
+# cython: auto_pickle=False
 from __future__ import absolute_import
 
-from collections import deque
 import sys
 from weakref import ref as wref
 
@@ -12,7 +12,6 @@ from greenlet import getcurrent
 from gevent._compat import PY3
 from gevent._compat import PYPY
 from gevent._compat import reraise
-from gevent._util import Lazy
 from gevent._tblib import dump_traceback
 from gevent._tblib import load_traceback
 from gevent.hub import GreenletExit
@@ -22,8 +21,6 @@ from gevent.hub import get_hub
 from gevent.hub import iwait
 from gevent.hub import wait
 from gevent.timeout import Timeout
-
-
 
 __all__ = [
     'Greenlet',
@@ -38,7 +35,8 @@ if PYPY:
 
 
 class SpawnedLink(object):
-    """A wrapper around link that calls it in another greenlet.
+    """
+    A wrapper around link that calls it in another greenlet.
 
     Can be called only from main loop.
     """
@@ -93,7 +91,6 @@ class FailureSpawnedLink(SpawnedLink):
         if not source.successful():
             return SpawnedLink.__call__(self, source)
 
-
 class _Frame(object):
 
     __slots__ = ('f_code', 'f_lineno', 'f_back')
@@ -111,55 +108,11 @@ class Greenlet(greenlet):
     """
     # pylint:disable=too-many-public-methods,too-many-instance-attributes
 
-    #: A dictionary that is shared between all the greenlets
-    #: in a "spawn tree", that is, a spawning greenlet and all
-    #: its descendent greenlets. All children of the main (root)
-    #: greenlet start their own spawn trees. Assign a new dictionary
-    #: to this attribute on an instance of this class to create a new
-    #: spawn tree (as far as locals are concerned).
-    #:
-    #: .. versionadded:: 1.3a2
-    spawn_tree_locals = None
-
-    #: A weak-reference to the greenlet that was current when this object
-    #: was created. Note that the :attr:`parent` attribute is always the
-    #: hub.
-    #:
-    #: .. versionadded:: 1.3a2
-    spawning_greenlet = None
-
-    #: A lightweight frame-like object capturing the stack when
-    #: this greenlet was created as well as the stack when the spawning
-    #: greenlet was created (if applicable). This can be passed to
-    #: :func:`traceback.print_stack`.
-    #:
-    #: .. versionadded:: 1.3a2
-    spawning_stack = None
-
-    #: A class attribute specifying how many levels of the spawning
-    #: stack will be kept. Specify a smaller number for higher performance,
-    #: specify a larger value for improved debugging.
-    #:
-    #: .. versionadded:: 1.3a2
     spawning_stack_limit = 10
-
-    value = None
-    _exc_info = ()
-    _notifier = None
-
-    #: An event, such as a timer or a callback that fires. It is established in
-    #: start() and start_later() as those two objects, respectively.
-    #: Once this becomes non-None, the Greenlet cannot be started again. Conversely,
-    #: kill() and throw() check for non-None to determine if this object has ever been
-    #: scheduled for starting. A placeholder _dummy_event is assigned by them to prevent
-    #: the greenlet from being started in the future, if necessary.
-    _start_event = None
-    args = ()
-    _kwargs = None
 
     def __init__(self, run=None, *args, **kwargs): # pylint:disable=keyword-arg-before-vararg
         """
-        Greenlet constructor.
+        Greenlet(run=None, *args, **kwargs) -> Greenlet
 
         :param args: The arguments passed to the ``run`` function.
         :param kwargs: The keyword arguments passed to the ``run`` function.
@@ -170,6 +123,53 @@ class Greenlet(greenlet):
             The ``run`` argument to the constructor is now verified to be a callable
             object. Previously, passing a non-callable object would fail after the greenlet
             was spawned.
+
+        .. attribute:: value
+
+            Holds the value returned by the function if the greenlet has
+            finished successfully. Until then, or if it finished in error, ``None``.
+
+            .. tip:: Recall that a greenlet killed with the default
+                     :class:`GreenletExit` is considered to have finished
+                     successfully, and the ``GreenletExit`` exception will be
+                     its value.
+
+
+        .. attribute:: spawn_tree_locals
+
+            A dictionary that is shared between all the greenlets
+            in a "spawn tree", that is, a spawning greenlet and all
+            its descendent greenlets. All children of the main (root)
+            greenlet start their own spawn trees. Assign a new dictionary
+            to this attribute on an instance of this class to create a new
+            spawn tree (as far as locals are concerned).
+
+            .. versionadded:: 1.3a2
+
+        .. attribute:: spawning_greenlet
+
+            A weak-reference to the greenlet that was current when this object
+            was created. Note that the :attr:`parent` attribute is always the
+            hub.
+
+            .. versionadded:: 1.3a2
+
+        .. attribute:: spawning_stack
+
+           A lightweight frame-like object capturing the stack when
+           this greenlet was created as well as the stack when the spawning
+           greenlet was created (if applicable). This can be passed to
+           :func:`traceback.print_stack`.
+
+            .. versionadded:: 1.3a2
+
+        .. attribute:: spawning_stack_limit
+
+            A class attribute specifying how many levels of the spawning
+            stack will be kept. Specify a smaller number for higher performance,
+            specify a larger value for improved debugging.
+
+            .. versionadded:: 1.3a2
         """
         # greenlet.greenlet(run=None, parent=None)
         # Calling it with both positional arguments instead of a keyword
@@ -192,8 +192,14 @@ class Greenlet(greenlet):
         # 2.7.14      : Mean +- std dev: 14.8 us +- 0.5 us  -> 10.2x
         # PyPy2 5.10.0: Mean +- std dev: 3.24 us +- 0.17 us ->  1.5x
 
+        # Compiling with Cython gets us to these numbers:
+        # 3.6.4        : Mean +- std dev: 4.36 us +- 0.23 us
+        # 2.7.12       : Mean +- std dev: 3.81 us +- 0.15 us
+        # PyPy2 5.10.0 : Mean +- std dev: 3.63 us +- 0.22 us
 
-        greenlet.__init__(self, None, get_hub())
+
+        #greenlet.__init__(self, None, get_hub())
+        super(Greenlet, self).__init__(None, get_hub())
 
         if run is not None:
             self._run = run
@@ -204,10 +210,21 @@ class Greenlet(greenlet):
         if not callable(self._run):
             raise TypeError("The run argument or self._run must be callable")
 
-        if args:
-            self.args = args
-        if kwargs:
-            self._kwargs = kwargs
+        #: An event, such as a timer or a callback that fires. It is established in
+        #: start() and start_later() as those two objects, respectively.
+        #: Once this becomes non-None, the Greenlet cannot be started again. Conversely,
+        #: kill() and throw() check for non-None to determine if this object has ever been
+        #: scheduled for starting. A placeholder _dummy_event is assigned by them to prevent
+        #: the greenlet from being started in the future, if necessary.
+        self._start_event = None
+        self.args = args
+        self._kwargs = kwargs
+        self.value = None
+        self._exc_info = ()
+        self._notifier = None
+
+
+        self._links = []
 
         spawner = getcurrent()
         self.spawning_greenlet = wref(spawner)
@@ -242,13 +259,6 @@ class Greenlet(greenlet):
     def kwargs(self):
         return self._kwargs or {}
 
-    @Lazy
-    def _links(self):
-        return deque()
-
-    def _has_links(self):
-        return '_links' in self.__dict__ and self._links
-
     def _raise_exception(self):
         reraise(*self.exc_info)
 
@@ -257,9 +267,14 @@ class Greenlet(greenlet):
         # needed by killall
         return self.parent.loop
 
-    def __bool__(self):
-        return self._start_event is not None and self._exc_info is Greenlet._exc_info
-    __nonzero__ = __bool__
+    def __nonzero__(self):
+        return self._start_event is not None and self._exc_info == ()
+    try:
+        __bool__ = __nonzero__ # Python 3
+    except NameError: # pragma: no cover
+        # When we're compiled with Cython, the __nonzero__ function
+        # goes directly into the slot and can't be accessed by name.
+        pass
 
     ### Lifecycle
 
@@ -269,38 +284,33 @@ class Greenlet(greenlet):
         def dead(self):
             if self._greenlet__main:
                 return False
-            if self.__start_cancelled_by_kill or self.__started_but_aborted:
+            if self.__start_cancelled_by_kill() or self.__started_but_aborted():
                 return True
 
             return self._greenlet__started and not _continulet.is_pending(self)
     else:
         @property
         def dead(self):
-            return self.__start_cancelled_by_kill or self.__started_but_aborted or greenlet.dead.__get__(self)
+            return self.__start_cancelled_by_kill() or self.__started_but_aborted() or greenlet.dead.__get__(self)
 
-    @property
     def __never_started_or_killed(self):
         return self._start_event is None
 
-    @property
     def __start_pending(self):
         return (self._start_event is not None
                 and (self._start_event.pending or getattr(self._start_event, 'active', False)))
 
-    @property
     def __start_cancelled_by_kill(self):
         return self._start_event is _cancelled_start_event
 
-    @property
     def __start_completed(self):
         return self._start_event is _start_completed_event
 
-    @property
     def __started_but_aborted(self):
-        return (not self.__never_started_or_killed # we have been started or killed
-                and not self.__start_cancelled_by_kill # we weren't killed, so we must have been started
-                and not self.__start_completed # the start never completed
-                and not self.__start_pending) # and we're not pending, so we must have been aborted
+        return (not self.__never_started_or_killed() # we have been started or killed
+                and not self.__start_cancelled_by_kill() # we weren't killed, so we must have been started
+                and not self.__start_completed() # the start never completed
+                and not self.__start_pending()) # and we're not pending, so we must have been aborted
 
     def __cancel_start(self):
         if self._start_event is None:
@@ -317,7 +327,7 @@ class Greenlet(greenlet):
 
     def __handle_death_before_start(self, *args):
         # args is (t, v, tb) or simply t or v
-        if self._exc_info is Greenlet._exc_info and self.dead:
+        if self._exc_info == () and self.dead:
             # the greenlet was never switched to before and it will never be, _report_error was not called
             # the result was not set and the links weren't notified. let's do it here.
             # checking that self.dead is true is essential, because throw() does not necessarily kill the greenlet
@@ -397,8 +407,9 @@ class Greenlet(greenlet):
 
     @property
     def exception(self):
-        """Holds the exception instance raised by the function if the greenlet has finished with an error.
-        Otherwise ``None``.
+        """
+        Holds the exception instance raised by the function if the
+        greenlet has finished with an error. Otherwise ``None``.
         """
         return self._exc_info[1] if self._exc_info else None
 
@@ -444,7 +455,12 @@ class Greenlet(greenlet):
             self._start_event = self.parent.loop.run_callback(self.switch)
 
     def start_later(self, seconds):
-        """Schedule the greenlet to run in the future loop iteration *seconds* later"""
+        """
+        start_later(seconds) -> None
+
+        Schedule the greenlet to run in the future loop iteration
+        *seconds* later
+        """
         if self._start_event is None:
             self._start_event = self.parent.loop.timer(seconds)
             self._start_event.start(self.switch)
@@ -539,11 +555,17 @@ class Greenlet(greenlet):
         # thus it should not raise when the greenlet is already killed (= not started)
 
     def get(self, block=True, timeout=None):
-        """Return the result the greenlet has returned or re-raise the exception it has raised.
+        """
+        get(block=True, timeout=None) -> object
 
-        If block is ``False``, raise :class:`gevent.Timeout` if the greenlet is still alive.
-        If block is ``True``, unschedule the current greenlet until the result is available
-        or the timeout expires. In the latter case, :class:`gevent.Timeout` is raised.
+        Return the result the greenlet has returned or re-raise the
+        exception it has raised.
+
+        If block is ``False``, raise :class:`gevent.Timeout` if the
+        greenlet is still alive. If block is ``True``, unschedule the
+        current greenlet until the result is available or the timeout
+        expires. In the latter case, :class:`gevent.Timeout` is
+        raised.
         """
         if self.ready():
             if self.successful():
@@ -577,8 +599,11 @@ class Greenlet(greenlet):
             self._raise_exception()
 
     def join(self, timeout=None):
-        """Wait until the greenlet finishes or *timeout* expires.
-        Return ``None`` regardless.
+        """
+        join(timeout=None) -> None
+
+        Wait until the greenlet finishes or *timeout* expires. Return
+        ``None`` regardless.
         """
         if self.ready():
             return
@@ -604,7 +629,7 @@ class Greenlet(greenlet):
     def _report_result(self, result):
         self._exc_info = (None, None, None)
         self.value = result
-        if self._has_links() and not self._notifier:
+        if self._links and not self._notifier:
             self._notifier = self.parent.loop.run_callback(self._notify_links)
 
     def _report_error(self, exc_info):
@@ -614,7 +639,7 @@ class Greenlet(greenlet):
 
         self._exc_info = exc_info[0], exc_info[1], dump_traceback(exc_info[2])
 
-        if self._has_links() and not self._notifier:
+        if self._links and not self._notifier:
             self._notifier = self.parent.loop.run_callback(self._notify_links)
 
         try:
@@ -635,8 +660,8 @@ class Greenlet(greenlet):
             self._report_result(result)
         finally:
             self.__dict__.pop('_run', None)
-            self.__dict__.pop('args', None)
-            self.__dict__.pop('kwargs', None)
+            self.args = None
+            self._kwargs = None
 
     def _run(self):
         """Subclasses may override this method to take any number of arguments and keyword arguments.
@@ -692,13 +717,23 @@ class Greenlet(greenlet):
         self.link(callback, SpawnedLink=SpawnedLink)
 
     def link_exception(self, callback, SpawnedLink=FailureSpawnedLink):
-        """Like :meth:`link` but *callback* is only notified when the greenlet dies because of an unhandled exception."""
+        """
+        Like :meth:`link` but *callback* is only notified when the
+        greenlet dies because of an unhandled exception.
+        """
         # pylint:disable=redefined-outer-name
         self.link(callback, SpawnedLink=SpawnedLink)
 
     def _notify_links(self):
         while self._links:
-            link = self._links.popleft() # pylint:disable=no-member
+            # Early links are allowed to remove later links
+            # before we get to them, and they're also allowed to
+            # add new links, so we have to be careful about iterating.
+
+            # We don't expect this list to be very large, so the time spent
+            # manipulating it should be small. a deque is probably not justified.
+            # Cython has optimizations to transform this into a memmove anyway.
+            link = self._links.pop(0)
             try:
                 link(self)
             except: # pylint:disable=bare-except
@@ -706,8 +741,10 @@ class Greenlet(greenlet):
 
 
 class _dummy_event(object):
-    pending = False
-    active = False
+    __slots__ = ('pending', 'active')
+
+    def __init__(self):
+        self.pending = self.active = False
 
     def stop(self):
         pass
@@ -715,11 +752,11 @@ class _dummy_event(object):
     def start(self, cb): # pylint:disable=unused-argument
         raise AssertionError("Cannot start the dummy event")
 
-    close = stop
+    def close(self):
+        pass
 
 _cancelled_start_event = _dummy_event()
 _start_completed_event = _dummy_event()
-del _dummy_event
 
 
 def _kill(glet, exception, waiter):

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -674,6 +674,9 @@ class Greenlet(greenlet):
         # pylint: disable=method-hidden
         return
 
+    def has_links(self):
+        return len(self._links)
+
     def rawlink(self, callback):
         """Register a callable to be executed when the greenlet finishes execution.
 
@@ -707,6 +710,14 @@ class Greenlet(greenlet):
             self._links.remove(callback) # pylint:disable=no-member
         except ValueError:
             pass
+
+    def unlink_all(self):
+        """
+        Remove all the callbacks.
+
+        .. versionadded:: 1.3a2
+        """
+        del self._links[:]
 
     def link_value(self, callback, SpawnedLink=SuccessSpawnedLink):
         """

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -96,14 +96,17 @@ class TestUnlink(greentest.TestCase):
 
     def _test_func(self, p, link):
         link(dummy_test_func)
-        assert len(p._links) == 1, p._links
+        self.assertEqual(1, p.has_links())
+
         p.unlink(dummy_test_func)
-        assert not p._links, p._links
+        self.assertEqual(0, p.has_links())
 
         link(self.setUp)
-        assert len(p._links) == 1, p._links
+        self.assertEqual(1, p.has_links())
+
         p.unlink(self.setUp)
-        assert not p._links, p._links
+        self.assertEqual(0, p.has_links())
+
         p.kill()
 
     def test_func_link(self):
@@ -170,8 +173,7 @@ class TestReturn_link(LinksTestCase):
     p = None
 
     def cleanup(self):
-        while self.p._links:
-            self.p._links.pop()
+        self.p.unlink_all()
         self.p = None
 
     def test_return(self):

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -374,7 +374,8 @@ class TestStuff(greentest.TestCase):
         link(results.listener2)
         link(results.listener3)
         sleep(DELAY * 10)
-        assert results.results == [5], results.results
+        self.assertEqual([5], results.results)
+
 
     def test_multiple_listeners_error_unlink_Greenlet_link(self):
         p = gevent.spawn(lambda: 5)
@@ -515,14 +516,14 @@ class TestBasic(greentest.TestCase):
         assert g.exception is None
 
         gevent.sleep(0.001)
-        assert g
-        assert not g.dead
-        assert g.started
-        assert not g.ready()
-        assert not g.successful()
-        assert g.value is None
-        assert g.exception is None
-        assert not link_test
+        self.assertTrue(g)
+        self.assertFalse(g.dead, g)
+        self.assertTrue(g.started, g)
+        self.assertFalse(g.ready(), g)
+        self.assertFalse(g.successful(), g)
+        self.assertIsNone(g.value, g)
+        self.assertIsNone(g.exception, g)
+        self.assertFalse(link_test)
 
         gevent.sleep(0.02)
         assert not g

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -405,6 +405,8 @@ class A(object):
 
 hexobj = re.compile('-?0x[0123456789abcdef]+L?', re.I)
 
+class Subclass(gevent.Greenlet):
+    pass
 
 class TestStr(greentest.TestCase):
 
@@ -427,6 +429,17 @@ class TestStr(greentest.TestCase):
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
         self.assertEqual(str_g, '<Greenlet at X: <bound method A.method of <module.A object at X>>>')
+
+    def test_subclass(self):
+        g = Subclass()
+        str_g = hexobj.sub('X', str(g))
+        str_g = str_g.replace(__name__, 'module')
+        self.assertEqual(str_g, '<Subclass at X: _run>')
+
+        g = Subclass(None, 'question', answer=42)
+        str_g = hexobj.sub('X', str(g))
+        str_g = str_g.replace(__name__, 'module')
+        self.assertEqual(str_g, "<Subclass at X: _run('question', answer=42)>")
 
 
 class TestJoin(AbstractGenericWaitTestCase):

--- a/src/greentest/test__issue330.py
+++ b/src/greentest/test__issue330.py
@@ -1,67 +1,80 @@
 # A greenlet that's killed before it is ever started
 # should never be switched to
 import gevent
-
-switched_to = [False, False]
-
-
-def runner(i):
-    switched_to[i] = True
+import greentest
 
 
-def check(g, g2):
-    gevent.joinall((g, g2))
-    assert switched_to == [False, False], switched_to
-
-    # They both have a GreenletExit as their value
-    assert isinstance(g.value, gevent.GreenletExit)
-    assert isinstance(g2.value, gevent.GreenletExit)
-    # They both have no reported exc_info
-    assert g._exc_info == (None, None, None)
-    assert g2._exc_info == (None, None, None)
-    assert g._exc_info is not type(g)._exc_info
-    assert g2._exc_info is not type(g2)._exc_info
-
-    switched_to[:] = [False, False]
-
-g = gevent.spawn(runner, 0) # create but do not switch to
-g2 = gevent.spawn(runner, 1) # create but do not switch to
-# Using gevent.kill
-gevent.kill(g)
-gevent.kill(g2)
-check(g, g2)
-
-# killing directly
-g = gevent.spawn(runner, 0)
-g2 = gevent.spawn(runner, 1)
-g.kill()
-g2.kill()
-check(g, g2)
-
-# throwing
-g = gevent.spawn(runner, 0)
-g2 = gevent.spawn(runner, 1)
-g.throw(gevent.GreenletExit)
-g2.throw(gevent.GreenletExit)
-check(g, g2)
-
-
-# Killing with gevent.kill gets the right exception
 class MyException(Exception):
     pass
 
+class TestSwitch(greentest.TestCase):
 
-def catcher():
-    try:
-        while True:
-            gevent.sleep(0)
-    except Exception as e:
-        switched_to[0] = e
+    def setUp(self):
+        self.switched_to = [False, False]
+        self.caught = None
 
-g = gevent.spawn(catcher)
-g.start()
-gevent.sleep()
-gevent.kill(g, MyException())
-gevent.sleep()
+    def runner(self, i):
+        self.switched_to[i] = True
 
-assert isinstance(switched_to[0], MyException), switched_to
+    def check(self, g, g2):
+        gevent.joinall((g, g2))
+        self.assertEqual([False, False], self.switched_to)
+
+        # They both have a GreenletExit as their value
+        self.assertIsInstance(g.value, gevent.GreenletExit)
+        self.assertIsInstance(g2.value, gevent.GreenletExit)
+
+        # They both have no reported exc_info
+        self.assertIsNone(g.exc_info)
+        self.assertIsNone(g2.exc_info)
+        self.assertIsNone(g.exception)
+        self.assertIsNone(g2.exception)
+
+
+    def test_gevent_kill(self):
+        g = gevent.spawn(self.runner, 0) # create but do not switch to
+        g2 = gevent.spawn(self.runner, 1) # create but do not switch to
+        # Using gevent.kill
+        gevent.kill(g)
+        gevent.kill(g2)
+        self.check(g, g2)
+
+    def test_greenlet_kill(self):
+        # killing directly
+        g = gevent.spawn(self.runner, 0)
+        g2 = gevent.spawn(self.runner, 1)
+        g.kill()
+        g2.kill()
+        self.check(g, g2)
+
+    def test_throw(self):
+        # throwing
+        g = gevent.spawn(self.runner, 0)
+        g2 = gevent.spawn(self.runner, 1)
+        g.throw(gevent.GreenletExit)
+        g2.throw(gevent.GreenletExit)
+        self.check(g, g2)
+
+
+    def catcher(self):
+        try:
+            while True:
+                gevent.sleep(0)
+        except MyException as e:
+            self.caught = e
+
+    def test_kill_exception(self):
+        # Killing with gevent.kill gets the right exception
+
+        g = gevent.spawn(self.catcher)
+        g.start()
+        gevent.sleep()
+        gevent.kill(g, MyException())
+        gevent.sleep()
+
+        self.assertIsInstance(self.caught, MyException)
+        self.assertIsNone(g.exception, MyException)
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/greentest/test__local.py
+++ b/src/greentest/test__local.py
@@ -273,7 +273,7 @@ class GeventLocalTestCase(greentest.TestCase):
             self.assertEqual(count, len(deleted_sentinels))
 
             # The links were removed as well.
-            self.assertEqual(list(running_greenlet._links), [])
+            self.assertFalse(running_greenlet.has_links())
 
 
         running_greenlet = gevent.spawn(demonstrate_my_local)

--- a/src/greentest/test__util.py
+++ b/src/greentest/test__util.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 gevent contributes
+# See LICENSE for details.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import greentest
+
+import gevent
+from gevent import util
+
+
+class TestFormat(greentest.TestCase):
+
+    def test_basic(self):
+        lines = util.format_run_info()
+
+        value = '\n'.join(lines)
+        self.assertIn('Threads', value)
+        self.assertIn('Greenlets', value)
+
+        # because it's a raw greenlet, we have no data for it.
+        self.assertNotIn("Spawned at", value)
+        self.assertNotIn("Parent greenlet", value)
+        self.assertNotIn("Spawn Tree Locals", value)
+
+    def test_with_Greenlet(self):
+        def root():
+            gevent.getcurrent().spawn_tree_locals['a value'] = 42
+            g = gevent.spawn(util.format_run_info)
+            g.join()
+            return g.value
+
+        g = gevent.spawn(root)
+        g.join()
+        value = '\n'.join(g.value)
+
+        self.assertIn("Spawned at", value)
+        self.assertIn("Parent greenlet", value)
+        self.assertIn("Spawn Tree Locals", value)
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/greentest/test__util.py
+++ b/src/greentest/test__util.py
@@ -11,7 +11,7 @@ import greentest
 import gevent
 from gevent import util
 
-
+@greentest.skipOnPyPy("5.10.x is *very* slow formatting stacks")
 class TestFormat(greentest.TestCase):
 
     def test_basic(self):

--- a/src/greentest/tests_that_dont_monkeypatch.txt
+++ b/src/greentest/tests_that_dont_monkeypatch.txt
@@ -13,3 +13,4 @@ test__socket_errors.py
 test__socket_send_memoryview.py
 test__socket_timeout.py
 test__examples.py
+test__issue330.py

--- a/src/greentest/tests_that_dont_use_resolver.txt
+++ b/src/greentest/tests_that_dont_use_resolver.txt
@@ -126,3 +126,4 @@ test_asyncore.py
 
 test___config.py
 test__destroy_default_loop.py
+test__util.py


### PR DESCRIPTION
This partially addressed #755. I will address the ID portion in a separate PR.

This slowed down spawning of greenlets a fair amount (8-10x) so to get the speed back close to where it was, that module is now compiled with Cython.

Raw timing before:
```
 python -m perf timeit -s 'import gevent' 'gevent.Greenlet()'
 3.6.4       : Mean +- std dev: 1.08 us +- 0.05 us
 2.7.14      : Mean +- std dev: 1.44 us +- 0.06 us
 PyPy2 5.10.0: Mean +- std dev: 2.14 ns +- 0.08 ns
```

Current timing:
```
3.6.4        : Mean +- std dev: 3.63 us +- 0.14 us
2.7.14       : Mean +- std dev: 3.37 us +- 0.20 us
PyPy2 5.10.0 : Mean +- std dev: 4.44 us +- 0.28 us
```

So approximately 3x slower in relative terms, but still pretty fast in absolute terms. This is very artificial, of course. Slightly less artificial is `bench_spawn.py`. Here's timings for 3.6.4 before:
```
python bench_spawn.py eventlet --ignore-import-errors
spawning: 11.93 microseconds per greenlet

python bench_spawn.py gevent --ignore-import-errors
spawning: 3.39 microseconds per greenlet

python bench_spawn.py geventpool --ignore-import-errors
spawning: 8.71 microseconds per greenlet
 joining: 7.34 microseconds per greenlet

python bench_spawn.py geventraw --ignore-import-errors
spawning: 2.09 microseconds per greenlet

python bench_spawn.py --with-kwargs eventlet
spawning: 12.06 microseconds per greenlet

python bench_spawn.py --with-kwargs gevent
spawning: 4.62 microseconds per greenlet

python bench_spawn.py --with-kwargs geventpool
spawning: 10.25 microseconds per greenlet
 joining: 7.14 microseconds per greenlet

python bench_spawn.py --with-kwargs geventraw
spawning: 3.27 microseconds per greenlet
```

And now:
```
python ./bench_spawn.py eventlet 
spawning: 11.63 microseconds per greenlet

python ./bench_spawn.py gevent
spawning: 8.99 microseconds per greenlet

python ./bench_spawn.py geventpool 
spawning: 11.76 microseconds per greenlet
 joining: 5.37 microseconds per greenlet

python ./bench_spawn.py geventraw
spawning: 4.62 microseconds per greenlet

python ./bench_spawn.py --with-kwargs eventlet 
spawning: 12.15 microseconds per greenlet

python ./bench_spawn.py --with-kwargs gevent
spawning: 9.23 microseconds per greenlet

python ./bench_spawn.py --with-kwargs geventpool
spawning: 12.15 microseconds per greenlet
 joining: 5.35 microseconds per greenlet

python ./bench_spawn.py --with-kwargs geventraw
spawning: 5.24 microseconds per greenlet
```

Again, some slowdown, but that attenuates as you use more sophisticated methods. Overall the comparison looks reasonable to me based on the benefits. And joining got faster!