### PR TITLE
Add Greenlet.add_spawn_callback() and Greenlet.remove_spawn_callback()

### DIFF
--- a/doc/api/gevent.greenlet.rst
+++ b/doc/api/gevent.greenlet.rst
@@ -176,6 +176,8 @@ yet and thus would evaluate to False.
 .. automethod:: Greenlet.rawlink
 .. automethod:: Greenlet.unlink
 .. automethod:: Greenlet.__str__
+.. automethod:: Greenlet.add_spawn_callback
+.. automethod:: Greenlet.remove_spawn_callback
 
 
 Raw greenlet Methods

--- a/src/gevent/_greenlet.pxd
+++ b/src/gevent/_greenlet.pxd
@@ -117,7 +117,6 @@ cdef class Greenlet(greenlet):
     cdef bint __start_pending(self)
     cdef bint __never_started_or_killed(self)
     cdef bint __start_completed(self)
-    cdef __call_spawn_callbacks(self)
     cdef __handle_death_before_start(self, tuple args)
 
     cdef __cancel_start(self)
@@ -150,7 +149,6 @@ cdef Waiter
 cdef wait
 cdef iwait
 cdef reraise
-cdef set _spawn_callbacks = None
 cpdef GEVENT_CONFIG
 
 
@@ -174,3 +172,6 @@ cdef _killall(list greenlets, object exception)
 
 @cython.locals(done=list)
 cpdef joinall(greenlets, timeout=*, raise_error=*, count=*)
+
+cdef set _spawn_callbacks = None
+cdef _call_spawn_callbacks(greenlet)

--- a/src/gevent/_greenlet.pxd
+++ b/src/gevent/_greenlet.pxd
@@ -174,4 +174,4 @@ cdef _killall(list greenlets, object exception)
 cpdef joinall(greenlets, timeout=*, raise_error=*, count=*)
 
 cdef set _spawn_callbacks = None
-cdef _call_spawn_callbacks(greenlet)
+cdef _call_spawn_callbacks(gr)

--- a/src/gevent/_greenlet.pxd
+++ b/src/gevent/_greenlet.pxd
@@ -117,6 +117,7 @@ cdef class Greenlet(greenlet):
     cdef bint __start_pending(self)
     cdef bint __never_started_or_killed(self)
     cdef bint __start_completed(self)
+    cdef __call_spawn_callbacks(self)
     cdef __handle_death_before_start(self, tuple args)
 
     cdef __cancel_start(self)
@@ -149,6 +150,7 @@ cdef Waiter
 cdef wait
 cdef iwait
 cdef reraise
+cdef set _spawn_callbacks = None
 cpdef GEVENT_CONFIG
 
 

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -508,6 +508,7 @@ class Greenlet(greenlet):
     def start(self):
         """Schedule the greenlet to run in this loop iteration"""
         if self._start_event is None:
+            _call_spawn_callbacks(self)
             self._start_event = self.parent.loop.run_callback(self.switch)
 
     def start_later(self, seconds):
@@ -518,6 +519,7 @@ class Greenlet(greenlet):
         *seconds* later
         """
         if self._start_event is None:
+            _call_spawn_callbacks(self)
             self._start_event = self.parent.loop.timer(seconds)
             self._start_event.start(self.switch)
 
@@ -572,7 +574,6 @@ class Greenlet(greenlet):
             instead of spawning a greenlet that will raise an uncaught TypeError.
         """
         g = cls(*args, **kwargs)
-        _call_spawn_callbacks(g)
         g.start()
         return g
 
@@ -596,7 +597,6 @@ class Greenlet(greenlet):
         if cls is Greenlet and not args and 'run' not in kwargs:
             raise TypeError("")
         g = cls(*args, **kwargs)
-        _call_spawn_callbacks(g)
         g.start_later(seconds)
         return g
 

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -538,7 +538,7 @@ class Greenlet(greenlet):
         .. versionadded:: 1.3.8
         """
         global _spawn_callbacks
-        if _spawn_callbacks is None:
+        if _spawn_callbacks is None:  # pylint:disable=used-before-assignment
             _spawn_callbacks = set()
         _spawn_callbacks.add(callback)
 
@@ -929,10 +929,10 @@ def _killall(greenlets, exception):
                 g.parent.handle_error(g, *sys_exc_info())
 
 
-def _call_spawn_callbacks(greenlet):
+def _call_spawn_callbacks(gr):
     if _spawn_callbacks is not None:
         for cb in _spawn_callbacks:
-            cb(greenlet)
+            cb(gr)
 
 
 _spawn_callbacks = None

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -522,15 +522,15 @@ class Greenlet(greenlet):
             self._start_event.start(self.switch)
 
     @staticmethod
-    def add_spawn_callback(cb):
+    def add_spawn_callback(callback):
         """
         add_spawn_callback(callback) -> None
 
         Set up a *callback* to be invoked when :class:`Greenlet` objects
         are started.
 
-        The invocation order of spawn callbacks is unspecified.  Adding one
-        callback more than one time will not cause it to be called more
+        The invocation order of spawn callbacks is unspecified.  Adding the
+        same callback more than one time will not cause it to be called more
         than once.
 
         .. versionadded:: 1.3.8
@@ -538,21 +538,22 @@ class Greenlet(greenlet):
         global _spawn_callbacks
         if _spawn_callbacks is None:
             _spawn_callbacks = set()
-        _spawn_callbacks.add(cb)
+        _spawn_callbacks.add(callback)
 
     @staticmethod
