### PR TITLE
Dynamic class in gevent.resolver.thread.Resolver.__repr__

### DIFF
--- a/src/gevent/resolver/thread.py
+++ b/src/gevent/resolver/thread.py
@@ -47,7 +47,9 @@ class Resolver(object):
             hub.NOT_ERROR += (_socket.gaierror, _socket.herror)
 
     def __repr__(self):
-        return '<gevent.resolver_thread.Resolver at 0x%x pool=%r>' % (id(self), self.pool)
+        return '<%s.%s at 0x%x pool=%r>' % (type(self).__module__,
+                                            type(self).__name__,
+                                            id(self), self.pool)
 
     def close(self):
         pass


### PR DESCRIPTION
The class name used in `gevent.resolver.thread.Resolver.__repr__` was
hard-coded. This meant that subclasses needed to reimplement their own
`__repr__`; otherwise, they'd appear as this parent class in debugging
output like that from print_run_info().

This also has the nice side effect of fixing a typo (`resolver_thread`
to `resolver.thread`).