### PR TITLE
Catch the ValueError that sys._getframe() can raise when there are no Python frames.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Nothing changed yet.
 
+- Fix embedded uses of :func:`gevent.Greenlet.spawn`, especially under
+  uwsgi. Reported in :issue:`1212` by Kunal Gangakhedkar.
 
 1.3.0 (2018-05-11)
 ==================


### PR DESCRIPTION
This can happen in the embedded case, when the CPython C api is used to directly call Greenlet.spawn, which itself is now implemented in C.

Fixes #1212.