### PR TITLE
Include locals in the debugging output.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,12 @@
   used when the environment variable ``PURE_PYTHON`` is set. This is
   not recommended except for debugging and testing. See :issue:`1118`.
 
+- Include the values of `gevent.local.local` objects associated with
+  each greenlet in `gevent.util.format_run_info`.
+
+- `gevent.Greenlet` objects now have a `gevent.Greenlet.name`
+  attribute that is included in the default repr.
+
 
 1.3a1 (2018-01-27)
 ==================

--- a/doc/gevent.rst
+++ b/doc/gevent.rst
@@ -36,6 +36,7 @@ generated.
 
 .. autoattribute:: Greenlet.exception
 .. autoattribute:: Greenlet.minimal_ident
+.. autoattribute:: Greenlet.name
 
 .. rubric:: Methods
 
@@ -97,8 +98,8 @@ __ https://greenlet.readthedocs.io/en/latest/#instantiation
 Spawn helpers
 =============
 
-.. autofunction:: spawn(function, *args, **kwargs)
-.. autofunction:: spawn_later(seconds, function, *args, **kwargs)
+.. autofunction:: spawn
+.. autofunction:: spawn_later
 .. autofunction:: spawn_raw
 
 

--- a/src/gevent/_util.py
+++ b/src/gevent/_util.py
@@ -5,6 +5,8 @@ internal gevent utilities, not for external use.
 
 from __future__ import print_function, absolute_import, division
 
+from functools import update_wrapper
+
 from gevent._compat import iteritems
 
 
@@ -110,6 +112,7 @@ class Lazy(object):
     """
     def __init__(self, func):
         self.data = (func, func.__name__)
+        update_wrapper(self, func)
 
     def __get__(self, inst, class_):
         if inst is None:
@@ -129,6 +132,7 @@ class readproperty(object):
 
     def __init__(self, func):
         self.func = func
+        update_wrapper(self, func)
 
     def __get__(self, inst, class_):
         if inst is None:

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -21,6 +21,7 @@ from gevent.hub import iwait
 from gevent.hub import wait
 from gevent.timeout import Timeout
 from gevent._util import Lazy
+from gevent._util import readproperty
 
 
 __all__ = [
@@ -312,6 +313,17 @@ class Greenlet(greenlet):
             self._ident = self._get_minimal_ident()
         return self._ident
 
+    @readproperty
+    def name(self):
+        """
+        The greenlet name. By default, a unique name is constructed using
+        the :attr:`minimal_ident`. You can assign a string to this
+        value to change it. It is shown in the `repr` of this object.
+
+        .. versionadded:: 1.3a2
+        """
+        return 'Greenlet-%d' % (self.minimal_ident)
+
     def _raise_exception(self):
         reraise(*self.exc_info)
 
@@ -428,7 +440,7 @@ class Greenlet(greenlet):
 
     def __repr__(self):
         classname = self.__class__.__name__
-        result = '<%s at %s' % (classname, hex(id(self)))
+        result = '<%s "%s" at %s' % (classname, self.name, hex(id(self)))
         formatted = self._formatinfo()
         if formatted:
             result += ': ' + formatted
@@ -526,6 +538,8 @@ class Greenlet(greenlet):
     @classmethod
     def spawn(cls, *args, **kwargs):
         """
+        spawn(function, *args, **kwargs) -> Greenlet
+
         Create a new :class:`Greenlet` object and schedule it to run ``function(*args, **kwargs)``.
         This can be used as ``gevent.spawn`` or ``Greenlet.spawn``.
 
@@ -542,8 +556,10 @@ class Greenlet(greenlet):
     @classmethod
     def spawn_later(cls, seconds, *args, **kwargs):
         """
-        Create and return a new Greenlet object scheduled to run ``function(*args, **kwargs)``
-        in the future loop iteration *seconds* later. This can be used as ``Greenlet.spawn_later``
+        spawn_later(seconds, function, *args, **kwargs) -> Greenlet
+
+        Create and return a new `Greenlet` object scheduled to run ``function(*args, **kwargs)``
+        in a future loop iteration *seconds* later. This can be used as ``Greenlet.spawn_later``
         or ``gevent.spawn_later``.
 
         The arguments are passed to :meth:`Greenlet.__init__`.

--- a/src/gevent/util.py
+++ b/src/gevent/util.py
@@ -78,7 +78,7 @@ def format_run_info():
     .. versionchanged:: 1.3a2
        Renamed from ``dump_stacks`` to reflect the fact that this
        prints additional information about greenlets, including their
-       spawning stack, parent, and any spawn tree locals.
+       spawning stack, parent, locals, and any spawn tree locals.
     """
 
     lines = []
@@ -112,10 +112,12 @@ def _format_thread_info(lines):
     del threads
 
 def _format_greenlet_info(lines):
+    # pylint:disable=too-many-locals
     from greenlet import greenlet
     import pprint
     import traceback
     import gc
+    from gevent.local import all_local_dicts_for_greenlet
 
     def _noop():
         return None
