### PR TITLE
Fix documentation for Pool.full()

### DIFF
--- a/src/gevent/pool.py
+++ b/src/gevent/pool.py
@@ -712,8 +712,10 @@ class Pool(Group):
 
     def full(self):
         """
-        Return a boolean indicating whether this pool has any room for
-        members. (True if it does, False if it doesn't.)
+        Return a boolean indicating whether this pool is full, e.g. if
+        :meth:`add` would block.
+
+        :return: False if there is room for new members, True if there isn't.
         """
         return self.free_count() <= 0
 


### PR DESCRIPTION
The original docs had the purpose of the boolean return value reversed. I fixed that distinction, and also tried to clarify how the method can be used.