### PR TITLE
Performance and correctness improvements for Greenlets.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,19 @@
 - Win: Make ``examples/process.py`` do something useful. See
   :pr:`1378` by Robert Iannucci.
 
+- Fix certain operations on a Greenlet in an invalid state (with an
+  invalid parent) to raise a `TypeError` sooner rather than an
+  `AttributeError` later. This is also slightly faster on CPython with
+  Cython. Inspired by :issue:`1363` as reported by Carson Ip. This
+  means that some extreme corner cases that might have passed by
+  replacing a Greenlet's parent with something that's not a gevent hub
+  now no longer will.
+
+- Fix: The ``spawning_stack`` for Greenlets on CPython should now have
+  correct line numbers in more cases.
+
+- Spawning greenlets can be up to 10% faster.
+
 1.4.0 (2019-01-04)
 ==================
 

--- a/src/gevent/__hub_primitives.pxd
+++ b/src/gevent/__hub_primitives.pxd
@@ -39,7 +39,7 @@ cdef inline void greenlet_init():
 
 
 cdef class WaitOperationsGreenlet(SwitchOutGreenletWithLoop):
-
+    # The Hub will extend this class.
     cpdef wait(self, watcher)
     cpdef cancel_wait(self, watcher, error, close_watcher=*)
     cpdef _cancel_wait(self, watcher, error, close_watcher)

--- a/src/gevent/__init__.py
+++ b/src/gevent/__init__.py
@@ -21,7 +21,7 @@ _version_info = namedtuple('version_info',
 #: .. deprecated:: 1.2
 #:  Use ``pkg_resources.parse_version(__version__)`` (or the equivalent
 #:  ``packaging.version.Version(__version__)``).
-version_info = _version_info(1, 4, 0, 'dev', 0)
+version_info = _version_info(1, 5, 0, 'dev', 0)
 
 #: The human-readable PEP 440 version identifier.
 #: Use ``pkg_resources.parse_version(__version__)`` or

--- a/src/gevent/_hub_primitives.py
+++ b/src/gevent/_hub_primitives.py
@@ -54,9 +54,15 @@ class WaitOperationsGreenlet(SwitchOutGreenletWithLoop): # pylint:disable=undefi
         try:
             result = waiter.get()
             if result is not waiter:
-                raise InvalidSwitchError('Invalid switch into %s: %r (expected %r)' % (
-                    getcurrent(), # pylint:disable=undefined-variable
-                    result, waiter))
+                raise InvalidSwitchError(
+                    'Invalid switch into %s: got %r (expected %r; waiting on %r with %r)' % (
+                        getcurrent(), # pylint:disable=undefined-variable
+                        result,
+                        waiter,
+                        self,
+                        watcher
+                    )
+                )
         finally:
             watcher.stop()
 

--- a/src/gevent/_ident.py
+++ b/src/gevent/_ident.py
@@ -27,7 +27,7 @@ class ValuedWeakRef(ref):
 
 class IdentRegistry(object):
     """
-    Maintains a unique mapping of (small) positive integer identifiers
+    Maintains a unique mapping of (small) non-negative integer identifiers
     to objects that can be weakly referenced.
 
     It is guaranteed that no two objects will have the the same

--- a/src/gevent/util.py
+++ b/src/gevent/util.py
@@ -417,9 +417,11 @@ class GreenletTree(object):
     def __render_children(self, tree):
         children = sorted(self.child_trees,
                           key=lambda c: (
-                              # raw greenlets first
+                              # raw greenlets first. Note that we could be accessing
+                              # minimal_ident for a hub from a different thread, which isn't
+                              # technically thread safe.
                               getattr(c, 'minimal_ident', -1),
-                              # running greenlets first
+                              # running greenlets next
                               getattr(c, 'ready', _ready)(),
                               id(c.parent)))
         for n, child in enumerate(children):


### PR DESCRIPTION
- Rework getting the stack, since we're no longer arbitrarily extending it. This is faster, and I found and fixed a bug on CPython.

- Let Cython do more of the work making sure we really have a hub as our parent.