### PR TITLE
API docs: remove duplicated entries for gevent.{queue,server}

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -61,13 +61,11 @@ Module Listing
    gevent.pool
    gevent.pywsgi
    gevent.queue
-   gevent.queue
    gevent.resolver.ares
    gevent.resolver.blocking
    gevent.resolver.dnspython
    gevent.resolver.thread
    gevent.select
-   gevent.server
    gevent.server
    gevent.signal
    gevent.socket


### PR DESCRIPTION
Trivial change: gevent.queue / gevent.server are listed twice in the API docs.