### PR TITLE
Drop `sudo` from our Travis config, following current recommendation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # .travis.yml based on https://github.com/DRMacIver/hypothesis/blob/master/.travis.yml
 language: python
-group: travis_latest
 # We have some unexpected failures on xenial
-#dist: xenial
+# dist: xenial
+# group: travis_latest
 python:
   - 3.7-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # .travis.yml based on https://github.com/DRMacIver/hypothesis/blob/master/.travis.yml
 language: python
 group: travis_latest
-dist: xenial
+# We have some unexpected failures on xenial
+#dist: xenial
 python:
   - 3.7-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # .travis.yml based on https://github.com/DRMacIver/hypothesis/blob/master/.travis.yml
 language: python
 group: travis_latest
-
+dist: xenial
 python:
   - 3.7-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # .travis.yml based on https://github.com/DRMacIver/hypothesis/blob/master/.travis.yml
 language: python
-sudo: false
+group: travis_latest
 
 python:
   - 3.7-dev


### PR DESCRIPTION
I tried doing some other updates too, but ran into more potential issues than I wanted to deal with in one PR right now.