### PR TITLE
Appveyor updates: Test PyPy6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 env:
     global:
         - BUILD_RUNTIMES=$HOME/.runtimes
-        - PYTHONHASHSEED=random
+        - PYTHONHASHSEED=8675309
         - CC="ccache gcc"
         - CCACHE_NOCPP2=true
         - CCACHE_SLOPPINESS=file_macro,time_macros,include_file_ctime,include_file_mtime

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Build with Cython 0.29 in '3str' mode.
 
+- Test with PyPy 6.0 on Windows.
+
 - Add support for application-wide callbacks when ``Greenlet`` objects
   are started. See :pr:`1289`, provided by Yury Selivanov.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@
 - Make gevent's pywsgi server set the non-standard environment value
   ``wsgi.input_terminated`` to True. See :issue:`1308`.
 
+- Make `gevent.util.assert_switches` produce more informative messages
+  when the assertion fails.
+
 1.3.7 (2018-10-12)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+clone_depth: 50
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
@@ -9,6 +10,11 @@ environment:
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
+    - PYTHON: "C:\\pypy2-v6.0.0-win32"
+      PYTHON_ID: "pypy"
+      PYTHON_EXE: pypy
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
@@ -24,12 +30,6 @@ environment:
       PYTHON_VERSION: "3.6.x" # currently 3.6.0
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
-
-    - PYTHON: "C:\\pypy2-v6.0.0-win32"
-      PYTHON_ID: "pypy"
-      PYTHON_EXE: pypy
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x" # currently 3.4.4
@@ -138,7 +138,15 @@ cache:
   - '%LOCALAPPDATA%\pip\Cache'
 
 build_script:
-  - "%PYEXE% -m pip install -U --upgrade-strategy=eager .[test,events,dnspython]"
+  # Build the compiled extension
+  - "%CMD_IN_ENV% %PYEXE% -m pip wheel . -w dist"
+  - ps: "ls dist"
+  # Now install the wheel.
+  # I couldn't get wildcards to work for pip install, so stuff it
+  # into a variable, using python to glob.
+  - "%PYEXE% -c \"import glob; print(glob.glob('dist/gevent*whl')[0])\" > whl.txt"
+  - set /p PYWHL=<whl.txt
+  - "%PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]"
 
 test_script:
   # Run the project tests
@@ -147,12 +155,15 @@ test_script:
   - "%PYEXE% -mgevent.tests --config known_failures.py --quiet"
 
 after_test:
-  - "%CMD_IN_ENV% %PYEXE% setup.py bdist_wheel"
+  # We already built the wheel during build_script, because it's
+  # much faster to do that and install from the wheel than to
+  # rebuild it here
+  #- "%CMD_IN_ENV% %PYEXE% setup.py bdist_wheel bdist_wininst"
   - ps: "ls dist"
 
 artifacts:
   # Archive the generated wheel package in the ci.appveyor.com build report.
-  - path: dist\*whl
+  - path: dist\gevent*whl
 
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    # Use a fixed hash seed for reproducability
+    PYTHONHASHSEED: 8675309
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - if not "%GWHEEL_ONLY%"=="true" %CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt
+  - "%CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt"
 
   - ps: "if(Test-Path(\"${env:PYTHON}\\bin\")) {ls ${env:PYTHON}\\bin;}"
   - ps: "if(Test-Path(\"${env:PYTHON}\\Scripts\")) {ls ${env:PYTHON}\\Scripts;}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - if not %GWHEEL_ONLY%==true %CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt
+  - if not "%GWHEEL_ONLY%"=="true" %CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt
 
   - ps: "if(Test-Path(\"${env:PYTHON}\\bin\")) {ls ${env:PYTHON}\\bin;}"
   - ps: "if(Test-Path(\"${env:PYTHON}\\Scripts\")) {ls ${env:PYTHON}\\Scripts;}"
@@ -156,13 +156,13 @@ build_script:
   # into a variable, using python to glob.
   - "%PYEXE% -c \"import glob; print(glob.glob('dist/gevent*whl')[0])\" > whl.txt"
   - set /p PYWHL=<whl.txt
-  - if not %GWHEEL_ONLY%==true %PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]
+  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]
 
 test_script:
   # Run the project tests
-  - if not %GWHEEL_ONLY%==true %PYEXE% -c "import gevent.core; print(gevent.core.loop)"
-  - if not %GWHEEL_ONLY%==true %PYEXE% -c "import gevent; print(gevent.config.settings['resolver'].get_options())"
-  - if not %GWHEEL_ONLY%==true %PYEXE% -mgevent.tests --config known_failures.py --quiet
+  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -c "import gevent.core; print(gevent.core.loop)"
+  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -c "import gevent; print(gevent.config.settings['resolver'].get_options())"
+  - if not "%GWHEEL_ONLY%"=="true" %PYEXE% -mgevent.tests --config known_failures.py --quiet
 
 after_test:
   # We already built the wheel during build_script, because it's

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 
-    - PYTHON: "C:\\pypy2-v5.10.0-win32"
+    - PYTHON: "C:\\pypy2-v6.0.0-win32"
       PYTHON_ID: "pypy"
       PYTHON_EXE: pypy
       PYTHON_VERSION: "2.7.x"
