### PR TITLE
Run leakchecks on Python 3.7.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@
 1.3.0rc1 (unreleased)
 =====================
 
-- Nothing changed yet.
+- Python 3.7 passes the automated memory leak checks. See :issue:`1197`.
 
 
 1.3b2 (2018-05-03)

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ test-py36: $(PY36)
 	PYTHON=python3.6.4 PATH=$(BUILD_RUNTIMES)/versions/python3.6.4/bin:$(PATH) make develop allbackendtest
 
 test-py37: $(PY37)
-	LD_LIBRARY_PATH=$(BUILD_RUNTIMES)/versions/python3.7.0b4/openssl/lib PYTHON=python3.7.0b4 PATH=$(BUILD_RUNTIMES)/versions/python3.7.0b4/bin:$(PATH) make develop allbackendtest
+	LD_LIBRARY_PATH=$(BUILD_RUNTIMES)/versions/python3.7.0b4/openssl/lib PYTHON=python3.7.0b4 PATH=$(BUILD_RUNTIMES)/versions/python3.7.0b4/bin:$(PATH) make develop leaktest cffibackendtest coverage_combine
 
 test-pypy: $(PYPY)
 	PYTHON=$(PYPY) PATH=$(BUILD_RUNTIMES)/versions/pypy5100/bin:$(PATH) make develop cffibackendtest

--- a/setup.py
+++ b/setup.py
@@ -357,6 +357,9 @@ def run_setup(ext_modules, run_make):
 
                 'futures ; python_version == "2.7"',
                 'mock ; python_version == "2.7"',
+
+                # leak checks. previously we had a hand-rolled version.
+                'objgraph',
             ]
         },
         # It's always safe to pass the CFFI keyword, even if

--- a/src/greentest/greentest/patched_tests_setup.py
+++ b/src/greentest/greentest/patched_tests_setup.py
@@ -269,6 +269,14 @@ if LIBUV:
             'test_socket.GeneralModuleTests.test_uknown_socket_family_repr',
         ]
 
+        if PY37:
+
+            disabled_tests += [
+                # This test sometimes fails at line 358. It's apparently
+                # extremely sensitive to timing.
+                'test_selectors.PollSelectorTestCase.test_timeout',
+            ]
+
         if OSX:
             disabled_tests += [
                 # XXX: Starting when we upgraded from libuv 1.18.0

--- a/src/greentest/greentest/testrunner.py
+++ b/src/greentest/greentest/testrunner.py
@@ -68,6 +68,15 @@ if RUNNING_ON_CI:
         # spawn processes of its own
         'test_signal.py',
     ]
+
+    if RUN_LEAKCHECKS and PY3:
+        # On a heavily loaded box, these can all take upwards of 200s
+        RUN_ALONE += [
+            'test__pool.py',
+            'test__pywsgi.py',
+            'test__queue.py',
+        ]
+
     if PYPY:
         # This often takes much longer on PyPy on CI.
         TEST_FILE_OPTIONS['test__threadpool.py'] = {'timeout': 180}

--- a/src/greentest/greentest/testrunner.py
+++ b/src/greentest/greentest/testrunner.py
@@ -18,6 +18,7 @@ from greentest.sysinfo import PY3
 from greentest.sysinfo import PY2
 from greentest.sysinfo import RESOLVER_ARES
 from greentest.sysinfo import LIBUV
+from greentest.sysinfo import RUN_LEAKCHECKS
 from greentest import six
 
 # Import this while we're probably single-threaded/single-processed
@@ -33,6 +34,11 @@ TIMEOUT = 100
 NWORKERS = int(os.environ.get('NWORKERS') or max(cpu_count() - 1, 4))
 if NWORKERS > 10:
     NWORKERS = 10
