### PR TITLE
Speed of gevent.local.local more, especially for subclasses (2-3x faster)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,7 +105,8 @@
 
 - Simple subclasses of ``gevent.local.local`` now have the same
   (substantially improved) performance characteristics of plain
-  ``gevent.local.local`` itself. If there are any compatibility
+  ``gevent.local.local`` itself, making them 2 to 3 times faster than
+  before. See :pr:`1117`. If there are any compatibility
   problems, please open issues.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,11 @@
   Hashemi and Kurt Rose. See :issue:`755`. As always, feedback is
   appreciated.
 
+- Simple subclasses of ``gevent.local.local`` now have the same
+  (substantially improved) performance characteristics of plain
+  ``gevent.local.local`` itself. If there are any compatibility
+  problems, please open issues.
+
 
 1.3a1 (2018-01-27)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,6 @@ SEMAPHORE = Extension(name="gevent._semaphore",
                       depends=['src/gevent/_semaphore.pxd'])
 SEMAPHORE = cythonize1(SEMAPHORE)
 
-LOCAL = Extension(name="gevent.local",
-                  sources=["src/gevent/local.py"],
-                  depends=['src/gevent/local.pxd'])
-LOCAL = cythonize1(LOCAL)
-
 # The sysconfig dir is not enough if we're in a virtualenv
 # See https://github.com/pypa/pip/issues/4610
 include_dirs = [sysconfig.get_path("include")]
@@ -68,6 +63,13 @@ venv_include_dir = os.path.join(sys.prefix, 'include', 'site',
 venv_include_dir = os.path.abspath(venv_include_dir)
 if os.path.exists(venv_include_dir):
     include_dirs.append(venv_include_dir)
+
+
+LOCAL = Extension(name="gevent.local",
+                  sources=["src/gevent/local.py"],
+                  depends=['src/gevent/local.pxd'],
+                  include_dirs=include_dirs)
+LOCAL = cythonize1(LOCAL)
 
 
 GREENLET = Extension(name="gevent.greenlet",

--- a/src/gevent/_ident.py
+++ b/src/gevent/_ident.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 gevent contributors. See LICENSE for details.
+# cython: auto_pickle=False,embedsignature=True,always_allow_keywords=False
 
 from __future__ import absolute_import
 from __future__ import division

--- a/src/gevent/greenlet.pxd
+++ b/src/gevent/greenlet.pxd
@@ -2,11 +2,30 @@
 
 cimport cython
 from gevent._ident cimport IdentRegistry
+cdef bint _greenlet_imported
+cdef bint _PYPY
 
 cdef extern from "greenlet/greenlet.h":
 
-  ctypedef class greenlet.greenlet [object PyGreenlet]:
-      pass
+    ctypedef class greenlet.greenlet [object PyGreenlet]:
+        pass
+
+    # These are actually macros and so much be included
+    # (defined) in each .pxd, as are the two functions
+    # that call them.
+    greenlet PyGreenlet_GetCurrent()
+    void PyGreenlet_Import()
+
+cdef inline greenlet getcurrent():
+    return PyGreenlet_GetCurrent()
+
+cdef inline void greenlet_init():
+    global _greenlet_imported
+    if not _greenlet_imported:
+        PyGreenlet_Import()
+        _greenlet_imported = True
+
+cdef void _init()
 
 cdef class SpawnedLink:
     cdef public object callback
@@ -87,7 +106,6 @@ cdef class Greenlet(greenlet):
 cdef _greenlet__init__
 cdef get_hub
 cdef wref
-cdef getcurrent
 
 cdef Timeout
 cdef dump_traceback


### PR DESCRIPTION


Do this with some cython tricks and some caching of type attributes.
Cython 0.28 compiles this code to be quite a bit faster than Cython
0.27 does (the below uses 0.28), but it's still a win on both.

The type caching could potentially be a compatibility issue, but in
practice I suspect it won't be.

Benchmarks on 3.6:


| Benchmark          | 3.6              | 3.6 This Branch             |
|--------------------|------------------|-----------------------------|
| getattr gevent     | 190 ns           | 158 ns: 1.20x faster (-17%) |
| setattr gevent     | 180 ns           | 165 ns: 1.09x faster (-8%)  |
| getattr gevent sub | 540 ns           | 175 ns: 3.09x faster (-68%) |
| setattr gevent sub | 528 ns           | 179 ns: 2.95x faster (-66%) |
| setattr native     | 80.8 ns          | 78.8 ns: 1.03x faster (-2%) |


Not significant (3): getattr native; getattr native sub; setattr native sub

Benchmarks on 2.7:

| Benchmark          | local_27_master2 | local_27_tweak2             |
|--------------------|------------------|-----------------------------|
| getattr gevent     | 162 ns           | 158 ns: 1.03x faster (-3%)  |
| setattr gevent     | 173 ns           | 165 ns: 1.04x faster (-4%)  |
| getattr gevent sub | 471 ns           | 181 ns: 2.61x faster (-62%) |
| setattr gevent sub | 462 ns           | 190 ns: 2.44x faster (-59%) |
| getattr native     | 87.4 ns          | 89.7 ns: 1.03x slower (+3%) |
| setattr native     | 133 ns           | 110 ns: 1.20x faster (-17%) |
| getattr native sub | 101 ns           | 97.9 ns: 1.03x faster (-3%) |
| setattr native sub | 118 ns           | 111 ns: 1.06x faster (-6%)  |


PyPy unfortunately shows as a little slower, though I'm not sure I
fully believe that:


| Benchmark          | local_pypy_master | local_pypy_tweak2           |
|--------------------|------------------|-----------------------------|
| getattr gevent     | 135 ns            | 157 ns: 1.16x slower (+16%) |
| setattr gevent     | 126 ns            | 162 ns: 1.28x slower (+28%) |
| getattr gevent sub | 150 ns            | 175 ns: 1.17x slower (+17%) |
| setattr gevent sub | 153 ns            | 183 ns: 1.20x slower (+20%) |
| getattr native     | 0.18 ns           | 0.19 ns: 1.05x slower (+5%) |
| setattr native     | 0.18 ns           | 0.20 ns: 1.06x slower (+6%) |
| getattr native sub | 0.18 ns           | 0.19 ns: 1.05x slower (+5%) |
| setattr native sub | 0.19 ns           | 0.18 ns: 1.06x faster (-6%) |
