### PR TITLE
 Patch the 'thread' module provided by 'future' if it's already imported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,14 @@
   <https://bugs.python.org/issue32270>`_ applied to all versions
   gevent runs on.
 
+- Python 2: If the backport of the ``_thread_`` module from
+  ``futures`` has already been imported at monkey-patch time, also
+  patch this module to be consistent. The ``pkg_resources`` package
+  imports this, and ``pkg_resources`` is often imported early on
+  Python 2 for namespace packages, so if ``futures`` is installed this
+  will likely be the case.
+
+
 1.4.0 (2019-01-04)
 ==================
 

--- a/src/gevent/_compat.py
+++ b/src/gevent/_compat.py
@@ -5,12 +5,19 @@ internal gevent python 2/python 3 bridges. Not for external use.
 
 from __future__ import print_function, absolute_import, division
 
+## Important: This module should generally not have any other gevent
+## imports (the exception is _util_py2)
+
 import sys
 import os
 
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
+PY35 = sys.version_info[:2] >= (3, 5)
+PY36 = sys.version_info[:2] >= (3, 6)
+PY37 = sys.version_info[:2] >= (3, 7)
+PY38 = sys.version_info[:2] >= (3, 8)
 PYPY = hasattr(sys, 'pypy_version_info')
 WIN = sys.platform.startswith("win")
 LINUX = sys.platform.startswith('linux')

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -607,25 +607,23 @@ class socket(object):
         """
         return self._sendfile_use_send(file, offset, count)
 
-    # get/set_inheritable new in 3.4
-    if hasattr(os, 'get_inheritable') or hasattr(os, 'get_handle_inheritable'):
-        # pylint:disable=no-member
-        if os.name == 'nt':
-            def get_inheritable(self):
-                return os.get_handle_inheritable(self.fileno())
 
-            def set_inheritable(self, inheritable):
-                os.set_handle_inheritable(self.fileno(), inheritable)
-        else:
-            def get_inheritable(self):
-                return os.get_inheritable(self.fileno())
+    if os.name == 'nt':
+        def get_inheritable(self):
+            return os.get_handle_inheritable(self.fileno())
 
-            def set_inheritable(self, inheritable):
-                os.set_inheritable(self.fileno(), inheritable)
-        _added = "\n\n.. versionadded:: 1.1rc4 Added in Python 3.4"
-        get_inheritable.__doc__ = "Get the inheritable flag of the socket" + _added
-        set_inheritable.__doc__ = "Set the inheritable flag of the socket" + _added
-        del _added
+        def set_inheritable(self, inheritable):
+            os.set_handle_inheritable(self.fileno(), inheritable)
+    else:
+        def get_inheritable(self):
+            return os.get_inheritable(self.fileno())
+
+        def set_inheritable(self, inheritable):
+            os.set_inheritable(self.fileno(), inheritable)
+
+    get_inheritable.__doc__ = "Get the inheritable flag of the socket"
+    set_inheritable.__doc__ = "Set the inheritable flag of the socket"
+
 
 
 SocketType = socket
@@ -651,6 +649,7 @@ if hasattr(_socket.socket, "share"):
         return socket(0, 0, 0, info)
 
     __implements__.append('fromshare')
+
 
 if hasattr(_socket, "socketpair"):
 
@@ -722,14 +721,6 @@ else: # pragma: no cover
         finally:
             lsock.close()
         return (ssock, csock)
-
-    if sys.version_info[:2] < (3, 5):
-        # Not provided natively
-        if 'socketpair' in __implements__:
-            # Multiple imports can cause this to be missing if _socketcommon
-            # was successfully imported, leading to subsequent imports to cause
-            # ValueError
-            __implements__.remove('socketpair')
 
 
 if hasattr(__socket__, 'close'): # Python 3.7b1+

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -678,9 +678,8 @@ if hasattr(_socket, "socketpair"):
 else: # pragma: no cover
     # Origin: https://gist.github.com/4325783, by Geert Jansen.  Public domain.
 
-    # gevent: taken from 3.6 release. Expected to be used only on Win. Added to Win/3.5
-    # gevent: for < 3.5, pass the default value of 128 to lsock.listen()
-    # (3.5+ uses this as a default and the original code passed no value)
+    # gevent: taken from 3.6 release, confirmed unchanged in 3.7 and
+    # 3.8a1. Expected to be used only on Win. Added to Win/3.5
 
     _LOCALHOST = '127.0.0.1'
     _LOCALHOST_V6 = '::1'
@@ -703,7 +702,7 @@ else: # pragma: no cover
         lsock = socket(family, type, proto)
         try:
             lsock.bind((host, 0))
-            lsock.listen(128)
+            lsock.listen()
             # On IPv6, ignore flow_info and scope_id
             addr, port = lsock.getsockname()[:2]
             csock = socket(family, type, proto)

--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -17,6 +17,7 @@ from gevent.greenlet import Greenlet
 from gevent.hub import getcurrent
 from gevent.server import StreamServer
 from gevent.pool import Pool
+from gevent._compat import PY36
 
 __all__ = ['BackdoorServer']
 
@@ -145,7 +146,7 @@ class BackdoorServer(StreamServer):
         getcurrent().switch_in()
         try:
             console = InteractiveConsole(self._create_interactive_locals())
-            if sys.version_info[:3] >= (3, 6, 0):
+            if PY36:
                 # Beginning in 3.6, the console likes to print "now exiting <class>"
                 # but probably our socket is already closed, so this just causes problems.
                 console.interact(banner=self.banner, exitmsg='') # pylint:disable=unexpected-keyword-arg

--- a/src/gevent/builtins.py
+++ b/src/gevent/builtins.py
@@ -2,10 +2,10 @@
 """gevent friendly implementations of builtin functions."""
 from __future__ import absolute_import
 
-import sys
 import weakref
 
 from gevent.lock import RLock
+from gevent._compat import PY3
 from gevent._compat import imp_acquire_lock
 from gevent._compat import imp_release_lock
 
@@ -121,7 +121,7 @@ def _lock_imports():
     global __lock_imports
     __lock_imports = True
 
-if sys.version_info[:2] >= (3, 3):
+if PY3:
     __implements__ = []
     __import__ = _import
 else:

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -44,6 +44,9 @@ from gevent.hub import sleep
 from gevent.hub import getcurrent
 from gevent._compat import integer_types, string_types, xrange
 from gevent._compat import PY3
+from gevent._compat import PY35
+from gevent._compat import PY36
+from gevent._compat import PY37
 from gevent._compat import reraise
 from gevent._compat import fspath
 from gevent._compat import fsencode
@@ -118,7 +121,7 @@ __extra__ = [
     'CompletedProcess',
 ]
 
-if sys.version_info[:2] >= (3, 3):
+if PY3:
     __imports__ += [
         'DEVNULL',
         'getstatusoutput',
@@ -130,7 +133,7 @@ else:
     __extra__.append("TimeoutExpired")
 
 
-if sys.version_info[:2] >= (3, 5):
+if PY35:
     __extra__.remove('run')
     __extra__.remove('CompletedProcess')
     __implements__.append('run')
@@ -144,12 +147,12 @@ if sys.version_info[:2] >= (3, 5):
     except:
         MAXFD = 256
 
-if sys.version_info[:2] >= (3, 6):
+if PY36:
     # This was added to __all__ for windows in 3.6
     __extra__.remove('STARTUPINFO')
     __imports__.append('STARTUPINFO')
 
-if sys.version_info[:2] >= (3, 7):
+if PY37:
     __imports__.extend([
         'ABOVE_NORMAL_PRIORITY_CLASS', 'BELOW_NORMAL_PRIORITY_CLASS',
         'HIGH_PRIORITY_CLASS', 'IDLE_PRIORITY_CLASS',
@@ -479,7 +482,7 @@ class Popen(object):
             if preexec_fn is not None:
                 raise ValueError("preexec_fn is not supported on Windows "
                                  "platforms")
-            if sys.version_info[:2] >= (3, 7):
+            if PY37:
                 if close_fds is _PLATFORM_DEFAULT_CLOSE_FDS:
                     close_fds = True
             else:

--- a/src/gevent/tests/test__monkey_futures_thread.py
+++ b/src/gevent/tests/test__monkey_futures_thread.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Tests that on Python 2, if the futures backport of 'thread' is already
+imported before we monkey-patch, it gets patched too.
+"""
+
+import unittest
+
+try:
+    import thread
+    import _thread
+    HAS_BOTH = True
+except ImportError:
+    HAS_BOTH = False
+
+class TestMonkey(unittest.TestCase):
+
+    @unittest.skipUnless(HAS_BOTH, "Python 2, needs future backport installed")
+    def test_patches_both(self):
+        thread_lt = thread.LockType
+        _thread_lt = _thread.LockType
+        self.assertIs(thread_lt, _thread_lt)
+
+        from gevent.thread import LockType as gLockType
+
+        self.assertIsNot(thread_lt, gLockType)
+
+        import gevent.monkey
+        gevent.monkey.patch_all()
+
+        thread_lt2 = thread.LockType
+        _thread_lt2 = _thread.LockType
+
+        self.assertIs(thread_lt2, gLockType)
+        self.assertIs(_thread_lt2, gLockType)
+
+        self.assertIs(thread_lt2, _thread_lt2)
+        self.assertIsNot(thread_lt2, thread_lt)
+
+        # Retrieving the original on the old name still works
+        orig_locktype = gevent.monkey.get_original('thread', 'LockType')
+        self.assertIs(orig_locktype, thread_lt)
+
+        # And the new name
+        orig__locktype = gevent.monkey.get_original('_thread', 'LockType')
+        self.assertIs(orig__locktype, thread_lt)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/gevent/tests/test__threading_monkey_in_thread.py
+++ b/src/gevent/tests/test__threading_monkey_in_thread.py
@@ -1,6 +1,6 @@
 # We can monkey-patch in a thread, but things don't work as expected.
 from __future__ import print_function
