### PR TITLE
Don't pass the port when calling getaddrinfo from socket.connect.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,14 @@
   :class:`concurrent.futures.ThreadPoolExecutor` as well. Reported in
   :issue:`1248` by wwqgtxx and :issue:`1251` by pyld.
 
+- :meth:`gevent.socket.socket.connect` doesn't pass the port (service)
+  to :func:`socket.getaddrinfo` when it resolves an ``AF_INET`` or
+  ``AF_INET6`` address. This fixes an issue on Solaris. Reported in
+  :issue:`1252` by wiggin15.
+
+- :meth:`gevent.socket.socket.connect` works with more address
+  families, notably AF_TIPC, AF_NETLINK, AF_BLUETOOTH, AF_ALG and AF_VSOCK.
+
 
 1.3.4 (2018-06-20)
 ==================

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -228,9 +228,7 @@ class socket(object):
         if self.timeout == 0.0:
             return self._sock.connect(address)
         sock = self._sock
-        if isinstance(address, tuple):
-            r = getaddrinfo(address[0], address[1], sock.family)
-            address = r[0][-1]
+        address = _socketcommon._resolve_addr(sock, address)
 
         timer = Timeout._start_new_or_dummy(self.timeout, timeout('timed out'))
         try:

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -326,9 +326,7 @@ class socket(object):
     def connect(self, address):
         if self.timeout == 0.0:
             return _socket.socket.connect(self._sock, address)
-        if isinstance(address, tuple):
-            r = getaddrinfo(address[0], address[1], self.family)
-            address = r[0][-1]
+        address = _socketcommon._resolve_addr(self._sock, address)
 
         with Timeout._start_new_or_dummy(self.timeout, timeout("timed out")):
             while True:


### PR DESCRIPTION
Also only attempt to resolve the address when we are AF_INET or AF_INET6; previously all other tuple address families would have been passed to getaddrinfo where they probably failed.

Fixes #1252 