### PR TITLE
Run tests in 3.7 dev mode; cleanup resource warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,8 @@
   addition, all *timeout* values less than zero are interpreted like
   *None* (as they always were under libev). See :issue:`1127`.
 
+- Monkey-patching now defaults to patching ``threading.Event``.
+
 1.3a1 (2018-01-27)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -83,9 +83,9 @@ Running Tests
 There are a few different ways to run the tests. To simply run the
 tests on one version of Python during development, try this::
 
-  python setup.py develop
-  cd src/greentest
-  PYTHONPATH=.. python testrunner.py --config known_failures.py
+  (env) $ pip install -e .
+  (env) $ cd src/greentest
+  (env) $ python ./testrunner.py
 
 Before submitting a pull request, it's a good idea to run the tests
 across all supported versions of Python, and to check the code quality
@@ -100,7 +100,7 @@ coverage metrics through the `coverage.py`_ package. That would go
 something like this::
 
   cd src/greentest
-  PYTHONPATH=.. python testrunner.py --config known_failures.py --coverage
+  python testrunner.py --coverage
   coverage combine
   coverage html -i
   <open htmlcov/index.html>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -132,7 +132,7 @@ install:
   # target Python version and architecture
   # Note that psutil won't build under PyPy on Windows.
   - "%CMD_IN_ENV% pip install -e git+https://github.com/cython/cython.git@63cd3bbb5eac22b92808eeb90b512359e3def20a#egg=cython"
