### PR TITLE
Provide a context manager API to prevent memory leaks in gevent.iwait()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@
   Previously such a construction would hang. See :pr:`1288`, provided by Josh
   Snyder.
 
+- There is new documentation on the possibility that `gevent.iwait` can produce
+  memory leaks when not fully consumed. To prevent such situations,
+  `gevent.iwait` now provides optional contextmanager support, which will ensure
+  that all resources are cleaned up. See :pr:`1290`, provided by Josh Snyder.
+
+
 1.3.7 (2018-10-12)
 ==================
 

--- a/src/gevent/__hub_primitives.pxd
+++ b/src/gevent/__hub_primitives.pxd
@@ -58,6 +58,10 @@ cdef class _WaitIterator:
     cdef _begin(self)
     cdef _cleanup(self)
 
+    cpdef __enter__(self)
+    cpdef __exit__(self, typ, value, tb)
+
+
 cpdef iwait_on_objects(objects, timeout=*, count=*)
 cpdef wait_on_objects(objects=*, timeout=*, count=*)
 

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -201,6 +201,8 @@ def iwait_on_objects(objects, timeout=None, count=None):
     .. versionchanged:: 1.1a2
        No longer raise :exc:`LoopExit` if our caller switches greenlets
        in between items yielded by this function.
+    .. versionchanged:: 1.4
+       Add support to use the returned object as a context manager.
     """
     # QQQ would be nice to support iterable here that can be generated slowly (why?)
     hub = get_hub()

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -168,6 +168,12 @@ class _WaitIterator(object):
                 except: # pylint:disable=bare-except
                     traceback.print_exc()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, typ, value, tb):
+        self._cleanup()
+
 
 def iwait_on_objects(objects, timeout=None, count=None):
     """

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -180,6 +180,11 @@ def iwait_on_objects(objects, timeout=None, count=None):
     Iteratively yield *objects* as they are ready, until all (or *count*) are ready
     or *timeout* expired.
 
+    This function allocates resources which must be cleaned up. Consuming the
+    iterator until it is exhausted will automatically clean them up, and it is
+    also possible to use the returned object as a context manager to ensure
+    cleanup occurs.
+
     :param objects: A sequence (supporting :func:`len`) containing objects
         implementing the wait protocol (rawlink() and unlink()).
     :keyword int count: If not `None`, then a number specifying the maximum number


### PR DESCRIPTION
This is a different approach to the `__del__` one proposed in #1290. Just like with open file descriptors, this PR provides (but does not require consumers to use) a context manager API to manage cleanup of WaitIterators.