### PR TITLE
libev-cffi: Use nlink_t and let the compiler fill in the definition.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,10 @@
 - Avoid unbounded memory usage when creating very deep spawn trees.
   Reported in :issue:`1371` by dmrlawson.
 
+- libev-cffi: Let the compiler fill in the definition of ``nlink_t`` for
+  ``st_nlink`` in ``struct stat``, instead of trying to guess it
+  ourself. Reported in :issue:`1372` by Andreas Schwab.
+
 1.4.0 (2019-01-04)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ if not WIN:
     # Python API functions, and you're not supposed to do that from
     # CFFI code. Plus I could never get the libraries= line to ffi.compile()
     # correct to make linking work.
+    # Also, we use the type `nlink_t`, which is not defined on Windows.
     cffi_modules.append(
         LIBEV_CFFI_MODULE
     )

--- a/src/gevent/libev/_corecffi_build.py
+++ b/src/gevent/libev/_corecffi_build.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 import sys
 import os
 import os.path # pylint:disable=no-name-in-module
-import struct
+
 
 __all__ = []
 

--- a/src/gevent/libev/_corecffi_build.py
+++ b/src/gevent/libev/_corecffi_build.py
@@ -15,18 +15,6 @@ import struct
 __all__ = []
 
 
-def system_bits():
-    return struct.calcsize('P') * 8
-
-
-def st_nlink_type():
-    if sys.platform == "darwin" or sys.platform.startswith("freebsd"):
-        return "short"
-    if system_bits() == 32:
-        return "unsigned long"
-    return "long long"
-
-
 from cffi import FFI
 ffi = FFI()
 
@@ -38,10 +26,14 @@ def read_source(name):
 _cdef = read_source('_corecffi_cdef.c')
 _source = read_source('_corecffi_source.c')
 
-_cdef = _cdef.replace('#define GEVENT_ST_NLINK_T int', '')
+# These defines and uses help keep the C file readable and lintable by
+# C tools.
 _cdef = _cdef.replace('#define GEVENT_STRUCT_DONE int', '')
-_cdef = _cdef.replace('GEVENT_ST_NLINK_T', st_nlink_type())
 _cdef = _cdef.replace("GEVENT_STRUCT_DONE _;", '...;')
+
+_cdef = _cdef.replace('#define GEVENT_ST_NLINK_T int',
+                      'typedef int... nlink_t;')
+_cdef = _cdef.replace('GEVENT_ST_NLINK_T', 'nlink_t')
 
 
 if sys.platform.startswith('win'):

--- a/src/gevent/libev/_corecffi_source.c
+++ b/src/gevent/libev/_corecffi_source.c
@@ -19,8 +19,8 @@ static void python_handle_error(void* handle, int revents);
 static void python_stop(void* handle);
 
 static void _gevent_generic_callback(struct ev_loop* loop,
-									 struct ev_watcher* watcher,
-									 int revents)
+				     struct ev_watcher* watcher,
+				     int revents)
 {
     void* handle = watcher->data;
     int cb_result = python_callback(handle, revents);
@@ -45,7 +45,7 @@ static void _gevent_generic_callback(struct ev_loop* loop,
         default:
             fprintf(stderr,
                     "WARNING: gevent: Unexpected return value %d from Python callback "
-                    "for watcher %p and handle %d\n",
+                    "for watcher %p and handle %p\n",
                     cb_result,
                     watcher, handle);
             // XXX: Possible leaking of resources here? Should we be

--- a/src/gevent/libuv/_corecffi_build.py
+++ b/src/gevent/libuv/_corecffi_build.py
@@ -33,8 +33,9 @@ _source = read_source('_corecffi_source.c')
 _cdef = _cdef.replace('#define GEVENT_STRUCT_DONE int', '')
 _cdef = _cdef.replace("GEVENT_STRUCT_DONE _;", '...;')
 
+# nlink_t is not used in libuv.
 _cdef = _cdef.replace('#define GEVENT_ST_NLINK_T int',
-                      'typedef int... nlink_t;')
+                      '')
 _cdef = _cdef.replace('GEVENT_ST_NLINK_T', 'nlink_t')
 
 

--- a/src/gevent/libuv/_corecffi_build.py
+++ b/src/gevent/libuv/_corecffi_build.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 import sys
 import os
 import os.path # pylint:disable=no-name-in-module
-import struct
+
 
 __all__ = []
 

--- a/src/gevent/testing/testrunner.py
+++ b/src/gevent/testing/testrunner.py
@@ -353,7 +353,10 @@ def print_list(lst):
         log(' - %s', name)
 
 def _setup_environ(debug=False):
-    if 'PYTHONWARNINGS' not in os.environ and not sys.warnoptions:
+    if ('PYTHONWARNINGS' not in os.environ
+            and (not sys.warnoptions
+                 # Python 3.7 goes from [] to ['default'] for nothing
+                 or sys.warnoptions == ['default'])):
 
         # action:message:category:module:line
         os.environ['PYTHONWARNINGS'] = ','.join([
@@ -373,6 +376,10 @@ def _setup_environ(debug=False):
             'ignore:::importlib._bootstrap_external:',
             # importing ABCs from collections, not collections.abc
             'ignore:::pkg_resources._vendor.pyparsing:',
+            'ignore:::dns.namedict:',
+            # dns.hash itself is being deprecated, importing it raises the warning;
+            # we don't import it, but dnspython still does
+            'ignore:::dns.hash:',
         ])
 
     if 'PYTHONFAULTHANDLER' not in os.environ:


### PR DESCRIPTION
Fixes #1372.

This may require a slightly stricter adherance to POSIX? It is defined by IEEE Std 1003.1 2004 (http://pubs.opengroup.org/onlinepubs/009696699/basedefs/sys/types.h.html)