### PR TITLE
Basic PyPy2.7-7 compatibility

### DIFF
--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -218,6 +218,11 @@ if sys.version_info[:2] >= (3, 3):
     _CRLock = None
     __implements__.append('_CRLock')
 
+elif hasattr(__threading__, '_CRLock'):
+    # Version 7 of PyPy2 backports _CRLock
+    _CRLock = None
+    __implements__.append('_CRLock')
+
 def _gevent_will_monkey_patch(native_module, items, warn): # pylint:disable=unused-argument
     # Make sure the MainThread can be found by our current greenlet ID,
     # otherwise we get a new DummyThread, which cannot be joined.


### PR DESCRIPTION
See https://github.com/gevent/gevent/issues/1356

This PR makes it possible to run `monkey.patch_all()` under PyPy2.7-7. It should not affect any other python version.

As with Python3, it works essentially by rendering `_patch_existing_locks` a no-op on `_CRLock` objects. This means there will be similar behaviour: any locks acquired before patching will not be patched under PyPy2.7-7.