-    def remove_spawn_callback(cb):
+    def remove_spawn_callback(callback):
         """
         remove_spawn_callback(callback) -> None
 
         Remove *callback* function added with :meth:`Greenlet.add_spawn_callback`.
-        This function will not fail if *callback* has been already removed.
+        This function will not fail if *callback* has been already removed or
+        if *callback* was never added.
 
         .. versionadded:: 1.3.8
         """
         global _spawn_callbacks
         if _spawn_callbacks is not None:
-            _spawn_callbacks.discard(cb)
+            _spawn_callbacks.discard(callback)
             if not _spawn_callbacks:
                 _spawn_callbacks = None
 

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -699,6 +699,21 @@ class TestBasic(greentest.TestCase):
         while not raw.dead:
             gevent.sleep(0.01)
 
+    def test_add_spawn_callback(self):
+        def cb(gr):
+            gr._called_test = True
+
+        gevent.Greenlet.add_spawn_callback(cb)
+        self.addCleanup(lambda: gevent.Greenlet.remove_spawn_callback(cb))
+
+        g = gevent.spawn(lambda: None)
+        self.assertTrue(hasattr(g, '_called_test'))
+        g.join()
+
+        gevent.Greenlet.remove_spawn_callback(cb)
+        g = gevent.spawn(lambda: None)
+        self.assertFalse(hasattr(g, '_called_test'))
+        g.join()
 
     def test_getframe_value_error(self):
         def get():

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -704,16 +704,17 @@ class TestBasic(greentest.TestCase):
             gr._called_test = True
 
         gevent.Greenlet.add_spawn_callback(cb)
-        self.addCleanup(lambda: gevent.Greenlet.remove_spawn_callback(cb))
+        try:
+            g = gevent.spawn(lambda: None)
+            self.assertTrue(hasattr(g, '_called_test'))
+            g.join()
 
-        g = gevent.spawn(lambda: None)
-        self.assertTrue(hasattr(g, '_called_test'))
-        g.join()
-
-        gevent.Greenlet.remove_spawn_callback(cb)
-        g = gevent.spawn(lambda: None)
-        self.assertFalse(hasattr(g, '_called_test'))
-        g.join()
+            gevent.Greenlet.remove_spawn_callback(cb)
+            g = gevent.spawn(lambda: None)
+            self.assertFalse(hasattr(g, '_called_test'))
+            g.join()
+        finally:
+            gevent.Greenlet.remove_spawn_callback(cb)
 
     def test_getframe_value_error(self):
         def get():

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -700,11 +700,10 @@ class TestBasic(greentest.TestCase):
             gevent.sleep(0.01)
 
     def test_add_spawn_callback(self):
-        called = 0
+        called = {'#': 0}
 
         def cb(gr):
-            nonlocal called
-            called += 1
+            called['#'] += 1
             gr._called_test = True
 
         gevent.Greenlet.add_spawn_callback(cb)
@@ -712,24 +711,24 @@ class TestBasic(greentest.TestCase):
             g = gevent.spawn(lambda: None)
             self.assertTrue(hasattr(g, '_called_test'))
             g.join()
-            self.assertEqual(called, 1)
+            self.assertEqual(called['#'], 1)
 
             g = gevent.spawn_later(1e-5, lambda: None)
             self.assertTrue(hasattr(g, '_called_test'))
             g.join()
-            self.assertEqual(called, 2)
+            self.assertEqual(called['#'], 2)
 
             g = gevent.Greenlet(lambda: None)
             g.start()
             self.assertTrue(hasattr(g, '_called_test'))
             g.join()
-            self.assertEqual(called, 3)
+            self.assertEqual(called['#'], 3)
 
             gevent.Greenlet.remove_spawn_callback(cb)
             g = gevent.spawn(lambda: None)
             self.assertFalse(hasattr(g, '_called_test'))
             g.join()
-            self.assertEqual(called, 3)
+            self.assertEqual(called['#'], 3)
         finally:
             gevent.Greenlet.remove_spawn_callback(cb)
 

--- a/src/greentest/test__greenlet.py
+++ b/src/greentest/test__greenlet.py
@@ -700,7 +700,11 @@ class TestBasic(greentest.TestCase):
             gevent.sleep(0.01)
 
     def test_add_spawn_callback(self):
+        called = 0
+
         def cb(gr):
+            nonlocal called
+            called += 1
             gr._called_test = True
 
         gevent.Greenlet.add_spawn_callback(cb)
@@ -708,11 +712,24 @@ class TestBasic(greentest.TestCase):
             g = gevent.spawn(lambda: None)
             self.assertTrue(hasattr(g, '_called_test'))
             g.join()
+            self.assertEqual(called, 1)
+
+            g = gevent.spawn_later(1e-5, lambda: None)
+            self.assertTrue(hasattr(g, '_called_test'))
+            g.join()
+            self.assertEqual(called, 2)
+
+            g = gevent.Greenlet(lambda: None)
+            g.start()
+            self.assertTrue(hasattr(g, '_called_test'))
+            g.join()
+            self.assertEqual(called, 3)
 
             gevent.Greenlet.remove_spawn_callback(cb)
             g = gevent.spawn(lambda: None)
             self.assertFalse(hasattr(g, '_called_test'))
             g.join()
+            self.assertEqual(called, 3)
         finally:
             gevent.Greenlet.remove_spawn_callback(cb)
 


### PR DESCRIPTION
These methods allow to set up code to intercept Greenlet objects
creation.  This is useful to implement custom tracing of gevent tasks
and custom variants of `gevent.local()`.

The performance impact is minuscule: one extra fast "if" check in
`Greenlet.__init__`.