### PR TITLE
WaitIterators: only return a given object once

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 - Add support for application-wide callbacks when ``Greenlet`` objects
   are started. See :pr:`1289`, provided by Yury Selivanov.
 
+- It is now possible to consume ready objects using `next(gevent.iwait(objs))`.
+  Previously such a construction would hang.
+
+- `gevent.iwait(objs)` will now return each ready object at most once.
+  Previously objects which could become ready multiple times could also be
+  returned by `gevent.iwait` multiple times.
 
 1.3.7 (2018-10-12)
 ==================

--- a/src/gevent/__hub_primitives.pxd
+++ b/src/gevent/__hub_primitives.pxd
@@ -48,14 +48,13 @@ cdef class _WaitIterator:
     cdef SwitchOutGreenletWithLoop _hub
     cdef MultipleWaiter _waiter
     cdef _switch
-    cdef _timeout
     cdef _objects
     cdef _timer
     cdef Py_ssize_t _count
     cdef bint _begun
 
 
-
+    cdef _unlink(self, aobj)
     cdef _cleanup(self)
 
 cpdef iwait_on_objects(objects, timeout=*, count=*)

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -221,6 +221,10 @@ def wait_on_objects(objects=None, timeout=None, count=None):
     ready. (For example, if count is ``1`` then the function exits
     when any object in the list is ready).
 
+    When ``count`` is ``None`` or ``count`` > 1, some kinds of objects (e.g
+    Event, Semaphore) may lose their readiness before this function returns. To
+    avoid this problem, use :func:`iwait` instead.
+
     If ``timeout`` is provided, it specifies the maximum number of
     seconds ``wait()`` will block.
 

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -107,6 +107,8 @@ class _WaitIterator(object):
         )
         self._begun = False
 
+        # XXX: If iteration doesn't actually happen, we
+        # could leave these links around!
         self._objects = set(objects)
         for obj in self._objects:
             obj.rawlink(self._switch)

--- a/src/greentest/test__wait.py
+++ b/src/greentest/test__wait.py
@@ -12,6 +12,22 @@ class TestWaiting(greentest.TestCase):
         ready = next(gevent.iwait((sem1, sem2)))
         self.assertEqual(sem1, ready)
 
+    def test_wait_unique(self):
+        sem1 = Semaphore()
+        sem2 = Semaphore()
+
+        def release():
+            for i in range(2):
+                sem1.release()
+                gevent.idle()
+            sem2.release()
+
+        glet = gevent.spawn(release)
+        waited_objs = set(gevent.iwait((sem1, sem2)))
+        self.assertEqual(waited_objs, set([sem1, sem2]))
+        glet.kill()
+        glet.get()
+
 
 if __name__ == '__main__':
         greentest.main()

--- a/src/greentest/test__wait.py
+++ b/src/greentest/test__wait.py
@@ -1,0 +1,17 @@
+import gevent
+import greentest
+from gevent.lock import Semaphore
+
+
+class TestWaiting(greentest.TestCase):
+    def test_wait_noiter(self):
+        sem1 = Semaphore()
+        sem2 = Semaphore()
+
+        gevent.spawn(sem1.release)
+        ready = next(gevent.iwait((sem1, sem2)))
+        self.assertEqual(sem1, ready)
+
+
+if __name__ == '__main__':
+        greentest.main()


### PR DESCRIPTION
Depending on feedback, this PR may supersede #1288.

There are detailed commit messages describing what is going on. As a summary, this PR:

* documents a pitfall of `gevent.wait`

Other than documentation, the alternative would be to break all calls to `gevent.wait` that include Events or Semaphores for `count > 1`, but this a) seems very backward-incompatible, and b) would require classifying all `AbstractLinkables` into resettable and non-resettable

* adds a test that `WaitIterators` can be iterated using just `next()` and without `iter()`, and makes it pass.
* fixes a memory leak alluded to by a comment in the `WaitIterator` code

I did this by decythonizing the WaitIterator class. The pro is that we can now use the Python `__del__`, which cython objects apparently cannot do. What are the cons?

One alternative I just thought of would be to split WaitIterator into a cython `WaitIterator` (no timeout functionality and therefore no possibility of leakage) and a Python subclass `WaitIteratorWithTimeout`.

* makes WaitIterator only return unique objects

Right now a WaitIterator can return the same object many times, which I think is very unexpected and probably pathological. I'm curious for feedback on backward compatibility, but my thought is that the current behavior is so broken (pardon me) that nobody would be relying on it.

PS: I think it might be worthwhile to expose WaitIterator (or something like it) as a documented interface, with `add` and `remove` methods so that users can dynamically choose greenlets to watch.

PPS: I had a lot of fun with the test suite while composing these changes. I especially liked the part where it kept track of reference counts and uncollectible garbage for me. Once I got the tests passing (and not a moment before), I was delighted to have such a detailed test suite.