@@ -145,6 +147,12 @@ def _format_greenlet_info(lines):
             seen_locals.add(id(spawn_tree_locals))
             lines.append("Spawn Tree Locals:\n")
             lines.append(pprint.pformat(spawn_tree_locals))
+        gr_locals = all_local_dicts_for_greenlet(ob)
+        if gr_locals:
+            lines.append("Greenlet Locals:\n")
+            for (kind, idl), vals in gr_locals:
+                lines.append("\tLocal %s at %s\n" % (kind, hex(idl)))
+                lines.append("\t" + pprint.pformat(vals))
 
 
     del lines

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -418,34 +418,36 @@ class TestStr(greentest.TestCase):
 
     def test_function(self):
         g = gevent.Greenlet.spawn(dummy_test_func)
-        self.assertEqual(hexobj.sub('X', str(g)), '<Greenlet at X: dummy_test_func>')
+        self.assertTrue(hexobj.sub('X', str(g)).endswith('at X: dummy_test_func>'))
         assert_not_ready(g)
         g.join()
         assert_ready(g)
-        self.assertEqual(hexobj.sub('X', str(g)), '<Greenlet at X: dummy_test_func>')
+        self.assertTrue(hexobj.sub('X', str(g)).endswith(' at X: dummy_test_func>'))
 
     def test_method(self):
         g = gevent.Greenlet.spawn(A().method)
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertEqual(str_g, '<Greenlet at X: <bound method A.method of <module.A object at X>>>')
+        self.assertTrue(str_g.startswith('<Greenlet "Greenlet-'))
+        self.assertTrue(str_g.endswith('at X: <bound method A.method of <module.A object at X>>>'))
         assert_not_ready(g)
         g.join()
         assert_ready(g)
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertEqual(str_g, '<Greenlet at X: <bound method A.method of <module.A object at X>>>')
+        self.assertTrue(str_g.endswith('at X: <bound method A.method of <module.A object at X>>>'))
 
     def test_subclass(self):
         g = Subclass()
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertEqual(str_g, '<Subclass at X: _run>')
+        self.assertTrue(str_g.startswith('<Subclass '))
+        self.assertTrue(str_g.endswith('at X: _run>'))
 
         g = Subclass(None, 'question', answer=42)
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertEqual(str_g, "<Subclass at X: _run('question', answer=42)>")
+        self.assertTrue(str_g.endswith(" at X: _run('question', answer=42)>"))
 
 
 class TestJoin(AbstractGenericWaitTestCase):

--- a/src/greentest/test__hub.py
+++ b/src/greentest/test__hub.py
@@ -110,7 +110,8 @@ class TestWaiter(greentest.TestCase):
         waiter = Waiter()
         g = gevent.spawn(waiter.get)
         gevent.sleep(0)
-        assert str(waiter).startswith('<Waiter greenlet=<Greenlet at '), str(waiter)
+        self.assertTrue(str(waiter).startswith('<Waiter greenlet=<Greenlet "Greenlet-'))
+
         g.kill()
 
 

--- a/src/greentest/test__local.py
+++ b/src/greentest/test__local.py
@@ -308,6 +308,21 @@ class GeventLocalTestCase(greentest.TestCase):
 
         self.assertEqual(count, len(deleted_sentinels))
 
+    def test_local_dicts_for_greenlet(self):
+        import gevent
+        from gevent.local import all_local_dicts_for_greenlet
+        x = MyLocal()
+        x.foo = 42
+        del x.sentinel
+
+        if greentest.PYPY:
+            import gc
+            gc.collect()
+
+        results = all_local_dicts_for_greenlet(gevent.getcurrent())
+        self.assertEqual(results,
+                         [((MyLocal, id(x)), {'foo': 42})])
+
 @greentest.skipOnPurePython("Needs C extension")
 class TestCExt(greentest.TestCase):
 

--- a/src/greentest/test__util.py
+++ b/src/greentest/test__util.py
@@ -10,6 +10,11 @@ import greentest
 
 import gevent
 from gevent import util
+from gevent import local
+
+class MyLocal(local.local):
+    def __init__(self, foo):
+        self.foo = foo
 
 @greentest.skipOnPyPy("5.10.x is *very* slow formatting stacks")
 class TestFormat(greentest.TestCase):
@@ -27,19 +32,26 @@ class TestFormat(greentest.TestCase):
         self.assertNotIn("Spawn Tree Locals", value)
 
     def test_with_Greenlet(self):
+        rl = local.local()
+        rl.foo = 1
         def root():
+            l = MyLocal(42)
             gevent.getcurrent().spawn_tree_locals['a value'] = 42
             g = gevent.spawn(util.format_run_info)
             g.join()
             return g.value
 
         g = gevent.spawn(root)
+        g.name = 'Printer'
         g.join()
         value = '\n'.join(g.value)
 
         self.assertIn("Spawned at", value)
         self.assertIn("Parent greenlet", value)
         self.assertIn("Spawn Tree Locals", value)
+        self.assertIn("Greenlet Locals:", value)
+        self.assertIn('MyLocal', value)
+        self.assertIn("Printer", value) # The name is printed
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also let greenlets have a name.

Some tweaks to the local implementation to speed it up by 3-4%.