### PR TITLE
Be more careful handling NOT_ERROR during interpreter shutdown.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@
   ``AsyncEvent``. Note that the order in which semaphore links are
   called is not specified. See :issue:`1287`, reported by Dan Milon.
 
+- Improve safety of handling exceptions during interpreter shutdown.
+  See :issue:`1295` reported by BobDenar1212.
+
 
 1.3.7 (2018-10-12)
 ==================

--- a/src/gevent/_ffi/loop.py
+++ b/src/gevent/_ffi/loop.py
@@ -137,7 +137,11 @@ class AbstractCallbacks(object):
             # Depending on when the exception happened, the watcher
             # may or may not have been stopped. We need to make sure its
             # memory stays valid so we can stop it at the ev level if needed.
-            the_watcher.loop._keepaliveset.add(the_watcher)
+            # If its loop is gone, it has already been stopped,
+            # see https://github.com/gevent/gevent/issues/1295 for a case where
+            # that happened
+            if the_watcher.loop is not None:
+                the_watcher.loop._keepaliveset.add(the_watcher)
             return -1
         else:
             if (the_watcher.loop is not None


### PR DESCRIPTION
Fixes #1295