### PR TITLE
Use environment markers to install CFFI on windows so the libuv backend can really be default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@
 1.3b2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- On Windows, CFFI is now a dependency so that the libuv backend
+  really can be used by default.
 
 
 1.3b1 (2018-04-13)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,7 +118,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "%CMD_IN_ENV% pip install --disable-pip-version-check --user --upgrade pip"
+  - "%CMD_IN_ENV% %PYEXE% -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
@@ -142,7 +142,7 @@ build_script:
   # into a variable, using python to glob.
   - "%PYEXE% -c \"import glob; print(glob.glob('dist/*whl')[0])\" > whl.txt"
   - set /p PYWHL=<whl.txt
-  - pip install %PYWHL%
+  - "%PYEXE% -m pip install %PYWHL%"
 
 test_script:
   # Run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,14 +124,8 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  # Note that psutil won't build under PyPy on Windows.
-  - "%CMD_IN_ENV% %PYEXE% -m pip install -U cython zope.interface zope.event"
-  - "%CMD_IN_ENV% %PYEXE% -m pip install -U setuptools wheel greenlet cffi dnspython idna requests"
+  - "%CMD_IN_ENV% %PYEXE% -m pip install -U -r ci-requirements.txt"
 
-  - ps:
-      if ("${env:PYTHON_ID}" -ne "pypy") {
-         pip install psutil | Out-Null;
-      }
   - ps: "if(Test-Path(\"${env:PYTHON}\\bin\")) {ls ${env:PYTHON}\\bin;}"
   - ps: "if(Test-Path(\"${env:PYTHON}\\Scripts\")) {ls ${env:PYTHON}\\Scripts;}"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,8 +125,8 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   # Note that psutil won't build under PyPy on Windows.
-  - "%CMD_IN_ENV% pip install -U cython zope.interface zope.event"
-  - "%CMD_IN_ENV% pip install -U setuptools wheel greenlet cffi dnspython idna requests"
+  - "%CMD_IN_ENV% %PYEXE% -m pip install -U cython zope.interface zope.event"
+  - "%CMD_IN_ENV% %PYEXE% -m pip install -U setuptools wheel greenlet cffi dnspython idna requests"
 
   - ps:
       if ("${env:PYTHON_ID}" -ne "pypy") {

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -22,9 +22,13 @@ futures
 dnspython
 idna
 # Makes tests faster
-psutil
+# Fails to build on PyPy on Windows.
+psutil ; platform_python_implementation == "CPython" or sys_platform != "win32"
 # benchmarks use this
 perf
+# examples, called from tests, use this
+requests
+
 # Events
 zope.event
 zope.interface

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -12,8 +12,10 @@ greenlet>=0.4.13 ; platform_python_implementation == "CPython"
 pylint>=1.8.0
 # pyyaml is included here and doesn't install on travis with 3.7a3
 prospector[with_pyroma] ; python_version < '3.7'
-coverage>=4.0
-coveralls>=1.0
+# We don't run coverage on Windows, and pypy can't build it there
+# anyway (coveralls -> cryptopgraphy -> openssl)
+coverage>=4.0 ; sys_platform != 'win32'
+coveralls>=1.0 ; sys_platform != 'win32'
 # See version requirements in setup.py
 cffi >= 1.11.5 ; platform_python_implementation == "CPython"
 futures
@@ -26,12 +28,3 @@ perf
 # Events
 zope.event
 zope.interface
-
-# Tests
-requests
-# For viewing README.rst (restview --long-description),
-# CONTRIBUTING.rst, etc.
-# https://github.com/mgedmin/restview
-restview
-
--r rtd-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 -r ci-requirements.txt
+-r rtd-requirements.txt
 -e .

--- a/setup.py
+++ b/setup.py
@@ -197,9 +197,10 @@ greenlet_requires = [
 # we need cffi 1.11.3 (on CPython 3) to avoid test errors.
 
 # The exception is on Windows, where we want the libuv backend we distribute
-# to be the default, and that requires cffi
+# to be the default, and that requires cffi; but don't try to install it
+# on PyPy or it messes up the build
 cffi_requires = [
-    "cffi >= 1.11.5 ; sys_platform == 'win32'",
+    "cffi >= 1.11.5 ; sys_platform == 'win32' and platform_python_implementation == 'CPython'",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,20 @@ greenlet_requires = [
     'greenlet >= 0.4.13; platform_python_implementation=="CPython"',
 ]
 
-install_requires = greenlet_requires + []
+# Note that we don't add cffi to install_requires, it's
+# optional. We tend to build and distribute wheels with the CFFI
+# modules built and they can be imported if CFFI is installed.
+# We need cffi 1.4.0 for new style callbacks;
+# we need cffi 1.11.3 (on CPython 3) to avoid test errors.
+
+# The exception is on Windows, where we want the libuv backend we distribute
+# to be the default, and that requires cffi
+cffi_requires = [
+    "cffi >= 1.11.5 ; sys_platform == 'win32'",
+]
+
+
+install_requires = greenlet_requires + cffi_requires
 
 # We use headers from greenlet, so it needs to be installed before we
 # can compile. If it isn't already installed before we start
@@ -204,7 +217,7 @@ install_requires = greenlet_requires + []
 # to install the headers at all, AFAICS, we don't need to bother with
 # the buggy setup_requires.)
 
-setup_requires = []
+setup_requires = cffi_requires + []
 
 if PYPY:
     # These use greenlet/greenlet.h, which doesn't exist on PyPy
@@ -249,18 +262,6 @@ for mod in _to_cythonize:
     EXT_MODULES.append(cythonize1(mod))
 del _to_cythonize
 
-try:
-    cffi = __import__('cffi')
-except ImportError:
-    pass
-else:
-    # Note that we don't add cffi to install_requires, it's
-    # optional. We tend to build and distribute wheels with the CFFI
-    # modules built and they can be imported if CFFI is installed.
-    # We need cffi 1.4.0 for new style callbacks;
-    # we need cffi 1.11.3 (on CPython 3) to avoid test errors
-    # install_requires.append('cffi >= 1.4.0')
-    pass
 
 if IGNORE_CFFI and not PYPY:
     # Allow distributors to turn off CFFI builds


### PR DESCRIPTION
Lots of problems due to pip 10 on Windows had to be worked through...