-  - "%CMD_IN_ENV% pip install -U setuptools wheel greenlet cffi dnspython idna"
+  - "%CMD_IN_ENV% pip install -U setuptools wheel greenlet cffi dnspython idna requests"
 
   - ps:
       if ("${env:PYTHON_ID}" -ne "pypy") {

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -26,6 +26,7 @@ psutil
 perf
 # Used in a test
 zope.interface
+requests
 # For viewing README.rst (restview --long-description),
 # CONTRIBUTING.rst, etc.
 # https://github.com/mgedmin/restview

--- a/examples/concurrent_download.py
+++ b/examples/concurrent_download.py
@@ -9,26 +9,21 @@ from gevent import monkey
 # patches stdlib (including socket and ssl modules) to cooperate with other greenlets
 monkey.patch_all()
 
-import sys
+import requests
 
-# Note that all of these redirect to HTTPS, so
+# Note that we're using HTTPS, so
 # this demonstrates that SSL works.
 urls = [
-    'http://www.google.com',
-    'http://www.apple.com',
-    'http://www.python.org'
+    'https://www.google.com/',
+    'https://www.apple.com/',
+    'https://www.python.org/'
 ]
 
-
-if sys.version_info[0] == 3:
-    from urllib.request import urlopen # pylint:disable=import-error,no-name-in-module
-else:
-    from urllib2 import urlopen # pylint: disable=import-error
 
 
 def print_head(url):
     print('Starting %s' % url)
-    data = urlopen(url).read()
+    data = requests.get(url).text
     print('%s: %s bytes: %r' % (url, len(data), data[:50]))
 
 jobs = [gevent.spawn(print_head, _url) for _url in urls]

--- a/src/gevent/_compat.py
+++ b/src/gevent/_compat.py
@@ -38,10 +38,13 @@ if PY3:
         if value.__traceback__ is not tb and tb is not None:
             raise value.with_traceback(tb)
         raise value
+    def exc_clear():
+        pass
 
 else:
     from gevent._util_py2 import reraise # pylint:disable=import-error,no-name-in-module
     reraise = reraise # export
+    exc_clear = sys.exc_clear
 
 ## Functions
 if PY3:

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -646,6 +646,7 @@ class SSLSocket(socket):
         SSL channel, and the address of the remote client."""
 
         newsock, addr = socket.accept(self)
+        newsock._drop_events()
         newsock = self._context.wrap_socket(newsock,
                                             do_handshake_on_connect=self.do_handshake_on_connect,
                                             suppress_ragged_eofs=self.suppress_ragged_eofs,

--- a/src/gevent/_sslgte279.py
+++ b/src/gevent/_sslgte279.py
@@ -625,6 +625,7 @@ class SSLSocket(socket):
         SSL channel, and the address of the remote client."""
 
         newsock, addr = socket.accept(self)
+        newsock._drop_events()
         newsock = self._context.wrap_socket(newsock,
                                             do_handshake_on_connect=self.do_handshake_on_connect,
                                             suppress_ragged_eofs=self.suppress_ragged_eofs,

--- a/src/gevent/hub.py
+++ b/src/gevent/hub.py
@@ -413,6 +413,11 @@ def set_hub(hub):
     _threadlocal.hub = hub
 
 
+class _dummy_greenlet(object):
+    def throw(self):
+        pass
+
+_dummy_greenlet = _dummy_greenlet()
 
 
 def _config(default, envvar):
@@ -637,11 +642,12 @@ class Hub(RawGreenlet):
             # See https://github.com/gevent/gevent/issues/1089
             return
         if watcher.callback is not None:
+            print('Scheduling close for', watcher, close_watcher)
             self.loop.run_callback(self._cancel_wait, watcher, error, close_watcher)
         elif close_watcher:
             watcher.close()
 
-    def _cancel_wait(self, watcher, error, close_watcher):
+    def _cancel_wait(self, watcher, error, close_watcher, _dummy_greenlet=_dummy_greenlet):
         # We have to check again to see if it was still active by the time
         # our callback actually runs.
         active = watcher.active
@@ -649,11 +655,9 @@ class Hub(RawGreenlet):
         if close_watcher:
             watcher.close()
         if active:
-            switch = cb
-            if switch is not None:
-                greenlet = getattr(switch, '__self__', None)
-                if greenlet is not None:
-                    greenlet.throw(error)
+            # The callback should be greenlet.switch(). It may or may not be None.
+            greenlet = getattr(cb, '__self__', _dummy_greenlet)
+            greenlet.throw(error)
 
     def run(self):
         """

--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -326,11 +326,11 @@ def _patch_existing_locks(threading):
                 o.owner = tid
 
 
-def patch_thread(threading=True, _threading_local=True, Event=False, logging=True,
+def patch_thread(threading=True, _threading_local=True, Event=True, logging=True,
                  existing_locks=True,
                  _warnings=None):
     """
-    patch_thread(threading=True, _threading_local=True, Event=False, logging=True, existing_locks=True) -> None
+    patch_thread(threading=True, _threading_local=True, Event=True, logging=True, existing_locks=True) -> None
 
     Replace the standard :mod:`thread` module to make it greenlet-based.
 
@@ -354,6 +354,8 @@ def patch_thread(threading=True, _threading_local=True, Event=False, logging=Tru
 
     .. versionchanged:: 1.1b1
         Add *logging* and *existing_locks* params.
+    .. versionchanged:: 1.3a2
+        ``Event`` defaults to True.
     """
     # XXX: Simplify
     # pylint:disable=too-many-branches,too-many-locals
@@ -666,7 +668,7 @@ def _check_repatching(**module_settings):
 
 
 def patch_all(socket=True, dns=True, time=True, select=True, thread=True, os=True, ssl=True, httplib=False,
-              subprocess=True, sys=False, aggressive=True, Event=False,
+              subprocess=True, sys=False, aggressive=True, Event=True,
               builtins=True, signal=True):
     """
     Do all of the default monkey patching (calls every other applicable
@@ -680,6 +682,8 @@ def patch_all(socket=True, dns=True, time=True, select=True, thread=True, os=Tru
        Issue a :mod:`warning <warnings>` if this function is called with ``os=False``
        and ``signal=True``. This will cause SIGCHLD handlers to not be called. This may
        be an error in the future.
+    .. versionchanged:: 1.3a2
+       ``Event`` defaults to True.
     """
     # pylint:disable=too-many-locals,too-many-branches
 

--- a/src/greentest/greentest/__init__.py
+++ b/src/greentest/greentest/__init__.py
@@ -43,6 +43,7 @@ from greentest.sysinfo import PY37
 
 from greentest.sysinfo import PYPY
 from greentest.sysinfo import PYPY3
+from greentest.sysinfo import CPYTHON
 
 from greentest.sysinfo import PLATFORM_SPECIFIC_SUFFIXES
 from greentest.sysinfo import NON_APPLICABLE_SUFFIXES

--- a/src/greentest/greentest/patched_tests_setup.py
+++ b/src/greentest/greentest/patched_tests_setup.py
@@ -804,6 +804,13 @@ if PY34:
             'test_socket.InterruptedSendTimeoutTest.testInterruptedSendmsgTimeout',
         ]
 
+        if TRAVIS:
+            # This has been seen to produce "Inconsistency detected by
+            # ld.so: dl-open.c: 231: dl_open_worker: Assertion
+            # `_dl_debug_initialize (0, args->nsid)->r_state ==
+            # RT_CONSISTENT' failed!" and fail.
+            'test_threading.ThreadTests.test_is_alive_after_fork',
+
     if TRAVIS:
         disabled_tests += [
             'test_subprocess.ProcessTestCase.test_double_close_on_error',

--- a/src/greentest/greentest/sysinfo.py
+++ b/src/greentest/greentest/sysinfo.py
@@ -25,6 +25,7 @@ import gevent.core
 from gevent import _compat as gsysinfo
 
 PYPY = gsysinfo.PYPY
+CPYTHON = not PYPY
 VERBOSE = sys.argv.count('-v') > 1
 WIN = gsysinfo.WIN
 LINUX = sys.platform.startswith('linux')

--- a/src/greentest/known_failures.py
+++ b/src/greentest/known_failures.py
@@ -171,6 +171,7 @@ if PYPY:
 
         if LIBUV:
             IGNORED_TESTS += [
+                # XXX: Re-enable this when we can investigate more.
                 # This has started crashing with a SystemError.
                 # I cannot reproduce with the same version on macOS
                 # and I cannot reproduce with the same version in a Linux vm.
@@ -178,6 +179,18 @@ if PYPY:
                 # https://bitbucket.org/pypy/pypy/issues/2769/systemerror-unexpected-internal-exception
                 'test__pywsgi.py',
             ]
+
+        IGNORED_TESTS += [
+            # XXX Re-enable these when we have more time to investigate.
+            # This test, which normally takes ~60s, sometimes
+            # hangs forever after running several tests. I cannot reproduce,
+            # it seems highly load dependent. Observed with both libev and libuv.
+            'test__threadpool.py',
+            # This test, which normally takes 4-5s, sometimes
+            # hangs forever after running two tests. I cannot reproduce,
+            # it seems highly load dependent. Observed with both libev and libuv.
+            'test_threading_2.py',
+        ]
 
     if PY3 and TRAVIS:
         FAILING_TESTS += [
@@ -226,6 +239,15 @@ if sys.version_info[:2] >= (3, 4) and APPVEYOR:
     FAILING_TESTS += [
         # Timing issues on appveyor
         'FLAKY test_selectors.py'
+    ]
+
+if sys.version_info == (3, 7, 0, 'beta', 2) and os.environ.get("PYTHONDEVMODE"):
+    # These crash when in devmode.
+    # See https://twitter.com/ossmkitty/status/970693025130311680
+    # https://bugs.python.org/issue33005
+    FAILING_TESTS += [
+        'test__monkey_sigchld_2.py',
+        'test__monkey_sigchld_3.py'
     ]
 
 if COVERAGE:

--- a/src/greentest/test___monkey_patching.py
+++ b/src/greentest/test___monkey_patching.py
@@ -49,6 +49,12 @@ def TESTRUNNER(tests=None):
         'timeout': TIMEOUT,
         'setenv': {
             'PYTHONPATH': PYTHONPATH,
+            # debug produces resource tracking warnings for the
+            # CFFI backends. On Python 2, many of the stdlib tests
+            # rely on refcounting to close sockets so they produce
+            # lots of noise. Python 3 is not completely immune;
+            # test_ftplib.py tends to produce warnings---and the Python 3
+            # test framework turns those into test failures!
             'GEVENT_DEBUG': 'error',
         }
     }
@@ -62,12 +68,10 @@ def TESTRUNNER(tests=None):
             util.log("Overriding %s from %s with file from %s", filename, directory, full_directory)
             continue
         yield basic_args + [filename], options.copy()
-        yield basic_args + ['--Event', filename], options.copy()
 
     options['cwd'] = full_directory
     for filename in version_tests:
         yield basic_args + [filename], options.copy()
-        yield basic_args + ['--Event', filename], options.copy()
 
 
 def main():

--- a/src/greentest/test__core_watcher.py
+++ b/src/greentest/test__core_watcher.py
@@ -1,81 +1,105 @@
 from __future__ import absolute_import, print_function
 
 import greentest
-from gevent import core
+from gevent import config
+from greentest.sysinfo import CFFI_BACKEND
 
-IS_CFFI = hasattr(core, 'libuv') or hasattr(core, 'libev')
+from gevent.core import READ # pylint:disable=no-name-in-module
+from gevent.core import WRITE # pylint:disable=no-name-in-module
+
 
 class Test(greentest.TestCase):
 
     __timeout__ = None
 
-    def test_types(self):
-        loop = core.loop(default=False)
-        lst = []
+    def setUp(self):
+        super(Test, self).setUp()
+        self.loop = config.loop(default=False)
+        self.timer = self.loop.timer(0.01)
 
-        io = loop.timer(0.01)
+    def tearDown(self):
+        if self.timer is not None:
+            self.timer.close()
+        if self.loop is not None:
+            self.loop.destroy()
+        self.loop = self.timer = None
+        super(Test, self).tearDown()
 
+    def test_non_callable_to_start(self):
         # test that cannot pass non-callable thing to start()
-        self.assertRaises(TypeError, io.start, None)
-        self.assertRaises(TypeError, io.start, 5)
-        # test that cannot set 'callback' to non-callable thing later either
-        io.start(lambda *args: lst.append(args))
-        self.assertEqual(io.args, ())
-        try:
-            io.callback = False
-            raise AssertionError('"io.callback = False" must raise TypeError')
-        except TypeError:
-            pass
-        try:
-            io.callback = 5
-            raise AssertionError('"io.callback = 5" must raise TypeError')
-        except TypeError:
-            pass
-        # test that args can be changed later
-        io.args = (1, 2, 3)
-        # test that only tuple and None are accepted by 'args' attribute
-        self.assertRaises(TypeError, setattr, io, 'args', 5)
-        self.assertEqual(io.args, (1, 2, 3))
+        self.assertRaises(TypeError, self.timer.start, None)
+        self.assertRaises(TypeError, self.timer.start, 5)
 
-        self.assertRaises(TypeError, setattr, io, 'args', [4, 5])
-        self.assertEqual(io.args, (1, 2, 3))
+    def test_non_callable_after_start(self):
+        # test that cannot set 'callback' to non-callable thing later either
+        lst = []
+        timer = self.timer
+        timer.start(lst.append)
+
+
+        with self.assertRaises(TypeError):
+            timer.callback = False
+
+        with self.assertRaises(TypeError):
+            timer.callback = 5
+
+    def test_args_can_be_changed_after_start(self):
+        lst = []
+        timer = self.timer
+        self.timer.start(lst.append)
+        self.assertEqual(timer.args, ())
+        timer.args = (1, 2, 3)
+        self.assertEqual(timer.args, (1, 2, 3))
+
+        # Only tuple can be args
+        with self.assertRaises(TypeError):
+            timer.args = 5
+        with self.assertRaises(TypeError):
+            timer.args = [4, 5]
+
+        self.assertEqual(timer.args, (1, 2, 3))
+
         # None also works, means empty tuple
         # XXX why?
-        io.args = None
-        self.assertEqual(io.args, None)
-        time_f = getattr(core, 'time', loop.now)
-        start = time_f()
-        loop.run()
-        took = time_f() - start
-        self.assertEqual(lst, [()])
-        if hasattr(core, 'time'):
-            # only useful on libev
-            assert took < 1, took
+        timer.args = None
+        self.assertEqual(timer.args, None)
 
-        io.start(reset, io, lst)
-        del io
+
+    def test_run(self):
+        loop = self.loop
+        lst = []
+
+        self.timer.start(lambda *args: lst.append(args))
+
+        loop.run()
+        loop.update_now()
+
+        self.assertEqual(lst, [()])
+
+        # Even if we lose all references to it, the ref in the callback
+        # keeps it alive
+        self.timer.start(reset, self.timer, lst)
+        self.timer = None
         loop.run()
         self.assertEqual(lst, [(), 25])
-        loop.destroy()
 
     def test_invalid_fd(self):
-        loop = core.loop(default=False)
+        loop = self.loop
 
         # Negative case caught everywhere. ValueError
         # on POSIX, OSError on Windows Py3, IOError on Windows Py2
         with self.assertRaises((ValueError, OSError, IOError)):
-            loop.io(-1, core.READ)
+            loop.io(-1, READ)
 
-        loop.destroy()
 
     @greentest.skipOnWindows("Stdout can't be watched on Win32")
     def test_reuse_io(self):
-        loop = core.loop(default=False)
+        loop = self.loop
 
         # Watchers aren't reused once all outstanding
         # refs go away BUT THEY MUST BE CLOSED
-        tty_watcher = loop.io(1, core.WRITE)
-        watcher_handle = tty_watcher._watcher if IS_CFFI else tty_watcher
+        tty_watcher = loop.io(1, WRITE)
+        watcher_handle = tty_watcher._watcher if CFFI_BACKEND else tty_watcher
         tty_watcher.close()
         del tty_watcher
         # XXX: Note there is a cycle in the CFFI code
@@ -84,15 +108,16 @@ class Test(greentest.TestCase):
         import gc
         gc.collect()
 
-        tty_watcher = loop.io(1, core.WRITE)
-        self.assertIsNot(tty_watcher._watcher if IS_CFFI else tty_watcher, watcher_handle)
+        tty_watcher = loop.io(1, WRITE)
+        self.assertIsNot(tty_watcher._watcher if CFFI_BACKEND else tty_watcher, watcher_handle)
         tty_watcher.close()
-        loop.destroy()
+
 
 def reset(watcher, lst):
     watcher.args = None
     watcher.callback = lambda: None
     lst.append(25)
+    watcher.close()
 
 
 if __name__ == '__main__':

--- a/src/greentest/test__example_udp_server.py
+++ b/src/greentest/test__example_udp_server.py
@@ -9,11 +9,13 @@ class Test(util.TestServer):
 
     def _run_all_tests(self):
         sock = socket.socket(type=socket.SOCK_DGRAM)
-        sock.connect(('127.0.0.1', 9000))
-        sock.send(b'Test udp_server')
-        data, _address = sock.recvfrom(8192)
-        self.assertEqual(data, b'Received 15 bytes')
-        sock.close()
+        try:
+            sock.connect(('127.0.0.1', 9000))
+            sock.send(b'Test udp_server')
+            data, _address = sock.recvfrom(8192)
+            self.assertEqual(data, b'Received 15 bytes')
+        finally:
+            sock.close()
 
 
 if __name__ == '__main__':

--- a/src/greentest/test__examples.py
+++ b/src/greentest/test__examples.py
@@ -3,54 +3,59 @@ import os
 import glob
 import time
 
+import greentest
 from greentest import util
 
 
 cwd = '../../examples/'
-ignore = ['wsgiserver.py',
-          'wsgiserver_ssl.py',
-          'webproxy.py',
-          'webpy.py',
-          'unixsocket_server.py',
-          'unixsocket_client.py',
-          'psycopg2_pool.py',
-          'geventsendfile.py']
+ignore = [
+    'wsgiserver.py',
+    'wsgiserver_ssl.py',
+    'webproxy.py',
+    'webpy.py',
+    'unixsocket_server.py',
+    'unixsocket_client.py',
+    'psycopg2_pool.py',
+    'geventsendfile.py',
+]
 ignore += [x[14:] for x in glob.glob('test__example_*.py')]
 
 default_time_range = (2, 4)
 time_ranges = {
     'concurrent_download.py': (0, 30),
-    'processes.py': (0, 4)}
+    'processes.py': (0, 4)
+}
 
+class _AbstractTestMixin(object):
+    time_range = (2, 4)
+    filename = None
 
-def main(tests=None):
-    if not tests:
-        tests = set(os.path.basename(x) for x in glob.glob(cwd + '/*.py'))
-        tests = sorted(tests)
-
-    failed = []
-
-    for filename in tests:
-        if filename in ignore:
-            continue
-        min_time, max_time = time_ranges.get(filename, default_time_range)
-
+    def test_runs(self):
         start = time.time()
-        if util.run([sys.executable, '-u', filename], timeout=max_time, cwd=cwd):
-            failed.append(filename)
+        min_time, max_time = self.time_range
+        if util.run([sys.executable, '-u', self.filename],
+                    timeout=max_time,
+                    cwd=cwd,
+                    quiet=True,
+                    buffer_output=True,
+                    nested=True,
+                    setenv={'GEVENT_DEBUG': 'error'}):
+            self.fail("Failed example: " + self.filename)
         else:
             took = time.time() - start
-            if took < min_time:
-                util.log('! Failed example %s: exited too quickly, after %.1fs (expected %.1fs)', filename, took, min_time)
-                failed.append(filename)
+            self.assertGreaterEqual(took, min_time)
 
-    if failed:
-        util.log('! Failed examples:\n! - %s', '\n! - '.join(failed))
-        sys.exit(1)
-
-    if not tests:
-        sys.exit('No tests.')
-
+for filename in glob.glob(cwd + '/*.py'):
+    bn = os.path.basename(filename)
+    if bn in ignore:
+        continue
+    tc = type('Test_' + bn,
+              (_AbstractTestMixin, greentest.TestCase),
+              {
+                  'filename': bn,
+                  'time_range': time_ranges.get(bn, _AbstractTestMixin.time_range)
+              })
+    locals()[tc.__name__] = tc
 
 if __name__ == '__main__':
-    main()
+    greentest.main()

--- a/src/greentest/test__issues461_471.py
+++ b/src/greentest/test__issues461_471.py
@@ -85,6 +85,7 @@ else:
             # on Python 2). We still
             # count this as success.
             self.assertEqual(p.returncode if not WIN else 0, 0)
+            p.stdout.close()
 
     if __name__ == '__main__':
         greentest.main()

--- a/src/greentest/test__monkey.py
+++ b/src/greentest/test__monkey.py
@@ -30,10 +30,7 @@ class TestMonkey(unittest.TestCase):
             from gevent import threading as gthreading
             self.assertIs(threading._sleep, gthreading._sleep)
 
-
-
-        self.assertFalse(monkey.is_object_patched('threading', 'Event'))
-        monkey.patch_thread(Event=True)
+        # Event patched by default
         self.assertTrue(monkey.is_object_patched('threading', 'Event'))
 
     def test_socket(self):

--- a/src/greentest/test__monkey_sigchld_2.py
+++ b/src/greentest/test__monkey_sigchld_2.py
@@ -8,7 +8,7 @@ import sys
 import signal
 
 
-def handle(*args):
+def handle(*_args):
     if not pid:
         # We only do this is the child so our
         # parent's waitpid can get the status.

--- a/src/greentest/test__select.py
+++ b/src/greentest/test__select.py
@@ -91,13 +91,19 @@ class TestSelectTypes(greentest.TestCase):
 
     def test_int(self):
         sock = socket.socket()
-        select.select([int(sock.fileno())], [], [], 0.001)
+        try:
+            select.select([int(sock.fileno())], [], [], 0.001)
+        finally:
+            sock.close()
 
     if hasattr(six.builtins, 'long'):
         def test_long(self):
             sock = socket.socket()
-            select.select(
-                [six.builtins.long(sock.fileno())], [], [], 0.001)
+            try:
+                select.select(
+                    [six.builtins.long(sock.fileno())], [], [], 0.001)
+            finally:
+                sock.close()
 
     def test_string(self):
         self.switch_expected = False

--- a/src/greentest/test__socket.py
+++ b/src/greentest/test__socket.py
@@ -22,7 +22,7 @@ def wrap_error(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except:
+        except: # pylint:disable=bare-except
             traceback.print_exc()
             os._exit(2)
 
@@ -278,8 +278,11 @@ class TestTCP(greentest.TestCase):
 
             s.setblocking(0)
             std_socket = monkey.get_original('socket', 'socket')(socket.AF_INET, socket.SOCK_DGRAM, 0)
-            std_socket.setblocking(0)
-            self.assertEqual(std_socket.type, s.type)
+            try:
+                std_socket.setblocking(0)
+                self.assertEqual(std_socket.type, s.type)
+            finally:
+                std_socket.close()
 
         s.close()
 
@@ -408,7 +411,7 @@ class TestFunctions(greentest.TestCase):
         orig_get_hub = gevent.socket.get_hub
 
         class get_hub(object):
-            def wait(self, io):
+            def wait(self, _io):
                 gevent.sleep(10)
 
         class io(object):


### PR DESCRIPTION
Especially as reported on PyPy.

The testrunner will now show the output of a successful test if the
output contains ResourceWarning.

Fix a bunch of such warnings.

Import _testcapi in testrunner to try to avoid the concurrency issues on PyPy.

Minor cleanups in some old tests.