### PR TITLE
Begin WaitIterator iteration when __next__ is called.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 - Add support for application-wide callbacks when ``Greenlet`` objects
   are started. See :pr:`1289`, provided by Yury Selivanov.
 
+- It is now possible to consume ready objects using next(gevent.iwait(objs)).
+  Previously such a construction would hang. See :pr:`1288`, provided by Josh
+  Snyder.
 
 1.3.7 (2018-10-12)
 ==================

--- a/src/gevent/__hub_primitives.pxd
+++ b/src/gevent/__hub_primitives.pxd
@@ -55,7 +55,7 @@ cdef class _WaitIterator:
     cdef bint _begun
 
 
-
+    cdef _begin(self)
     cdef _cleanup(self)
 
 cpdef iwait_on_objects(objects, timeout=*, count=*)

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -118,6 +118,8 @@ class _WaitIterator(object):
 
         self._begun = True
 
+        # XXX: If iteration doesn't actually happen, we
+        # could leave these links around!
         for obj in self._objects:
             obj.rawlink(self._switch)
 

--- a/src/greentest/test_wait.py
+++ b/src/greentest/test_wait.py
@@ -1,0 +1,16 @@
+import gevent
+import greentest
+from gevent.lock import Semaphore
+
+
+class TestWaiting(greentest.TestCase):
+    def test_wait_noiter(self):
+        """Test that gevent.iwait returns objects which can be iterated upon
+        without additional calls to iter()"""
+
+        sem1 = Semaphore()
+        sem2 = Semaphore()
+
+        gevent.spawn(sem1.release)
+        ready = next(gevent.iwait((sem1, sem2)))
+        self.assertEqual(sem1, ready)


### PR DESCRIPTION
For scenarios where they only want to get the first greenlet which exits, a
user might write this code:

    next(gevent.iwait(greenlets))

Without this commit, the above snippet will hang, because the waited-upon
objects have not been `rawlink()`ed. This change makes such bugs impossible.