+
+if RUN_LEAKCHECKS:
+    # Capturing the stats takes time, and we run each
+    # test at least twice
+    TIMEOUT = 200
 
 DEFAULT_RUN_OPTIONS = {
     'timeout': TIMEOUT

--- a/src/greentest/greentest/timing.py
+++ b/src/greentest/greentest/timing.py
@@ -37,6 +37,10 @@ if sysinfo.RUNNING_ON_APPVEYOR:
     SMALL_TICK_MAX_ADJ = 1.5
 
 
+LARGE_TICK = 0.2
+LARGE_TICK_MIN_ADJ = LARGE_TICK / 2.0
+LARGE_TICK_MAX_ADJ = SMALL_TICK_MAX_ADJ
+
 
 class _DelayWaitMixin(object):
 
@@ -83,9 +87,6 @@ class _DelayWaitMixin(object):
         finally:
             timeout.close()
 
-LARGE_TICK = 0.2
-LARGE_TICK_MIN_ADJ = LARGE_TICK / 2.0
-LARGE_TICK_MAX_ADJ = SMALL_TICK_MAX_ADJ
 
 class AbstractGenericWaitTestCase(_DelayWaitMixin, TestCase):
     # pylint:disable=abstract-method

--- a/src/greentest/known_failures.py
+++ b/src/greentest/known_failures.py
@@ -223,25 +223,6 @@ if PY3:
         'FLAKY test__socket_dns.py',
     ]
 
-    if LEAKTEST:
-        FAILING_TESTS += ['FLAKY test__threadpool.py']
-        # refcount problems:
-        FAILING_TESTS += [
-            'test__timeout.py',
-            'FLAKY test__greenletset.py',
-            'test__core.py',
-            'test__systemerror.py',
-            'test__exc_info.py',
-            'test__api_timeout.py',
-            'test__event.py',
-            'test__api.py',
-            'test__hub.py',
-            'test__queue.py',
-            'test__socket_close.py',
-            'test__select.py',
-            'test__greenlet.py',
-            'FLAKY test__socket.py',
-        ]
 
 
 if sys.version_info[:2] >= (3, 4) and APPVEYOR:

--- a/src/greentest/test__api.py
+++ b/src/greentest/test__api.py
@@ -105,7 +105,12 @@ class TestTimers(greentest.TestCase):
             gevent.sleep(0.02)
 
         gevent.spawn(func)
+        # Func has not run yet
         self.assertEqual(lst, [1])
+        # Run callbacks but don't yield.
+        gevent.sleep()
+
+        # Let timers fire. Func should be done.
         gevent.sleep(0.1)
         self.assertEqual(lst, [])
 

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -30,8 +30,9 @@ from gevent.queue import Queue, Channel
 
 from greentest.timing import AbstractGenericWaitTestCase
 from greentest.timing import AbstractGenericGetTestCase
+from greentest import timing
 
-DELAY = 0.01
+DELAY = timing.SMALL_TICK
 greentest.TestCase.error_fatal = False
 
 
@@ -567,11 +568,12 @@ class TestBasic(greentest.TestCase):
             setattr(error, 'myattr', return_value)
             raise error
 
-        g = gevent.Greenlet(func, 0.001, return_value=5)
+        g = gevent.Greenlet(func, timing.SMALLEST_RELIABLE_DELAY, return_value=5)
         # use rawlink to avoid timing issues on Appveyor (not always successful)
         g.rawlink(link_test.append)
         g.start()
-        gevent.sleep(0.1)
+        gevent.sleep()
+        gevent.sleep(timing.LARGE_TICK)
         self.assertFalse(g)
         self.assertTrue(g.dead)
         self.assertFalse(g.started)

--- a/src/greentest/test__greenletset.py
+++ b/src/greentest/test__greenletset.py
@@ -39,6 +39,7 @@ class Test(greentest.TestCase):
         self.assertEqual(len(s), 1, s)
         s.spawn(gevent.sleep, timing.LARGE_TICK * 5)
         self.assertEqual(len(s), 2, s)
