### PR TITLE
Fix #1441 - FileObjectPosix should use 'str' in text mode

### DIFF
--- a/src/gevent/_fileobjectcommon.py
+++ b/src/gevent/_fileobjectcommon.py
@@ -60,11 +60,10 @@ class FileObjectBase(object):
     )
 
 
-    # Whether we are translating universal newlines or not.
-    _translate = False
-
-    _translate_encoding = None
-    _translate_errors = None
+    _text_mode = False
+    _text_encoding = None
+    _text_errors = None
+    _text_newline = None
 
     def __init__(self, io, closefd):
         """
@@ -75,10 +74,10 @@ class FileObjectBase(object):
         # pass it along) for compatibility.
         self._close = closefd
 
-        if self._translate:
+        if self._text_mode:
             # This automatically handles delegation by assigning to
             # self.io
-            self.translate_newlines(None, self._translate_encoding, self._translate_errors)
+            self.text_mode(None, self._text_encoding, self._text_errors, self._text_newline)
         else:
             self._do_delegate_methods()
 
@@ -107,12 +106,12 @@ class FileObjectBase(object):
         """
         return method
 
-    def translate_newlines(self, mode, *text_args, **text_kwargs):
+    def text_mode(self, mode, *text_args, **text_kwargs):
         wrapper = TextIOWrapper(self._io, *text_args, **text_kwargs)
         if mode:
             wrapper.mode = mode
         self.io = wrapper
-        self._translate = True
+        self._text_mode = True
 
     @property
     def closed(self):

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -582,10 +582,10 @@ class Popen(object):
                 # Under Python 3, if we left on the 'b' we'd get different results
                 # depending on whether we used FileObjectPosix or FileObjectThread
                 self.stdin = FileObject(p2cwrite, 'wb', bufsize)
-                self.stdin.translate_newlines(None,
-                                              write_through=True,
-                                              line_buffering=(bufsize == 1),
-                                              encoding=self.encoding, errors=self.errors)
+                self.stdin.text_mode(None,
+                                     write_through=True,
+                                     line_buffering=(bufsize == 1),
+                                     encoding=self.encoding, errors=self.errors)
             else:
                 self.stdin = FileObject(p2cwrite, 'wb', bufsize)
         if c2pread != -1:
@@ -600,7 +600,7 @@ class Popen(object):
                     # test__subprocess.py that depend on python_universal_newlines,
                     # but would be inconsistent with the stdlib:
                     #msvcrt.setmode(self.stdout.fileno(), os.O_TEXT)
-                    self.stdout.translate_newlines('r', encoding=self.encoding, errors=self.errors)
+                    self.stdout.text_mode('r', encoding=self.encoding, errors=self.errors)
                 else:
                     self.stdout = FileObject(c2pread, 'rU', bufsize)
             else:
@@ -609,7 +609,7 @@ class Popen(object):
             if universal_newlines or text_mode:
                 if PY3:
                     self.stderr = FileObject(errread, 'rb', bufsize)
-                    self.stderr.translate_newlines(None, encoding=encoding, errors=errors)
+                    self.stderr.text_mode(None, encoding=encoding, errors=errors)
                 else:
                     self.stderr = FileObject(errread, 'rU', bufsize)
             else:


### PR DESCRIPTION
This PR fixes the different issues with FileObjectPosix mentioned in #1441.
This PR introduces a few changes that break backward-compatibility, but for good reasons:
1. Strictly enforcing `mode` prevents strange modes that are not supposed to be possible but could previously be passed, like `wU` and `rbt`. It also fixes some of the issues mentioned in #1441, like when passing `rUt`. The documentation already explicitly mentioned the supported modes, so any code that may break was already using the class improperly.
2. `translate_newlines` was renamed, but it was only used as a workaround specifically for newlines until now, while the new name, `text_mode`, is more general and better explains its effect. I don't know if it is really used directly outside of the package much.