@@ -99,10 +99,10 @@ install:
         New-Item -ItemType directory -Path "$env:PYTMP" | Out-Null;
       }
       if ("${env:PYTHON_ID}" -eq "pypy") {
-        if (!(Test-Path "${env:PYTMP}\pypy2-v5.10.0-win32.zip")) {
-          (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.10.0-win32.zip', "${env:PYTMP}\pypy2-v5.10.0-win32.zip");
+        if (!(Test-Path "${env:PYTMP}\pypy2-v6.0.0-win32.zip")) {
+          (New-Object Net.WebClient).DownloadFile('https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-win32.zip', "${env:PYTMP}\pypy2-v6.0.0-win32.zip");
         }
-        7z x -y "${env:PYTMP}\pypy2-v5.10.0-win32.zip" -oC:\ | Out-Null;
+        7z x -y "${env:PYTMP}\pypy2-v6.0.0-win32.zip" -oC:\ | Out-Null;
         & "${env:PYTHON}\pypy.exe" "-mensurepip";
 
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - if not %GWHEEL_ONLY%==true "%CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt"
+  - if not %GWHEEL_ONLY%==true %CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt
 
   - ps: "if(Test-Path(\"${env:PYTHON}\\bin\")) {ls ${env:PYTHON}\\bin;}"
   - ps: "if(Test-Path(\"${env:PYTHON}\\Scripts\")) {ls ${env:PYTHON}\\Scripts;}"
@@ -156,13 +156,13 @@ build_script:
   # into a variable, using python to glob.
   - "%PYEXE% -c \"import glob; print(glob.glob('dist/gevent*whl')[0])\" > whl.txt"
   - set /p PYWHL=<whl.txt
-  - if not %GWHEEL_ONLY%==true "%PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]"
+  - if not %GWHEEL_ONLY%==true %PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]
 
 test_script:
   # Run the project tests
-  - if not %GWHEEL_ONLY%==true "%PYEXE% -c \"import gevent.core; print(gevent.core.loop)\""
-  - if not %GWHEEL_ONLY%==true "%PYEXE% -c \"import gevent; print(gevent.config.settings['resolver'].get_options())\""
-  - if not %GWHEEL_ONLY%==true "%PYEXE% -mgevent.tests --config known_failures.py --quiet"
+  - if not %GWHEEL_ONLY%==true %PYEXE% -c "import gevent.core; print(gevent.core.loop)"
+  - if not %GWHEEL_ONLY%==true %PYEXE% -c "import gevent; print(gevent.config.settings['resolver'].get_options())"
+  - if not %GWHEEL_ONLY%==true %PYEXE% -mgevent.tests --config known_failures.py --quiet
 
 after_test:
   # We already built the wheel during build_script, because it's

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,8 @@ environment:
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
-    - PYTHON: "C:\\pypy2-v6.0.0-win32"
-      PYTHON_ID: "pypy"
-      PYTHON_EXE: pypy
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
+
+    # 64-bit
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
@@ -31,30 +28,27 @@ environment:
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.4
-      PYTHON_ARCH: "64"
-      PYTHON_EXE: python
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x" # currently 3.5.2
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.2
-      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.4
+      PYTHON_ARCH: "64"
       PYTHON_EXE: python
-      GWHEEL_ONLY: true
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.13
+    # 32-bit
+    - PYTHON: "C:\\pypy2-v6.0.0-win32"
+      PYTHON_ID: "pypy"
+      PYTHON_EXE: pypy
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+    # 32-bit, wheel only (no testing)
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
       GWHEEL_ONLY: true
@@ -65,12 +59,23 @@ environment:
       PYTHON_EXE: python
       GWHEEL_ONLY: true
 
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.x"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x" # currently 3.5.2
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
       GWHEEL_ONLY: true
 
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "32"
+      PYTHON_EXE: python
+      GWHEEL_ONLY: true
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.13
+      PYTHON_ARCH: "32"
+      PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
     # Also test a Python version not pre-installed
     # See: https://github.com/ogrisel/python-appveyor-demo/issues/10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,21 +45,31 @@ environment:
       PYTHON_VERSION: "3.5.x" # currently 3.5.2
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x" # currently 2.7.13
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x" # currently 3.6.3
       PYTHON_ARCH: "32"
       PYTHON_EXE: python
+      GWHEEL_ONLY: true
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
+      PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
 
     # Also test a Python version not pre-installed
@@ -128,7 +138,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt"
+  - if not %GWHEEL_ONLY%==true "%CMD_IN_ENV% %PYEXE% -m pip install -U --upgrade-strategy=eager -r ci-requirements.txt"
 
   - ps: "if(Test-Path(\"${env:PYTHON}\\bin\")) {ls ${env:PYTHON}\\bin;}"
   - ps: "if(Test-Path(\"${env:PYTHON}\\Scripts\")) {ls ${env:PYTHON}\\Scripts;}"
@@ -146,13 +156,13 @@ build_script:
   # into a variable, using python to glob.
   - "%PYEXE% -c \"import glob; print(glob.glob('dist/gevent*whl')[0])\" > whl.txt"
   - set /p PYWHL=<whl.txt
-  - "%PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]"
+  - if not %GWHEEL_ONLY%==true "%PYEXE% -m pip install -U --upgrade-strategy=eager %PYWHL%[test,events,dnspython]"
 
 test_script:
   # Run the project tests
-  - "%PYEXE% -c \"import gevent.core; print(gevent.core.loop)\""
-  - "%PYEXE% -c \"import gevent; print(gevent.config.settings['resolver'].get_options())\""
-  - "%PYEXE% -mgevent.tests --config known_failures.py --quiet"
+  - if not %GWHEEL_ONLY%==true "%PYEXE% -c \"import gevent.core; print(gevent.core.loop)\""
+  - if not %GWHEEL_ONLY%==true "%PYEXE% -c \"import gevent; print(gevent.config.settings['resolver'].get_options())\""
+  - if not %GWHEEL_ONLY%==true "%PYEXE% -mgevent.tests --config known_failures.py --quiet"
 
 after_test:
   # We already built the wheel during build_script, because it's

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -593,6 +593,7 @@ if WIN:
         'test_socket.SendfileUsingSendTest.testWithTimeout': _flaky_socket_timeout,
         'test_socket.SendfileUsingSendTest.testOffset': _flaky_socket_timeout,
         'test_socket.SendfileUsingSendTest.testRegularFile': _flaky_socket_timeout,
+        'test_socket.SendfileUsingSendTest.testCount': _flaky_socket_timeout,
     })
 
 if PYPY:

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -461,9 +461,11 @@ if LIBUV:
             # Inserting GCs doesn't fix it.
             'test_ssl.ThreadedTests.test_handshake_timeout',
 
