### PR TITLE
Introduce GEVENT_TRACK_GREENLET_TREE to disable greenlet tree features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,14 @@
   monkey-patch the underlying class, ``threading._Event``. Some code
   may be type-checking for that. See :issue:`1136`.
 
+- Introduce the configuration variable
+  `gevent.config.track_greenlet_tree` (aka
+  ``GEVENT_TRACK_GREENLET_TREE``) to allow disabling the greenlet tree
+  features for applications where greenlet spawning is performance
+  critical. This restores spawning performance to 1.2 levels.
+
+- Add additional optimizations for spawning greenlets, making it
+  faster than 1.3a2.
 
 1.3a2 (2018-03-06)
 ==================

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -109,6 +109,8 @@ def validate_bool(value):
 def validate_anything(value):
     return value
 
+convert_str_value_as_is = validate_anything
+
 class Setting(object):
     name = None
     value = None
@@ -396,6 +398,27 @@ class TraceMalloc(Setting):
     tracking information for FFI objects.
     """
 
+
+class TrackGreenletTree(Setting):
+    name = 'track_greenlet_tree'
+    environment_key = 'GEVENT_TRACK_GREENLET_TREE'
+    default = True
+
+    validate = staticmethod(validate_bool)
+    # Don't do string-to-list conversion.
+    _convert = staticmethod(convert_str_value_as_is)
+
+    desc = """\
+    Should `Greenlet` objects track their spawning tree?
+
+    Setting this to a false value will make spawning `Greenlet`
+    objects and using `spawn_raw` faster, but the
+    ``spawning_greenlet``, ``spawn_tree_locals`` and ``spawning_stack``
+    will not be captured.
+
+    .. versionadded:: 1.3b1
+    """
+
 # The ares settings are all interpreted by
 # gevent/resolver/ares.pyx, so we don't do
 # any validation here.
@@ -410,7 +433,7 @@ class AresSettingMixin(object):
 
     validate = staticmethod(validate_anything)
 
-    _convert = staticmethod(validate_anything)
+    _convert = staticmethod(convert_str_value_as_is)
 
 class AresFlags(AresSettingMixin, Setting):
     name = 'ares_flags'

--- a/src/gevent/_greenlet.pxd
+++ b/src/gevent/_greenlet.pxd
@@ -75,6 +75,9 @@ cdef inline list _extract_stack(int limit)
 @cython.locals(previous=_Frame, frame=tuple, f=_Frame)
 cdef _Frame _Frame_from_list(list frames)
 
+@cython.final
+cdef inline get_hub()
+
 
 cdef class Greenlet(greenlet):
     cdef readonly object value
@@ -128,7 +131,8 @@ cdef class Greenlet(greenlet):
 # doing a module global lookup. This is especially important
 # for spawning greenlets.
 cdef _greenlet__init__
-cdef get_hub
+cdef _threadlocal
+cdef get_hub_class
 cdef wref
 
 cdef Timeout
@@ -139,6 +143,7 @@ cdef wait
 cdef iwait
 cdef reraise
 cdef InvalidSwitchError
+cpdef GEVENT_CONFIG
 
 
 @cython.final

--- a/src/gevent/util.py
+++ b/src/gevent/util.py
@@ -283,6 +283,10 @@ class GreenletTree(object):
         tb = ''.join(traceback.format_stack(frame))
         tree.child_multidata(tb)
 
+    @staticmethod
+    def __spawning_parent(greenlet):
+        return (getattr(greenlet, 'spawning_greenlet', None) or _noop)()
+
     def __render_locals(self, tree):
         gr_locals = all_local_dicts_for_greenlet(self.greenlet)
         if gr_locals:
@@ -316,7 +320,7 @@ class GreenletTree(object):
         if spawning_stack and tree.details and tree.details['stacks']:
             self.__render_tb(tree, 'Spawned at:', spawning_stack)
 
-        spawning_parent = getattr(self.greenlet, 'spawning_greenlet', _noop)()
+        spawning_parent = self.__spawning_parent(self.greenlet)
         tree_locals = getattr(self.greenlet, 'spawn_tree_locals', None)
         if tree_locals and tree_locals is not getattr(spawning_parent, 'spawn_tree_locals', None):
             tree.child_data('Spawn Tree Locals')
@@ -377,7 +381,7 @@ class GreenletTree(object):
             if not isinstance(ob, RawGreenlet):
                 continue
 
-            spawn_parent = getattr(ob, 'spawning_greenlet', _noop)()
+            spawn_parent = cls.__spawning_parent(ob)
 
             if spawn_parent is None:
                 root = cls._root_greenlet(ob)


### PR DESCRIPTION
As a performance optimization for applications where spawning greenlets is critical. Plus some other optimizations to speed up spawning in the general case.

CPython 3.6 with 1.2.2 vs these changes with tracking disabled:

| Benchmark              | 36_122_bench_spawn | 36config_bench_spawn_tree_off |
|------------------------|--------------------|-------------------------------|
| eventlet spawn         | 12.6 us            | 12.2 us: 1.04x faster (-4%)   |
| eventlet sleep         | 5.22 us            | 4.97 us: 1.05x faster (-5%)   |
| gevent spawn           | 4.27 us            | 5.06 us: 1.19x slower (+19%)  |
| gevent sleep           | 2.63 us            | 1.25 us: 2.11x faster (-53%)  |
| geventpool spawn       | 9.00 us            | 8.31 us: 1.08x faster (-8%)   |
| geventpool sleep       | 4.82 us            | 2.83 us: 1.70x faster (-41%)  |
| geventraw spawn        | 2.51 us            | 2.81 us: 1.12x slower (+12%)  |
| geventraw sleep        | 649 ns             | 679 ns: 1.05x slower (+5%)    |
| geventpool join        | 3.47 us            | 1.42 us: 2.44x faster (-59%)  |
| geventpool spawn kwarg | 11.0 us            | 8.95 us: 1.23x faster (-19%)  |
| geventraw spawn kwarg  | 3.87 us            | 4.20 us: 1.08x slower (+8%)   |

The differences compared to master are hard to quantify because the standard deviation ends up being more than 10% of the mean in many cases---and about a 10% improvement is what we typically see, so it goes back and forth.