-import sys
+
 import threading
 from gevent import monkey
 import gevent.testing as greentest

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -157,7 +157,6 @@ else:
 
         return main_threads[0]
 
-import sys
 if PY3:
     # XXX: Issue 18808 breaks us on Python 3.4+.
     # Thread objects now expect a callback from the interpreter itself

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -39,8 +39,13 @@ __implements__ = [
 import threading as __threading__
 _DummyThread_ = __threading__._DummyThread
 from gevent.local import local
-from gevent.thread import start_new_thread as _start_new_thread, allocate_lock as _allocate_lock, get_ident as _get_ident
+from gevent.thread import start_new_thread as _start_new_thread
+from gevent.thread import allocate_lock as _allocate_lock
+from gevent.thread import get_ident as _get_ident
 from gevent.hub import sleep as _sleep, getcurrent
+
+from gevent._compat import PY3
+from gevent._compat import PYPY
 
 # Exports, prevent unused import warnings
 local = local
@@ -153,7 +158,7 @@ else:
         return main_threads[0]
 
 import sys
-if sys.version_info[0] >= 3:
+if PY3:
     # XXX: Issue 18808 breaks us on Python 3.4+.
     # Thread objects now expect a callback from the interpreter itself
     # (threadmodule.c:release_sentinel). Because this never happens
@@ -202,7 +207,7 @@ if sys.version_info[0] >= 3:
     # The main thread is patched up with more care
     # in _gevent_will_monkey_patch
 
-if sys.version_info[0] >= 3:
+if PY3:
     __implements__.remove('_get_ident')
     __implements__.append('get_ident')
     get_ident = _get_ident
@@ -217,7 +222,7 @@ if hasattr(__threading__, '_CRLock'):
     # Fortunately they left the Python fallback in place.
 
     # This was also backported to PyPy 2.7-7.0
-    assert sys.version_info[0] >= 3 or hasattr(sys, 'pypy_version_info'), "Unsupported Python version"
+    assert PY3 or PYPY, "Unsupported Python version"
     _CRLock = None
     __implements__.append('_CRLock')
 


### PR DESCRIPTION
This is likely under Python 2, because pkg_resources imports it if it's installed. It does a `from thread import *`, meaning anything that tries to also use `_thread.LockType` or such would be inconsistent if it had already been imported.

Our development stack winds up pulling in `future` as a dependency of something, which is how I discovered this; debugging was confusing for a bit.

Also a few minor Python 3 cleanups.