### PR TITLE
Only issue the ssl MonkeyPatchWarning if we can be pretty sure there will be problems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@
 1.3.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Be more careful about issuing ``MonkeyPatchWarning`` for ssl
+  imports. Now, we only issue it if we detect the one specific
+  condition that is known to lead to RecursionError. This may produce
+  false negatives, but should reduce or eliminate false positives.
 
 
 1.3.3 (2018-06-08)

--- a/src/greentest/test__monkey_ssl_warning2.py
+++ b/src/greentest/test__monkey_ssl_warning2.py
@@ -1,0 +1,44 @@
+import unittest
+import warnings
+import sys
+
+# All supported python versions now provide SSLContext.
+# We import it by name and subclass it here by name.
+# compare with warning3.py
+from ssl import SSLContext
+
+class MySubclass(SSLContext):
+    pass
+
+# This file should only have this one test in it
+# because we have to be careful about our imports
+# and because we need to be careful about our patching.
+
+class Test(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info[:2] < (3, 6),
+                     "Only on Python 3.6+")
+    def test_ssl_subclass_and_module_reference(self):
+
+        from gevent import monkey
+
+        self.assertFalse(monkey.saved)
+
+        with warnings.catch_warnings(record=True) as issued_warnings:
+            warnings.simplefilter('always')
+
+            monkey.patch_all()
+            monkey.patch_all()
+
+        issued_warnings = [x for x in issued_warnings
+                           if isinstance(x.message, monkey.MonkeyPatchWarning)]
+
+        self.assertEqual(1, len(issued_warnings))
+        message = issued_warnings[0].message
+        self.assertIn("Modules that had direct imports", str(message))
+        self.assertIn("Subclasses (NOT patched)", str(message))
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/greentest/test__monkey_ssl_warning3.py
+++ b/src/greentest/test__monkey_ssl_warning3.py
@@ -1,0 +1,47 @@
+import unittest
+import warnings
+import sys
+
+# All supported python versions now provide SSLContext.
+# We subclass without importing by name. Compare with
+# warning2.py
+import ssl
+
+class MySubclass(ssl.SSLContext):
+    pass
+
+# This file should only have this one test in it
+# because we have to be careful about our imports
+# and because we need to be careful about our patching.
+
+class Test(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info[:2] < (3, 6),
+                     "Only on Python 3.6+")
+    def test_ssl_subclass_and_module_reference(self):
+
+        from gevent import monkey
+
+        self.assertFalse(monkey.saved)
+
+        with warnings.catch_warnings(record=True) as issued_warnings:
+            warnings.simplefilter('always')
+
+            monkey.patch_all()
+            monkey.patch_all()
+
+        issued_warnings = [x for x in issued_warnings
+                           if isinstance(x.message, monkey.MonkeyPatchWarning)]
+
+        self.assertEqual(1, len(issued_warnings))
+        message = str(issued_warnings[0].message)
+
+        self.assertNotIn("Modules that had direct imports", message)
+        self.assertIn("Subclasses (NOT patched)", message)
+        # the gevent subclasses should not be in here.
+        self.assertNotIn('gevent.', message)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This increases the false negative chances, but decreases the false positives substantially.

Given 
```python
import requests
import gevent.monkey; gevent.monkey.patch_all()
```

The expected warning would be something like:

> MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.util (//lib/python3.6/site-packages/urllib3/util/__init__.py)', 'urllib3.util.ssl_ (//lib/python3.6/site-packages/urllib3/util/ssl_.py)'].