+        gevent.sleep()
         gevent.sleep(timing.LARGE_TICK * 2 + timing.LARGE_TICK_MIN_ADJ)
         self.assertEqual(len(s), 1, s)
         gevent.sleep(timing.LARGE_TICK * 5 + timing.LARGE_TICK_MIN_ADJ)

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -295,7 +295,7 @@ TIMEOUT1, TIMEOUT2, TIMEOUT3 = 0.082, 0.035, 0.14
 SMALL_RANGE = 10
 LARGE_RANGE = 1000
 
-if greentest.PYPY and greentest.WIN:
+if (greentest.PYPY and greentest.WIN) or greentest.RUN_LEAKCHECKS or greentest.RUN_COVERAGE:
     # See comments in test__threadpool.py.
     LARGE_RANGE = 50
 elif greentest.RUNNING_ON_CI or greentest.EXPECT_POOR_TIMER_RESOLUTION:
@@ -469,11 +469,11 @@ class TestPool(greentest.TestCase): # pylint:disable=too-many-public-methods
 class TestPool2(TestPool):
     size = 2
 
-
+@greentest.ignores_leakcheck
 class TestPool3(TestPool):
     size = 3
 
-
+@greentest.ignores_leakcheck
 class TestPool10(TestPool):
     size = 10
 

--- a/src/greentest/test__pool.py
+++ b/src/greentest/test__pool.py
@@ -297,7 +297,7 @@ LARGE_RANGE = 1000
 
 if (greentest.PYPY and greentest.WIN) or greentest.RUN_LEAKCHECKS or greentest.RUN_COVERAGE:
     # See comments in test__threadpool.py.
-    LARGE_RANGE = 50
+    LARGE_RANGE = 25
 elif greentest.RUNNING_ON_CI or greentest.EXPECT_POOR_TIMER_RESOLUTION:
     LARGE_RANGE = 100
 
@@ -465,7 +465,7 @@ class TestPool(greentest.TestCase): # pylint:disable=too-many-public-methods
             l = reader()
             self.assertEqual(sorted(l), iterable)
 
-
+@greentest.ignores_leakcheck
 class TestPool2(TestPool):
     size = 2
 

--- a/src/greentest/test__pywsgi.py
+++ b/src/greentest/test__pywsgi.py
@@ -899,10 +899,11 @@ class TestInputN(TestCase):
 
 class TestError(TestCase):
 
-    error = greentest.ExpectedException('TestError.application')
+    error = object()
     error_fatal = False
 
     def application(self, env, start_response):
+        self.error = greentest.ExpectedException('TestError.application')
         raise self.error
 
     def test(self):
@@ -913,9 +914,8 @@ class TestError(TestCase):
 
 class TestError_after_start_response(TestError):
 
-    error = greentest.ExpectedException('TestError_after_start_response.application')
-
     def application(self, env, start_response):
+        self.error = greentest.ExpectedException('TestError_after_start_response.application')
         start_response('200 OK', [('Content-Type', 'text/plain')])
         raise self.error
 

--- a/src/greentest/test__refcount.py
+++ b/src/greentest/test__refcount.py
@@ -139,6 +139,9 @@ def run_and_check(run_client):
 
 
 @greentest.skipOnCI("Often fail with timeouts or force closed connections; not sure why.")
+@greentest.skipIf(greentest.RUN_LEAKCHECKS and greentest.PY3,
+                  "Often fail with force closed connections; not sure why. "
+)
 class Test(greentest.TestCase):
 
     __timeout__ = greentest.LARGE_TIMEOUT


### PR DESCRIPTION
Fixes #1197

Switch to objgraph to handle the measurement for us. That cleared up a
few of the obscure issues with references to
functions/getset_descriptors and the like. (Possibly because it keys
by string names and we were keeping type objects alive.)

Many of the real failures were due to re-using exception instances,
which is bad because of chaining.

Most of the @ignore_leakcheck are for performance, only one is for a
real issue---and that test was skipped already on CI anyway for being
too flaky.