### PR TITLE
Fix references to six.PY3 in case python4 becomes a thing

### DIFF
--- a/src/gevent/_tblib.py
+++ b/src/gevent/_tblib.py
@@ -120,7 +120,7 @@ except ImportError:
 __version__ = '1.3.0'
 __all__ = ('Traceback',)
 
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
 FRAME_RE = re.compile(r'^\s*File "(?P<co_filename>.+)", line (?P<tb_lineno>\d+)(, in (?P<co_name>.+))?$')
 
 

--- a/src/gevent/testing/six.py
+++ b/src/gevent/testing/six.py
@@ -1,6 +1,7 @@
 import sys
 # pylint:disable=unused-argument,import-error
 
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
 
 if PY3:

--- a/src/gevent/testing/sysinfo.py
+++ b/src/gevent/testing/sysinfo.py
@@ -62,7 +62,7 @@ PY36 = None
 PY37 = None
 
 NON_APPLICABLE_SUFFIXES = ()
-if sys.version_info[0] == 3:
+if sys.version_info[0] >= 3:
     # Python 3
     NON_APPLICABLE_SUFFIXES += ('2', '279')
     PY2 = False

--- a/src/gevent/tests/test__all__.py
+++ b/src/gevent/tests/test__all__.py
@@ -27,7 +27,7 @@ NOT_IMPLEMENTED = {
     'select': ANY,
     'os': ANY,
     'threading': ANY,
-    'builtins' if six.PY3 else '__builtin__': ANY,
+    '__builtin__' if six.PY2 else 'builtins': ANY,
     'signal': ANY,
 }
 

--- a/src/gevent/tests/test__exc_info.py
+++ b/src/gevent/tests/test__exc_info.py
@@ -4,7 +4,7 @@ import gevent.testing as greentest
 from gevent.testing import six
 from gevent.testing import ExpectedException as ExpectedError
 
-if not six.PY3:
+if six.PY2:
     sys.exc_clear()
 
 class RawException(Exception):

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -124,7 +124,7 @@ class TestTCP(greentest.TestCase):
     def test_sendall_str(self):
         self._test_sendall(self.long_data)
 
-    if not six.PY3:
+    if six.PY2:
         def test_sendall_unicode(self):
             self._test_sendall(six.text_type(self.long_data))
 


### PR DESCRIPTION
Detected using [flake8-2020](https://github.com/asottile/flake8-2020)