-            # These sometimes raise LoopExit, for no apparent reason.
+            # These sometimes raise LoopExit, for no apparent reason,
+            # mostly but not exclusively on Python 2.
             'test_socket.BufferIOTest.testRecvFromIntoBytearray',
             'test_socket.BufferIOTest.testRecvFromIntoArray',
+            'test_socket.BufferIOTest.testRecvFromIntoEmptyBuffer',
         ]
 
         if PY3:

--- a/src/gevent/tests/test__greenlet.py
+++ b/src/gevent/tests/test__greenlet.py
@@ -424,13 +424,24 @@ class TestStr(greentest.TestCase):
         assert_not_ready(g)
         g.join()
         assert_ready(g)
-        self.assertTrue(hexobj.sub('X', str(g)).endswith(' at X: dummy_test_func>'))
+        self.assertTrue(hexobj.sub('X', str(g)).endswith(' at X: dummy_test_func>'), str(g))
 
     def test_method(self):
         g = gevent.Greenlet.spawn(A().method)
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertTrue(str_g.startswith('<Greenlet "Greenlet-'))
+        self.assertTrue(str_g.startswith('<Greenlet at X:'), str_g)
+        # Accessing the name to generate a minimal_ident will cause it to be included.
+        getattr(g, 'name')
+        str_g = hexobj.sub('X', str(g))
+        str_g = str_g.replace(__name__, 'module')
+        self.assertTrue(str_g.startswith('<Greenlet "Greenlet-'), str_g)
+        # Assigning to the name changes it
+        g.name = 'Foo'
+        str_g = hexobj.sub('X', str(g))
+        str_g = str_g.replace(__name__, 'module')
+        self.assertTrue(str_g.startswith('<Greenlet "Foo"'), str_g)
+
         self.assertTrue(str_g.endswith('at X: <bound method A.method of <module.A object at X>>>'))
         assert_not_ready(g)
         g.join()
@@ -443,7 +454,7 @@ class TestStr(greentest.TestCase):
         g = Subclass()
         str_g = hexobj.sub('X', str(g))
         str_g = str_g.replace(__name__, 'module')
-        self.assertTrue(str_g.startswith('<Subclass '))
+        self.assertTrue(str_g.startswith('<Subclass '), str_g)
         self.assertTrue(str_g.endswith('at X: _run>'))
 
         g = Subclass(None, 'question', answer=42)

--- a/src/gevent/tests/test__hub.py
+++ b/src/gevent/tests/test__hub.py
@@ -115,8 +115,11 @@ class TestWaiter(greentest.TestCase):
 
         waiter = Waiter()
         g = gevent.spawn(waiter.get)
+        g.name = 'AName'
         gevent.sleep(0)
-        self.assertTrue(str(waiter).startswith('<Waiter greenlet=<Greenlet "Greenlet-'))
+        str_waiter = str(waiter)
+        self.assertTrue(str_waiter.startswith('<Waiter greenlet=<Greenlet "AName'),
+                        str_waiter)
 
         g.kill()
 


### PR DESCRIPTION
- Use a fixed hashseed everywhere to maybe help with failure reproduction
- Build windows wheels for 3.7 32-bit (but don't run tests there; in fact stop double-testing most 32-bit implementations, with the exception of PyPy).
- Fix several flaky tests, including a GC issue with weakrefs and interpreter shutdown