### PR TITLE
Use _is_owned method to check RLock ownership.

### DIFF
--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -485,11 +485,10 @@ def _patch_existing_locks(threading):
     gc = __import__('gc')
     for o in gc.get_objects():
         if isinstance(o, rlock_type):
-            if hasattr(o, '_owner'): # Py3
-                if o._owner is not None:
+            if o._is_owned():
+                if hasattr(o, '_owner'): # Py3
                     o._owner = tid
-            else:
-                if o._RLock__owner is not None:
+                else:
                     o._RLock__owner = tid
         elif isinstance(o, _ModuleLock):
             if o.owner is not None:


### PR DESCRIPTION
Fixes PyPY 2.7-7 compatability issue with monkey.patch_all(). Namely, the following raises an attribute error under PyPy2.7-7:
```python
from gevent import monkey
monkey.patch_all()
```

See https://bitbucket.org/pypy/pypy/issues/2962/gevent-cannot-patch-rlock-under-pypy-27-7 for the underlying PyPy change and a minimal dockerfile reproducing the error.

It is possible I can add some backwards compatible patches to the PyPy codebase. But this PR fixes basic monkey patching functionality under PyPy 2.7-7.0.0.