### PR TITLE
Support TLS1.3, OpenSSL 1.1.1 (and Python 3.7.4)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,14 @@
 [MASTER]
 extension-pkg-whitelist=gevent.libuv._corecffi,gevent.libev._corecffi,gevent.local,gevent._ident
 
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+# gevent: The changes for Python 3.7 in _ssl3.py lead to infinite recursion
+# in pylint 2.3.1/astroid 2.2.5 in that file unless we this this to 1
+# from the default of 100.
+limit-inference-results=1
+
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You
@@ -110,3 +118,7 @@ bad-functions=input
 # pylint leaves it off. This is the proximal cause of the
 # undefined-all-variable crash.
 #unsafe-load-any-extension = no
+
+# Local Variables:
+# mode: conf
+# End:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-extension-pkg-whitelist=gevent.libuv._corecffi,gevent.libev._corecffi,gevent.local,gevent._ident
+extension-pkg-whitelist=gevent.greenlet,gevent.libuv._corecffi,gevent.libev._corecffi,gevent.local,gevent._ident
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
@@ -98,9 +98,7 @@ generated-members=exc_clear
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-# greenlet, Greenlet, parent, dead: all attempts to fix issues in greenlet.py
-# only seen on the service, e.g., self.parent.loop: class parent has no loop
-ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
+#ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
@@ -117,7 +115,7 @@ bad-functions=input
 # Prospector turns ot unsafe-load-any-extension by default, but
 # pylint leaves it off. This is the proximal cause of the
 # undefined-all-variable crash.
-#unsafe-load-any-extension = no
+unsafe-load-any-extension = yes
 
 # Local Variables:
 # mode: conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,9 +199,7 @@ jobs:
     # pylint has stopped updating for Python 2.
     - stage: test
       # We need pylint, since above we're not installing a
-      # requirements file. Code added to _ssl3.SSLContext for Python
-      # 3.8 triggers an infinite recursion bug in pylint 2.3.1/astroid 2.2.5
-      # unless we disable inference.
+      # requirements file.
       install: pip install pylint
       script: python -m pylint --limit-inference-results=1 --rcfile=.pylintrc gevent
       env: TRAVIS_PYTHON_VERSION=3.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@
 
 - Implement ``SSLSocket.verify_client_post_handshake()`` when available.
 
+- Fix tests when TLS1.3 is supported.
+
 1.5a1 (2019-05-02)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@
 
 - Fix tests when TLS1.3 is supported.
 
+- Disable Nagle's algorithm in the backdoor server. This can improve
+  interactive response time.
+
 1.5a1 (2019-05-02)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@
 - Disable Nagle's algorithm in the backdoor server. This can improve
   interactive response time.
 
+- Test on Python 3.7.4. There are important SSL test fixes.
+
 1.5a1 (2019-05-02)
 ==================
 

--- a/docs/api/gevent.ssl.rst
+++ b/docs/api/gevent.ssl.rst
@@ -14,6 +14,21 @@ The exact API exposed by this module varies depending on what version
 of Python you are using. The documents below describe the API for
 Python 3, Python 2.7.9 and above, and Python 2.7.8 and below, respectively.
 
+.. tip::
+
+    As an implementation note, gevent's exact behaviour will differ
+    somewhat depending on the underlying TLS version in use. For
+    example, the number of data exchanges involved in the handshake
+    process, and exactly when that process occurs, will vary. This can
+    be indirectly observed by the number and timing of greenlet
+    switches or trips around the event loop gevent makes.
+
+    Most applications should not notice this, but some applications
+    (and especially tests, where it is common for a process to be both
+    a server and its own client), may find that they have coded in
+    assumptions about the order in which multiple greenlets run. As
+    TLS 1.3 gets deployed, those assumptions are likely to break.
+
 .. warning:: All the described APIs should be imported from
    ``gevent.ssl``, and *not* from their implementation modules.
    Their organization is an implementation detail that may change at

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,15 +72,23 @@ install () {
     # so that we don't get *spurious* caching. (Travis doesn't check for mod times,
     # just contents, so echoing each time doesn't cause it to re-cache.)
 
-    # Overwrite an existing alias
-    ln -sf $DESTINATION/bin/python $SNAKEPIT/$ALIAS
-    ln -sf $DESTINATION $SNAKEPIT/$DIR_ALIAS
+    # Overwrite an existing alias.
+    # For whatever reason, ln -sf on Travis works fine for the ALIAS,
+    # but fails for the DIR_ALIAS. No clue why. So we delete an existing one of those
+    # manually.
+    if [ -L "$SNAKEPIT/$DIR_ALIAS" ]; then
+        rm -f $SNAKEPIT/$DIR_ALIAS
+    fi
+    ln -sfv $DESTINATION/bin/python $SNAKEPIT/$ALIAS
+    ln -sfv $DESTINATION $SNAKEPIT/$DIR_ALIAS
     echo $VERSION $ALIAS $DIR_ALIAS > $SNAKEPIT/$ALIAS.installed
     $SNAKEPIT/$ALIAS --version
+    $DESTINATION/bin/python --version
     # Set the PATH to include the install's bin directory so pip
     # doesn't nag.
     PATH="$DESTINATION/bin/:$PATH" $SNAKEPIT/$ALIAS -m pip install --upgrade pip wheel virtualenv
     ls -l $SNAKEPIT
+    ls -l $BASE/versions
 
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ for var in "$@"; do
             install 3.6.8 python3.6 3.6.d
             ;;
         3.7)
-            install 3.7.2 python3.7 3.7.d
+            install 3.7.4 python3.7 3.7.d
             ;;
         3.8)
             install 3.8.0b4 python3.8 3.8.d

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -106,9 +106,6 @@ def validate_bool(value):
             raise ValueError("Invalid boolean string: %r" % (value,))
     return bool(value)
 
-def get_environ_bool(key, default=None):
-    return validate_bool(os.environ.get(key, default))
-
 def validate_anything(value):
     return value
 

--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -106,6 +106,9 @@ def validate_bool(value):
             raise ValueError("Invalid boolean string: %r" % (value,))
     return bool(value)
 
+def get_environ_bool(key, default=None):
+    return validate_bool(os.environ.get(key, default))
+
 def validate_anything(value):
     return value
 

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -216,8 +216,6 @@ class socket(object):
 
     def close(self, _closedsocket=_closedsocket):
         if not self._sock:
-            assert self._read_event is None
-            assert self._write_event is None
             return
 
         # This function should not reference any globals. See Python issue #808164.

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -3,6 +3,7 @@
 Python 2 socket module.
 """
 from __future__ import absolute_import
+from __future__ import print_function
 
 # Our import magic sadly makes this warning useless
 # pylint: disable=undefined-variable
@@ -80,6 +81,11 @@ class _closedsocket(object):
     # All _delegate_methods must also be initialized here.
     send = recv = recv_into = sendto = recvfrom = recvfrom_into = _dummy
 
+    def __nonzero__(self):
+        return False
+
+    __bool__ = __nonzero__
+
     if PYPY:
 
         def _drop(self):
@@ -92,6 +98,7 @@ class _closedsocket(object):
 
 
 timeout_default = object()
+gtype = type
 
 from gevent._hub_primitives import wait_on_socket as _wait_on_socket
 
@@ -111,22 +118,23 @@ class socket(object):
     # pylint:disable=too-many-public-methods
 
     def __init__(self, family=AF_INET, type=SOCK_STREAM, proto=0, _sock=None):
+        timeout = _socket.getdefaulttimeout()
         if _sock is None:
             self._sock = _realsocket(family, type, proto)
-            self.timeout = _socket.getdefaulttimeout()
         else:
             if hasattr(_sock, '_sock'):
-                # passed a gevent socket
-                self._sock = _sock._sock
-                self.timeout = getattr(_sock, 'timeout', False)
-                if self.timeout is False:
-                    self.timeout = _socket.getdefaulttimeout()
-            else:
-                # passed a native socket
-                self._sock = _sock
-                self.timeout = _socket.getdefaulttimeout()
+                timeout = getattr(_sock, 'timeout', timeout)
+                while hasattr(_sock, '_sock'):
+                    # passed a gevent socket or a native
+                    # socket._socketobject. Unwrap this all the way to the
+                    # native _socket.socket.
+                    _sock = _sock._sock
+
+            self._sock = _sock
+
             if PYPY:
                 self._sock._reuse()
+        self.timeout = timeout
         self._sock.setblocking(0)
         fileno = self._sock.fileno()
         self.hub = get_hub()
@@ -207,22 +215,34 @@ class socket(object):
 
 
     def close(self, _closedsocket=_closedsocket):
+        if not self._sock:
+            assert self._read_event is None
+            assert self._write_event is None
+            return
+
         # This function should not reference any globals. See Python issue #808164.
 
-        # Also break any reference to the loop.io objects. Our fileno,
-        # which they were tied to, is now free to be reused, so these
-        # objects are no longer functional.
-        self._drop_events()
+        # First, change self._sock. On CPython, this drops a
+        # reference, and if it was the last reference, __del__ will
+        # close it. (We cannot close it, makefile() relies on
+        # reference counting like this, and it may be shared among
+        # multiple wrapper objects). Methods *must not* cache
+        # `self._sock` separately from
+        # self._write_event/self._read_event, or they will be out of
+        # sync and we may get inappropriate errors. (See
+        # test__hub:TestCloseSocketWhilePolling for an example).
         s = self._sock
-
-        # Note that we change self._sock at this point. Methods *must not*
-        # cache `self._sock` separately from self._write_event/self._read_event,
-        # or they will be out of sync and we may get inappropriate errors.
-        # (See test__hub:TestCloseSocketWhilePolling for an example).
-
         self._sock = _closedsocket()
+
+        # On PyPy we have to manually tell it to drop a ref.
         if PYPY:
             s._drop()
+
+        # Finally, break any reference to the loop.io objects. Our
+        # fileno, which they were tied to, is about to be free to be
+        # reused, so these objects are no longer functional.
+        self._drop_events()
+
 
     @property
     def closed(self):

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -158,11 +158,16 @@ class socket(object):
             s = '<socket [%r]>' % ex
 
         if s.startswith("<socket object"):
-            s = "<%s.%s%s%s" % (self.__class__.__module__,
-                                self.__class__.__name__,
-                                getattr(self, '_closed', False) and " [closed] " or "",
-                                s[7:])
+            s = "<%s.%s%s%s%s" % (
+                self.__class__.__module__,
+                self.__class__.__name__,
+                getattr(self, '_closed', False) and " [closed] " or "",
+                self._extra_repr(),
+                s[7:])
         return s
+
+    def _extra_repr(self):
+        return ''
 
     def __getstate__(self):
         raise TypeError("Cannot serialize socket object")

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -330,6 +330,8 @@ class SSLSocket(socket):
         # pylint:disable=too-many-branches
         self._checkClosed()
         nbytes = len
+        len = __builtins__['len']
+        initial_buf_len = len(buffer) if buffer is not None else None
         while True:
             if not self._sslobj:
                 raise ValueError("Read on closed or unwrapped SSL socket.")
@@ -352,9 +354,7 @@ class SSLSocket(socket):
                 self._wait(self._write_event, timeout_exc=_SSLErrorReadTimeout)
             except SSLError as ex:
                 if ex.args[0] == SSL_ERROR_EOF and self.suppress_ragged_eofs:
-                    if buffer is None:
-                        return b''
-                    return 0
+                    return b'' if buffer is None else len(buffer) - initial_buf_len
                 raise
             except ConnectionResetError:
                 # Certain versions of Python, built against certain
@@ -362,7 +362,7 @@ class SSLSocket(socket):
                 # can produce this instead of SSLError. Notably, it looks
                 # like anything built against 1.1.1c do?
                 if self.suppress_ragged_eofs:
-                    return b'' if buffer is None else 0
+                    return b'' if buffer is None else len(buffer) - initial_buf_len
                 raise
 
 

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -172,8 +172,9 @@ else:
 
 class SSLSocket(socket):
     """
-    gevent `ssl.SSLSocket <https://docs.python.org/3/library/ssl.html#ssl-sockets>`_
-    for Python 3.
+    gevent `ssl.SSLSocket
+    <https://docs.python.org/3/library/ssl.html#ssl-sockets>`_ for
+    Python 3.
     """
 
     # pylint:disable=too-many-instance-attributes,too-many-public-methods
@@ -279,6 +280,13 @@ class SSLSocket(socket):
             except socket_error as x:
                 self.close()
                 raise x
+
+    def _extra_repr(self):
+        return ' server=%s, cipher=%r' % (
+            self.server_side,
+            self._sslobj.cipher() if self._sslobj is not None else ''
+
+        )
 
     @property
     def context(self):
@@ -650,16 +658,19 @@ class SSLSocket(socket):
         return self._real_connect(addr, True)
 
     def accept(self):
-        """Accepts a new connection from a remote client, and returns
-        a tuple containing that new connection wrapped with a server-side
-        SSL channel, and the address of the remote client."""
-
-        newsock, addr = socket.accept(self)
+        """
+        Accepts a new connection from a remote client, and returns a
+        tuple containing that new connection wrapped with a
+        server-side SSL channel, and the address of the remote client.
+        """
+        newsock, addr = super().accept()
         newsock._drop_events()
-        newsock = self._context.wrap_socket(newsock,
-                                            do_handshake_on_connect=self.do_handshake_on_connect,
-                                            suppress_ragged_eofs=self.suppress_ragged_eofs,
-                                            server_side=True)
+        newsock = self._context.wrap_socket(
+            newsock,
+            do_handshake_on_connect=self.do_handshake_on_connect,
+            suppress_ragged_eofs=self.suppress_ragged_eofs,
+            server_side=True
+        )
         return newsock, addr
 
     def get_channel_binding(self, cb_type="tls-unique"):

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -554,9 +554,18 @@ class SSLSocket(socket):
         if not self._sslobj:
             raise ValueError("No SSL wrapper around " + str(self))
 
+        try:
+            # 3.7 and newer, that use the SSLSocket object
+            # call its shutdown.
+            shutdown = self._sslobj.shutdown
+        except AttributeError:
+            # Earlier versions use SSLObject, which covers
+            # that with a layer.
+            shutdown = self._sslobj.unwrap
+
         while True:
             try:
-                s = self._sslobj.shutdown()
+                s = shutdown()
                 break
             except SSLWantReadError:
                 # Callers of this method expect to get a socket

--- a/src/gevent/_threading.py
+++ b/src/gevent/_threading.py
@@ -1,9 +1,7 @@
-"""A clone of threading module (version 2.7.2) that always
-targets real OS threads. (Unlike 'threading' which flips between
-green and OS threads based on whether the monkey patching is in effect
-or not).
-
-This module is missing 'Thread' class, but includes 'Queue'.
+"""
+A small selection of primitives that always work with
+native threads. This has very limited utility and is
+targeted only for the use of gevent's threadpool.
 """
 from __future__ import absolute_import
 
@@ -80,6 +78,9 @@ class _Condition(object):
         waiter.acquire()
         self.__waiters.append(waiter)
         saved_state = self._release_save()
+        # This variable is for the monitoring utils to know that
+        # this is an idle frame and shouldn't be counted.
+        gevent_threadpool_worker_idle = True # pylint:disable=unused-variable
         try:    # restore state no matter what (e.g., KeyboardInterrupt)
             waiter.acquire() # Block on the native lock
         finally:

--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -158,13 +158,6 @@ class BackdoorServer(StreamServer):
             _locals['__builtins__'] = builtins
         return _locals
 
-    def do_read(self):
-        print(now(), "Accepting from", self.socket, file=sys.stderr)
-        result = super(BackdoorServer, self).do_read()
-        print(now(), "Accepted", result, file=sys.stderr)
-        return result
-
-
     def handle(self, conn, _address): # pylint: disable=method-hidden
         """
         Interact with one remote user.
@@ -177,7 +170,7 @@ class BackdoorServer(StreamServer):
         raw_file = conn.makefile(mode="r")
         getcurrent().stdin = _StdIn(conn, raw_file)
         getcurrent().stdout = _StdErr(conn, raw_file)
-        print(now(), "Interacting")
+
         # Swizzle the inputs
         getcurrent().switch_in()
         try:

--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -13,7 +13,6 @@ from __future__ import print_function, absolute_import
 import sys
 import socket
 from code import InteractiveConsole
-from time import time as now
 
 from gevent.greenlet import Greenlet
 from gevent.hub import getcurrent

--- a/src/gevent/backdoor.py
+++ b/src/gevent/backdoor.py
@@ -13,6 +13,7 @@ from __future__ import print_function, absolute_import
 import sys
 import socket
 from code import InteractiveConsole
+from time import time as now
 
 from gevent.greenlet import Greenlet
 from gevent.hub import getcurrent
@@ -157,6 +158,13 @@ class BackdoorServer(StreamServer):
             _locals['__builtins__'] = builtins
         return _locals
 
+    def do_read(self):
+        print(now(), "Accepting from", self.socket, file=sys.stderr)
+        result = super(BackdoorServer, self).do_read()
+        print(now(), "Accepted", result, file=sys.stderr)
+        return result
+
+
     def handle(self, conn, _address): # pylint: disable=method-hidden
         """
         Interact with one remote user.
@@ -169,7 +177,7 @@ class BackdoorServer(StreamServer):
         raw_file = conn.makefile(mode="r")
         getcurrent().stdin = _StdIn(conn, raw_file)
         getcurrent().stdout = _StdErr(conn, raw_file)
-
+        print(now(), "Interacting")
         # Swizzle the inputs
         getcurrent().switch_in()
         try:

--- a/src/gevent/baseserver.py
+++ b/src/gevent/baseserver.py
@@ -1,8 +1,13 @@
 """Base class for implementing servers"""
 # Copyright (c) 2009-2012 Denis Bilenko. See LICENSE for details.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
 import sys
 import _socket
 import errno
+
 from gevent.greenlet import Greenlet
 from gevent.event import Event
 from gevent.hub import get_hub
@@ -286,11 +291,14 @@ class BaseServer(object):
             return self.address[1]
 
     def init_socket(self):
-        """If the user initialized the server with an address rather than socket,
-        then this function will create a socket, bind it and put it into listening mode.
+        """
+        If the user initialized the server with an address rather than
+        socket, then this function must create a socket, bind it, and
+        put it into listening mode.
 
         It is not supposed to be called by the user, it is called by :meth:`start` before starting
-        the accept loop."""
+        the accept loop.
+        """
 
     @property
     def started(self):

--- a/src/gevent/baseserver.py
+++ b/src/gevent/baseserver.py
@@ -14,8 +14,7 @@ from gevent.hub import get_hub
 from gevent._compat import string_types
 from gevent._compat import integer_types
 from gevent._compat import xrange
-from gevent._compat import WIN
-from gevent._config import get_environ_bool
+
 
 
 __all__ = ['BaseServer']
@@ -88,16 +87,17 @@ class BaseServer(object):
     #: Sets the maximum number of consecutive accepts that a process may perform on
     #: a single wake up. High values give higher priority to high connection rates,
     #: while lower values give higher priority to already established connections.
-    #: Default is 100 on Unix and 1 on Windows.
-    #: Note, that in case of multiple working processes on the same
-    #: listening value, it should be set to a lower value. (pywsgi.WSGIServer sets it
-    #: to 1 when environ["wsgi.multiprocess"] is true)
+    #: Default is 100.
+    #:
+    #: Note that, in case of multiple working processes on the same
+    #: listening socket, it should be set to a lower value. (pywsgi.WSGIServer sets it
+    #: to 1 when ``environ["wsgi.multiprocess"]`` is true)
     #:
     #: This is equivalent to libuv's `uv_tcp_simultaneous_accepts
     #: <http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_simultaneous_accepts>`_
     #: value. Setting the environment variable UV_TCP_SINGLE_ACCEPT to a true value
-    #: (usually 1) changes the Unix default to 1.
-    max_accept = 100 if not WIN and not get_environ_bool('UV_TCP_SINGLE_ACCEPT') else 1
+    #: (usually 1) changes the default to 1.
+    max_accept = 100
 
     _spawn = Greenlet.spawn
 

--- a/src/gevent/baseserver.py
+++ b/src/gevent/baseserver.py
@@ -11,7 +11,11 @@ import errno
 from gevent.greenlet import Greenlet
 from gevent.event import Event
 from gevent.hub import get_hub
-from gevent._compat import string_types, integer_types, xrange
+from gevent._compat import string_types
+from gevent._compat import integer_types
+from gevent._compat import xrange
+from gevent._compat import WIN
+from gevent._config import get_environ_bool
 
 
 __all__ = ['BaseServer']
@@ -84,10 +88,16 @@ class BaseServer(object):
     #: Sets the maximum number of consecutive accepts that a process may perform on
     #: a single wake up. High values give higher priority to high connection rates,
     #: while lower values give higher priority to already established connections.
-    #: Default is 100. Note, that in case of multiple working processes on the same
+    #: Default is 100 on Unix and 1 on Windows.
+    #: Note, that in case of multiple working processes on the same
     #: listening value, it should be set to a lower value. (pywsgi.WSGIServer sets it
     #: to 1 when environ["wsgi.multiprocess"] is true)
-    max_accept = 100
+    #:
+    #: This is equivalent to libuv's `uv_tcp_simultaneous_accepts
+    #: <http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_simultaneous_accepts>`_
+    #: value. Setting the environment variable UV_TCP_SINGLE_ACCEPT to a true value
+    #: (usually 1) changes the Unix default to 1.
+    max_accept = 100 if not WIN and not get_environ_bool('UV_TCP_SINGLE_ACCEPT') else 1
 
     _spawn = Greenlet.spawn
 

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -383,6 +383,7 @@ class Greenlet(greenlet):
         @property
         def dead(self):
             "Boolean indicating that the greenlet is dead and will not run again."
+            # pylint:disable=no-member
             if self._greenlet__main:
                 return False
             if self.__start_cancelled_by_kill() or self.__started_but_aborted():

--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -739,7 +739,15 @@ def patch_thread(threading=True, _threading_local=True, Event=True, logging=True
 
                 main_thread._tstate_lock.release()
                 from gevent import sleep
-                sleep()
+                try:
+                    sleep()
+                except: # pylint:disable=bare-except
+                    # A greenlet could have .kill() us
+                    # or .throw() to us. I'm the main greenlet,
+                    # there's no where else for this to go.
+                    from gevent  import get_hub
+                    get_hub().print_exception(_greenlet, *sys.exc_info())
+
                 # Now, this may have resulted in us getting stopped
                 # if some other greenlet actually just ran there.
                 # That's not good, we're not supposed to be stopped

--- a/src/gevent/server.py
+++ b/src/gevent/server.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2009-2012 Denis Bilenko. See LICENSE for details.
 """TCP/SSL server"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
 
 from contextlib import closing
 
@@ -134,10 +137,21 @@ class StreamServer(BaseServer):
 
     def set_listener(self, listener):
         BaseServer.set_listener(self, listener)
-        try:
-            self.socket = self.socket._sock
-        except AttributeError:
-            pass
+
+    def _make_socket_stdlib(self):
+        # We want to unwrap the gevent wrapping of the listening socket.
+        # This lets us be just a hair more efficient: when our 'do_read' is
+        # called, we've already waited on the socket to be ready to accept(), so
+        # we don't need to (potentially) do it again. Also we avoid a layer
+        # of method calls. The cost, though, is that we have to manually wrap
+        # sockets back up to be non-blocking in do_read(). I'm not sure that's worth
+        # it.
+        #
+        # In the past, we only did this when set_listener() was called with a socket
+        # object and not an address. It makes sense to do it always though,
+        # so that we get consistent behaviour.
+        while hasattr(self.socket, '_sock'):
+            self.socket = self.socket._sock # pylint:disable=attribute-defined-outside-init
 
     def init_socket(self):
         if not hasattr(self, 'socket'):
@@ -149,6 +163,7 @@ class StreamServer(BaseServer):
             self._handle = self.wrap_socket_and_handle
         else:
             self._handle = self.handle
+        self._make_socket_stdlib()
 
     @classmethod
     def get_listener(cls, address, backlog=None, family=None):
@@ -157,7 +172,6 @@ class StreamServer(BaseServer):
         return _tcp_listener(address, backlog=backlog, reuse_addr=cls.reuse_addr, family=family)
 
     if PY3:
-
         def do_read(self):
             sock = self.socket
             try:
@@ -168,11 +182,13 @@ class StreamServer(BaseServer):
                 raise
 
             sock = GeventSocket(sock.family, sock.type, sock.proto, fileno=fd)
-            # XXX Python issue #7995?
+            # XXX Python issue #7995? "if no default timeout is set
+            # and the listening socket had a (non-zero) timeout, force
+            # the new socket in blocking mode to override
+            # platform-specific socket flags inheritance."
             return sock, address
 
     else:
-
         def do_read(self):
             try:
                 client_socket, address = self.socket.accept()
@@ -180,16 +196,12 @@ class StreamServer(BaseServer):
                 if err.args[0] == EWOULDBLOCK:
                     return
                 raise
-            # XXX: When would this not be the case? In Python 3 it makes sense
-            # because we're using the low-level _accept method,
-            # but not in Python 2.
-            if not isinstance(client_socket, GeventSocket):
-                # This leads to a leak of the watchers in client_socket
-                sockobj = GeventSocket(_sock=client_socket)
-                if PYPY:
-                    client_socket._drop()
-            else:
-                sockobj = client_socket
+
+            sockobj = GeventSocket(_sock=client_socket)
+            if PYPY:
+                # Undo the ref-count bump that the constructor
+                # did. We gave it ownership.
+                client_socket._drop()
             return sockobj, address
 
     def do_close(self, sock, *args):

--- a/src/gevent/testing/leakcheck.py
+++ b/src/gevent/testing/leakcheck.py
@@ -117,6 +117,7 @@ class _RefCountChecker(object):
             self.function(self.testcase, *args, **kwargs)
         finally:
             self.testcase.tearDown()
+            self.testcase.doCleanups()
             self.testcase.skipTearDown = True
             self.needs_setUp = True
             if gc_enabled:

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -1135,6 +1135,14 @@ if PY37:
         'test_ssl.SimpleBackgroundTests.test_get_server_certificate',
         # Probably the same as NetworkConnectionNoServer.test_create_connection_timeout
         'test_socket.NetworkConnectionNoServer.test_create_connection',
+
+        # Internals of the threading module that change.
+        'test_threading.ThreadedTests.test_finalization_shutdown',
+        'test_threading.ThreadedTests.test_shutdown_locks',
+        # This tries to use threading.interrupt_main() from a new Thread;
+        # but of course that's actually the same thread and things don't
+        # work as expected.
+        'test_threading.InterruptMainTests.test_interrupt_main_subthread',
     ]
 
     if APPVEYOR:
@@ -1155,11 +1163,6 @@ if PY38:
         # and can't see the patched threading.get_ident() we use, so the
         # output doesn't match.
         'test_threading.ExceptHookTests.test_excepthook_thread_None',
-
-        # This tries to use threading.interrupt_main() from a new Thread;
-        # but of course that's actually the same thread and things don't
-        # work as expected.
-        'test_threading.InterruptMainTests.test_interrupt_main_subthread',
     ]
 
 # if 'signalfd' in os.environ.get('GEVENT_BACKEND', ''):

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -1137,12 +1137,18 @@ if PY37:
         'test_socket.NetworkConnectionNoServer.test_create_connection',
 
         # Internals of the threading module that change.
-        'test_threading.ThreadedTests.test_finalization_shutdown',
-        'test_threading.ThreadedTests.test_shutdown_locks',
+        'test_threading.ThreadTests.test_finalization_shutdown',
+        'test_threading.ThreadTests.test_shutdown_locks',
+        # Expects a deprecation warning we don't raise
+        'test_threading.ThreadTests.test_old_threading_api',
         # This tries to use threading.interrupt_main() from a new Thread;
         # but of course that's actually the same thread and things don't
         # work as expected.
         'test_threading.InterruptMainTests.test_interrupt_main_subthread',
+        'test_threading.InterruptMainTests.test_interrupt_main_noerror',
+
+        # TLS1.3 seems flaky
+        'test_ssl.ThreadedTests.test_wrong_cert_tls13',
     ]
 
     if APPVEYOR:

--- a/src/gevent/tests/known_failures.py
+++ b/src/gevent/tests/known_failures.py
@@ -351,16 +351,6 @@ RUN_ALONE = [
     'test__example_webproxy.py',
 ]
 
-if APPVEYOR:
-    # Strange failures sometimes, but only on Python 3.7, reporting
-    # "ConnectionAbortedError: [WinError 10053] An established
-    # connection was aborted by the software in your host machine"
-    # when we've done no such thing. Try running not in parallel
-    RUN_ALONE += [
-        'test__ssl.py',
-        'test__server.py',
-    ]
-
 
 if APPVEYOR or TRAVIS:
     RUN_ALONE += [

--- a/src/gevent/tests/test__backdoor.py
+++ b/src/gevent/tests/test__backdoor.py
@@ -141,4 +141,6 @@ class Test(greentest.TestCase):
         self._close(conn)
 
 if __name__ == '__main__':
+    import sys
+    sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/tests/test__backdoor.py
+++ b/src/gevent/tests/test__backdoor.py
@@ -141,6 +141,4 @@ class Test(greentest.TestCase):
         self._close(conn)
 
 if __name__ == '__main__':
-    import sys
-    sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/tests/test__backdoor.py
+++ b/src/gevent/tests/test__backdoor.py
@@ -78,14 +78,16 @@ class Test(greentest.TestCase):
 
         def connect():
             conn, _ = self._create_connection()
-
             conn.sendall(b'2+2\r\n')
             line = readline(conn)
             self.assertEqual(line.strip(), '4', repr(line))
             self._close(conn)
 
         jobs = [WorkerGreenlet.spawn(connect) for _ in range(10)]
-        done = gevent.joinall(jobs, raise_error=True)
+        try:
+            done = gevent.joinall(jobs, raise_error=True)
+        finally:
+            gevent.joinall(jobs, raise_error=False)
 
         self.assertEqual(len(done), len(jobs), done)
 

--- a/src/gevent/tests/test__server.py
+++ b/src/gevent/tests/test__server.py
@@ -205,7 +205,7 @@ class TestCase(greentest.TestCase):
     def init_server(self):
         self.server = self._create_server()
         self.server.start()
-        gevent.sleep(0.01)
+        gevent.sleep()
 
     @property
     def socket(self):
@@ -338,11 +338,6 @@ class TestDefaultSpawn(TestCase):
 
         self.stop_server()
 
-    def init_server(self):
-        self.server = self._create_server()
-        self.server.start()
-        gevent.sleep(0.01)
-
     @property
     def socket(self):
         return self.server.socket
@@ -359,7 +354,7 @@ class TestDefaultSpawn(TestCase):
     def test_server_repr_when_handle_is_instancemethod(self):
         # PR 501
         self.init_server()
-        self.start_server()
+        assert self.server.started
         self.assertIn('Server', repr(self.server))
 
         self.server.set_handle(self.server.handle)

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -13,7 +13,7 @@ import unittest
 from functools import wraps
 
 from gevent._compat import reraise
-from gevent._compat import PY2
+
 import gevent.testing as greentest
 
 from gevent.testing import six
@@ -162,12 +162,16 @@ class TestTCP(greentest.TestCase):
                 raise
             finally:
                 log("shutdown")
-                if PY2:
+                if greentest.PY2:
                     # The implicit reference-based nastiness of Python 2
                     # sockets interferes, especially when using SSL sockets.
                     # The best way to get a decent FIN to the server is to shutdown
                     # the output. Doing that on Python 3, OTOH, is contraindicated.
                     client.shutdown(socket.SHUT_RDWR)
+                elif hasattr(client, 'unwrap') and greentest.PY37 and greentest.WIN:
+                    # We seem to have a buffer stuck somewhere on appveyor?
+                    # https://ci.appveyor.com/project/denik/gevent/builds/27320824/job/bdbax88sqnjoti6i#L712
+                    client.unwrap()
                 log("closing")
                 client.close()
         finally:

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -126,13 +126,21 @@ class TestTCP(greentest.TestCase):
         def accept_and_read():
             log("accepting", self.listener)
             conn, _ = self.listener.accept()
-            self._close_on_teardown(conn)
-            r = self._close_on_teardown(conn.makefile(mode='rb'))
-            log("accepted on server", conn)
-            accepted_event.set()
-            log("reading")
-            read_data.append(r.read())
-            log("done reading")
+            try:
+                r = conn.makefile(mode='rb')
+                try:
+                    log("accepted on server", conn)
+                    accepted_event.set()
+                    log("reading")
+                    read_data.append(r.read())
+                    log("done reading")
+                finally:
+                    r.close()
+                    del r
+            finally:
+                conn.close()
+                del conn
+
 
         server = Thread(target=accept_and_read)
         try:

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -67,14 +67,14 @@ class TestSSL(test__socket.TestTCP):
             client.close()
             server_sock[0][0].close()
 
-    def test_fullduplex(self):
-        try:
-            super(TestSSL, self).test_fullduplex()
-        except LoopExit:
-            if greentest.LIBUV and greentest.WIN:
-                # XXX: Unable to duplicate locally
-                raise greentest.SkipTest("libuv on Windows sometimes raises LoopExit")
-            raise
+    # def test_fullduplex(self):
+    #     try:
+    #         super(TestSSL, self).test_fullduplex()
+    #     except LoopExit:
+    #         if greentest.LIBUV and greentest.WIN:
+    #             # XXX: Unable to duplicate locally
+    #             raise greentest.SkipTest("libuv on Windows sometimes raises LoopExit")
+    #         raise
 
     @greentest.ignores_leakcheck
     def test_empty_send(self):
@@ -104,5 +104,7 @@ class TestSSL(test__socket.TestTCP):
 
 if __name__ == '__main__':
     import sys
+    sys.argv.append('TestSSL.test_sendall_array')
+    sys.argv.append('TestSSL.test_recv_timeout')
     sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -16,7 +16,7 @@ from gevent.hub import LoopExit
 def ssl_listener(private_key, certificate):
     raw_listener = socket.socket()
     greentest.bind_and_listen(raw_listener)
-    sock = ssl.wrap_socket(raw_listener, private_key, certificate)
+    sock = ssl.wrap_socket(raw_listener, private_key, certificate, server_side=True)
     return sock, raw_listener
 
 
@@ -103,4 +103,6 @@ class TestSSL(test__socket.TestTCP):
 
 
 if __name__ == '__main__':
+    import sys
+    sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -100,5 +100,4 @@ class TestSSL(test__socket.TestTCP):
 
 
 if __name__ == '__main__':
-    import sys
     greentest.main()

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -101,6 +101,4 @@ class TestSSL(test__socket.TestTCP):
 
 if __name__ == '__main__':
     import sys
-    if sys.version_info[0] >= 3:
-        sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -9,10 +9,6 @@ import gevent.testing as greentest
 from gevent.tests import test__socket
 import ssl
 
-
-#import unittest
-from gevent.hub import LoopExit
-
 def ssl_listener(private_key, certificate):
     raw_listener = socket.socket()
     greentest.bind_and_listen(raw_listener)
@@ -37,7 +33,8 @@ class TestSSL(test__socket.TestTCP):
         return listener
 
     def create_connection(self, *args, **kwargs): # pylint:disable=arguments-differ
-        return ssl.wrap_socket(super(TestSSL, self).create_connection(*args, **kwargs))
+        return self._close_on_teardown(
+            ssl.wrap_socket(super(TestSSL, self).create_connection(*args, **kwargs)))
 
     # The SSL library can take a long time to buffer the large amount of data we're trying
     # to send, so we can't compare to the timeout values
@@ -104,7 +101,6 @@ class TestSSL(test__socket.TestTCP):
 
 if __name__ == '__main__':
     import sys
-    sys.argv.append('TestSSL.test_sendall_array')
-    sys.argv.append('TestSSL.test_recv_timeout')
-    sys.argv.append('-v')
+    if sys.version_info[0] >= 3:
+        sys.argv.append('-v')
     greentest.main()

--- a/src/gevent/timeout.py
+++ b/src/gevent/timeout.py
@@ -234,7 +234,11 @@ class Timeout(BaseException):
 
         # Make sure the timer updates the current time so that we don't
         # expire prematurely.
-        self.timer.start(getcurrent().throw, throws, update=True)
+        self.timer.start(self._on_expiration, getcurrent(), throws, update=True)
+
+    def _on_expiration(self, prev_greenlet, ex):
+        # Hook for subclasses.
+        prev_greenlet.throw(ex)
 
     @classmethod
     def start_new(cls, timeout=None, exception=None, ref=True, _one_shot=False):

--- a/src/greentest/3.7/test_asyncore.py
+++ b/src/greentest/3.7/test_asyncore.py
@@ -70,8 +70,8 @@ def capture_server(evt, buf, serv):
         pass
     else:
         n = 200
-        start = time.time()
-        while n > 0 and time.time() - start < 3.0:
+        start = time.monotonic()
+        while n > 0 and time.monotonic() - start < 3.0:
             r, w, e = select.select([conn], [], [], 0.1)
             if r:
                 n -= 1

--- a/src/greentest/3.7/test_ssl.py
+++ b/src/greentest/3.7/test_ssl.py
@@ -34,6 +34,19 @@ IS_OPENSSL_1_1_0 = not IS_LIBRESSL and ssl.OPENSSL_VERSION_INFO >= (1, 1, 0)
 IS_OPENSSL_1_1_1 = not IS_LIBRESSL and ssl.OPENSSL_VERSION_INFO >= (1, 1, 1)
 PY_SSL_DEFAULT_CIPHERS = sysconfig.get_config_var('PY_SSL_DEFAULT_CIPHERS')
 
+PROTOCOL_TO_TLS_VERSION = {}
+for proto, ver in (
+    ("PROTOCOL_SSLv23", "SSLv3"),
+    ("PROTOCOL_TLSv1", "TLSv1"),
+    ("PROTOCOL_TLSv1_1", "TLSv1_1"),
+):
+    try:
+        proto = getattr(ssl, proto)
+        ver = getattr(ssl.TLSVersion, ver)
+    except AttributeError:
+        continue
+    PROTOCOL_TO_TLS_VERSION[proto] = ver
+
 def data_file(*name):
     return os.path.join(os.path.dirname(__file__), *name)
 
@@ -116,6 +129,7 @@ NONEXISTINGCERT = data_file("XXXnonexisting.pem")
 BADKEY = data_file("badkey.pem")
 NOKIACERT = data_file("nokia.pem")
 NULLBYTECERT = data_file("nullbytecert.pem")
+TALOS_INVALID_CRLDP = data_file("talos-2019-0758.pem")
 
 DHFILE = data_file("ffdh3072.pem")
 BYTES_DHFILE = os.fsencode(DHFILE)
@@ -364,6 +378,27 @@ class BasicSocketTests(unittest.TestCase):
                          ('http://SVRIntl-G3-aia.verisign.com/SVRIntlG3.cer',))
         self.assertEqual(p['crlDistributionPoints'],
                          ('http://SVRIntl-G3-crl.verisign.com/SVRIntlG3.crl',))
+
+    def test_parse_cert_CVE_2019_5010(self):
+        p = ssl._ssl._test_decode_cert(TALOS_INVALID_CRLDP)
+        if support.verbose:
+            sys.stdout.write("\n" + pprint.pformat(p) + "\n")
+        self.assertEqual(
+            p,
+            {
+                'issuer': (
+                    (('countryName', 'UK'),), (('commonName', 'cody-ca'),)),
+                'notAfter': 'Jun 14 18:00:58 2028 GMT',
+                'notBefore': 'Jun 18 18:00:58 2018 GMT',
+                'serialNumber': '02',
+                'subject': ((('countryName', 'UK'),),
+                            (('commonName',
+                              'codenomicon-vm-2.test.lal.cisco.com'),)),
+                'subjectAltName': (
+                    ('DNS', 'codenomicon-vm-2.test.lal.cisco.com'),),
+                'version': 3
+            }
+        )
 
     def test_parse_cert_CVE_2013_4238(self):
         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
@@ -646,9 +681,14 @@ class BasicSocketTests(unittest.TestCase):
         cert = {'subject': ((('commonName', 'example.com'),),),
                 'subjectAltName': (('DNS', 'example.com'),
                                    ('IP Address', '10.11.12.13'),
-                                   ('IP Address', '14.15.16.17'))}
+                                   ('IP Address', '14.15.16.17'),
+                                   ('IP Address', '127.0.0.1'))}
         ok(cert, '10.11.12.13')
         ok(cert, '14.15.16.17')
+        # socket.inet_ntoa(socket.inet_aton('127.1')) == '127.0.0.1'
+        fail(cert, '127.1')
+        fail(cert, '14.15.16.17 ')
+        fail(cert, '14.15.16.17 extra data')
         fail(cert, '14.15.16.18')
         fail(cert, 'example.net')
 
@@ -661,6 +701,8 @@ class BasicSocketTests(unittest.TestCase):
                         ('IP Address', '2003:0:0:0:0:0:0:BABA\n'))}
             ok(cert, '2001::cafe')
             ok(cert, '2003::baba')
+            fail(cert, '2003::baba ')
+            fail(cert, '2003::baba extra data')
             fail(cert, '2003::bebe')
             fail(cert, 'example.net')
 
@@ -1086,8 +1128,15 @@ class ContextTests(unittest.TestCase):
                          "required OpenSSL 1.1.0g")
     def test_min_max_version(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+        # OpenSSL default is MINIMUM_SUPPORTED, however some vendors like
+        # Fedora override the setting to TLS 1.0.
+        self.assertIn(
+            ctx.minimum_version,
+            {ssl.TLSVersion.MINIMUM_SUPPORTED,
+             # Fedora 29 uses TLS 1.0 by default
+             ssl.TLSVersion.TLSv1,
+             # RHEL 8 uses TLS 1.2 by default
+             ssl.TLSVersion.TLSv1_2}
         )
         self.assertEqual(
             ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
@@ -1974,16 +2023,16 @@ class SimpleBackgroundTests(unittest.TestCase):
     def test_ciphers(self):
         with test_wrap_socket(socket.socket(socket.AF_INET),
                              cert_reqs=ssl.CERT_NONE, ciphers="ALL") as s:
-            s.connect(self.server_addr) # gevent: mark 1
+            s.connect(self.server_addr)
         with test_wrap_socket(socket.socket(socket.AF_INET),
                              cert_reqs=ssl.CERT_NONE, ciphers="DEFAULT") as s:
-            s.connect(self.server_addr) # gevent: mark 2
+            s.connect(self.server_addr)
         # Error checking can happen at instantiation or when connecting
         with self.assertRaisesRegex(ssl.SSLError, "No cipher can be selected"):
             with socket.socket(socket.AF_INET) as sock:
                 s = test_wrap_socket(sock,
                                     cert_reqs=ssl.CERT_NONE, ciphers="^$:,;?*'dorothyx")
-                s.connect(self.server_addr) # gevent: mark 3
+                s.connect(self.server_addr)
 
     def test_get_ca_certs_capath(self):
         # capath certs are loaded on request
@@ -2172,7 +2221,7 @@ class ThreadedEchoServer(threading.Thread):
                     self.sock, server_side=True)
                 self.server.selected_npn_protocols.append(self.sslconn.selected_npn_protocol())
                 self.server.selected_alpn_protocols.append(self.sslconn.selected_alpn_protocol())
-            except (ConnectionResetError, BrokenPipeError) as e:
+            except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError) as e:
                 # We treat ConnectionResetError as though it were an
                 # SSLError - OpenSSL on Ubuntu abruptly closes the
                 # connection when asked to use an unsupported protocol.
@@ -2180,9 +2229,12 @@ class ThreadedEchoServer(threading.Thread):
                 # BrokenPipeError is raised in TLS 1.3 mode, when OpenSSL
                 # tries to send session tickets after handshake.
                 # https://github.com/openssl/openssl/issues/6342
+                #
+                # ConnectionAbortedError is raised in TLS 1.3 mode, when OpenSSL
+                # tries to send session tickets after handshake when using WinSock.
                 self.server.conn_errors.append(str(e))
                 if self.server.chatty:
-                    handle_error("\n server: 1bad connection attempt from " + repr(self.addr) + ":\n")
+                    handle_error("\n server:  bad connection attempt from " + repr(self.addr) + ":\n")
                 self.running = False
                 self.close()
                 return False
@@ -2199,7 +2251,7 @@ class ThreadedEchoServer(threading.Thread):
                 # -> traceback -> self (ConnectionHandler) -> server
                 self.server.conn_errors.append(str(e))
                 if self.server.chatty:
-                    handle_error("\n server: 2bad connection attempt from " + repr(self.addr) + ":\n")
+                    handle_error("\n server:  bad connection attempt from " + repr(self.addr) + ":\n")
                 self.running = False
                 self.server.stop()
                 self.close()
@@ -2310,7 +2362,7 @@ class ThreadedEchoServer(threading.Thread):
                             sys.stdout.write(" server: read %r (%s), sending back %r (%s)...\n"
                                              % (msg, ctype, msg.lower(), ctype))
                         self.write(msg.lower())
-                except ConnectionResetError:
+                except (ConnectionResetError, ConnectionAbortedError):
                     # XXX: OpenSSL 1.1.1 sometimes raises ConnectionResetError
                     # when connection is not shut down gracefully.
                     if self.server.chatty and support.verbose:
@@ -2320,6 +2372,18 @@ class ThreadedEchoServer(threading.Thread):
                         )
                     self.close()
                     self.running = False
+                except ssl.SSLError as err:
+                    # On Windows sometimes test_pha_required_nocert receives the
+                    # PEER_DID_NOT_RETURN_A_CERTIFICATE exception
+                    # before the 'tlsv13 alert certificate required' exception.
+                    # If the server is stopped when PEER_DID_NOT_RETURN_A_CERTIFICATE
+                    # is received test_pha_required_nocert fails with ConnectionResetError
+                    # because the underlying socket is closed
+                    if 'PEER_DID_NOT_RETURN_A_CERTIFICATE' == err.reason:
+                        if self.server.chatty and support.verbose:
+                            sys.stdout.write(err.args[1])
+                        # test_pha_required_nocert is expecting this exception
+                        raise ssl.SSLError('tlsv13 alert certificate required')
                 except OSError:
                     if self.server.chatty:
                         handle_error("Test server failure:\n")
@@ -2604,6 +2668,17 @@ def try_protocol_combo(server_protocol, client_protocol, expect_success,
     client_context.options |= client_options
     server_context = ssl.SSLContext(server_protocol)
     server_context.options |= server_options
+
+    min_version = PROTOCOL_TO_TLS_VERSION.get(client_protocol, None)
+    if (min_version is not None
+    # SSLContext.minimum_version is only available on recent OpenSSL
+    # (setter added in OpenSSL 1.1.0, getter added in OpenSSL 1.1.1)
+    and hasattr(server_context, 'minimum_version')
+    and server_protocol == ssl.PROTOCOL_TLS
+    and server_context.minimum_version > min_version):
+        # If OpenSSL configuration is strict and requires more recent TLS
+        # version, we have to change the minimum to test old TLS versions.
+        server_context.minimum_version = min_version
 
     # NOTE: we must enable "ALL" ciphers on the client, otherwise an
     # SSLv23 client will send an SSLv3 hello (rather than SSLv2)
@@ -4312,7 +4387,7 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 self.assertEqual(s.recv(1024), b'FALSE\n')
                 s.write(b'PHA')
                 self.assertEqual(s.recv(1024), b'OK\n')
-                # optional doens't fail when client does not have a cert
+                # optional doesn't fail when client does not have a cert
                 s.write(b'HASCERT')
                 self.assertEqual(s.recv(1024), b'FALSE\n')
 
@@ -4368,6 +4443,37 @@ class TestPostHandshakeAuth(unittest.TestCase):
                 # PHA fails for TLS != 1.3
                 s.write(b'PHA')
                 self.assertIn(b'WRONG_SSL_VERSION', s.recv(1024))
+
+    def test_bpo37428_pha_cert_none(self):
+        # verify that post_handshake_auth does not implicitly enable cert
+        # validation.
+        hostname = SIGNED_CERTFILE_HOSTNAME
+        client_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        client_context.post_handshake_auth = True
+        client_context.load_cert_chain(SIGNED_CERTFILE)
+        # no cert validation and CA on client side
+        client_context.check_hostname = False
+        client_context.verify_mode = ssl.CERT_NONE
+
+        server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_context.load_cert_chain(SIGNED_CERTFILE)
+        server_context.load_verify_locations(SIGNING_CA)
+        server_context.post_handshake_auth = True
+        server_context.verify_mode = ssl.CERT_REQUIRED
+
+        server = ThreadedEchoServer(context=server_context, chatty=False)
+        with server:
+            with client_context.wrap_socket(socket.socket(),
+                                            server_hostname=hostname) as s:
+                s.connect((HOST, server.port))
+                s.write(b'HASCERT')
+                self.assertEqual(s.recv(1024), b'FALSE\n')
+                s.write(b'PHA')
+                self.assertEqual(s.recv(1024), b'OK\n')
+                s.write(b'HASCERT')
+                self.assertEqual(s.recv(1024), b'TRUE\n')
+                # server cert has not been validated
+                self.assertEqual(s.getpeercert(), {})
 
 
 def test_main(verbose=False):

--- a/src/greentest/3.7/test_ssl.py
+++ b/src/greentest/3.7/test_ssl.py
@@ -130,7 +130,7 @@ OP_ENABLE_MIDDLEBOX_COMPAT = getattr(ssl, "OP_ENABLE_MIDDLEBOX_COMPAT", 0)
 
 def handle_error(prefix):
     exc_format = ' '.join(traceback.format_exception(*sys.exc_info()))
-    if True: # support.verbose: # gevent: temporarily enable
+    if support.verbose:
         sys.stdout.write(prefix + exc_format)
 
 def can_clear_options():

--- a/src/greentest/3.7/test_ssl.py
+++ b/src/greentest/3.7/test_ssl.py
@@ -130,7 +130,7 @@ OP_ENABLE_MIDDLEBOX_COMPAT = getattr(ssl, "OP_ENABLE_MIDDLEBOX_COMPAT", 0)
 
 def handle_error(prefix):
     exc_format = ' '.join(traceback.format_exception(*sys.exc_info()))
-    if support.verbose:
+    if True: # support.verbose: # gevent: temporarily enable
         sys.stdout.write(prefix + exc_format)
 
 def can_clear_options():
@@ -1974,16 +1974,16 @@ class SimpleBackgroundTests(unittest.TestCase):
     def test_ciphers(self):
         with test_wrap_socket(socket.socket(socket.AF_INET),
                              cert_reqs=ssl.CERT_NONE, ciphers="ALL") as s:
-            s.connect(self.server_addr)
+            s.connect(self.server_addr) # gevent: mark 1
         with test_wrap_socket(socket.socket(socket.AF_INET),
                              cert_reqs=ssl.CERT_NONE, ciphers="DEFAULT") as s:
-            s.connect(self.server_addr)
+            s.connect(self.server_addr) # gevent: mark 2
         # Error checking can happen at instantiation or when connecting
         with self.assertRaisesRegex(ssl.SSLError, "No cipher can be selected"):
             with socket.socket(socket.AF_INET) as sock:
                 s = test_wrap_socket(sock,
                                     cert_reqs=ssl.CERT_NONE, ciphers="^$:,;?*'dorothyx")
-                s.connect(self.server_addr)
+                s.connect(self.server_addr) # gevent: mark 3
 
     def test_get_ca_certs_capath(self):
         # capath certs are loaded on request
@@ -2182,7 +2182,7 @@ class ThreadedEchoServer(threading.Thread):
                 # https://github.com/openssl/openssl/issues/6342
                 self.server.conn_errors.append(str(e))
                 if self.server.chatty:
-                    handle_error("\n server:  bad connection attempt from " + repr(self.addr) + ":\n")
+                    handle_error("\n server: 1bad connection attempt from " + repr(self.addr) + ":\n")
                 self.running = False
                 self.close()
                 return False
@@ -2199,7 +2199,7 @@ class ThreadedEchoServer(threading.Thread):
                 # -> traceback -> self (ConnectionHandler) -> server
                 self.server.conn_errors.append(str(e))
                 if self.server.chatty:
-                    handle_error("\n server:  bad connection attempt from " + repr(self.addr) + ":\n")
+                    handle_error("\n server: 2bad connection attempt from " + repr(self.addr) + ":\n")
                 self.running = False
                 self.server.stop()
                 self.close()

--- a/src/greentest/3.7/test_threading.py
+++ b/src/greentest/3.7/test_threading.py
@@ -16,6 +16,7 @@ import unittest
 import weakref
 import os
 import subprocess
+import signal
 
 from gevent.tests import lock_tests # gevent: use our local copy
 from test import support
@@ -415,7 +416,8 @@ class ThreadTests(BaseTestCase):
         t.setDaemon(True)
         t.getName()
         t.setName("name")
-        t.isAlive()
+        with self.assertWarnsRegex(PendingDeprecationWarning, 'use is_alive()'):
+            t.isAlive()
         e = threading.Event()
         e.isSet()
         threading.activeCount()
@@ -576,6 +578,41 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(data.splitlines(),
                          ["GC: True True True"] * 2)
 
+    def test_finalization_shutdown(self):
+        # bpo-36402: Py_Finalize() calls threading._shutdown() which must wait
+        # until Python thread states of all non-daemon threads get deleted.
+        #
+        # Test similar to SubinterpThreadingTests.test_threads_join_2(), but
+        # test the finalization of the main interpreter.
+        code = """if 1:
+            import os
+            import threading
+            import time
+            import random
+
+            def random_sleep():
+                seconds = random.random() * 0.010
+                time.sleep(seconds)
+
+            class Sleeper:
+                def __del__(self):
+                    random_sleep()
+
+            tls = threading.local()
+
+            def f():
+                # Sleep a bit so that the thread is still running when
+                # Py_Finalize() is called.
+                random_sleep()
+                tls.x = Sleeper()
+                random_sleep()
+
+            threading.Thread(target=f).start()
+            random_sleep()
+        """
+        rc, out, err = assert_python_ok("-c", code)
+        self.assertEqual(err, b"")
+
     def test_tstate_lock(self):
         # Test an implementation detail of Thread objects.
         started = _thread.allocate_lock()
@@ -695,6 +732,30 @@ class ThreadTests(BaseTestCase):
                 callback()
         finally:
             sys.settrace(old_trace)
+
+    @cpython_only
+    def test_shutdown_locks(self):
+        for daemon in (False, True):
+            with self.subTest(daemon=daemon):
+                event = threading.Event()
+                thread = threading.Thread(target=event.wait, daemon=daemon)
+
+                # Thread.start() must add lock to _shutdown_locks,
+                # but only for non-daemon thread
+                thread.start()
+                tstate_lock = thread._tstate_lock
+                if not daemon:
+                    self.assertIn(tstate_lock, threading._shutdown_locks)
+                else:
+                    self.assertNotIn(tstate_lock, threading._shutdown_locks)
+
+                # unblock the thread and join it
+                event.set()
+                thread.join()
+
+                # Thread._stop() must remove tstate_lock from _shutdown_locks.
+                # Daemon threads must never add it to _shutdown_locks.
+                self.assertNotIn(tstate_lock, threading._shutdown_locks)
 
 
 class ThreadJoinOnShutdown(BaseTestCase):
@@ -873,15 +934,22 @@ class SubinterpThreadingTests(BaseTestCase):
         self.addCleanup(os.close, w)
         code = r"""if 1:
             import os
+            import random
             import threading
             import time
+
+            def random_sleep():
+                seconds = random.random() * 0.010
+                time.sleep(seconds)
 
             def f():
                 # Sleep a bit so that the thread is still running when
                 # Py_EndInterpreter is called.
-                time.sleep(0.05)
+                random_sleep()
                 os.write(%d, b"x")
+
             threading.Thread(target=f).start()
+            random_sleep()
             """ % (w,)
         ret = test.support.run_in_subinterp(code)
         self.assertEqual(ret, 0)
@@ -898,22 +966,29 @@ class SubinterpThreadingTests(BaseTestCase):
         self.addCleanup(os.close, w)
         code = r"""if 1:
             import os
+            import random
             import threading
             import time
 
+            def random_sleep():
+                seconds = random.random() * 0.010
+                time.sleep(seconds)
+
             class Sleeper:
                 def __del__(self):
-                    time.sleep(0.05)
+                    random_sleep()
 
             tls = threading.local()
 
             def f():
                 # Sleep a bit so that the thread is still running when
                 # Py_EndInterpreter is called.
-                time.sleep(0.05)
+                random_sleep()
                 tls.x = Sleeper()
                 os.write(%d, b"x")
+
             threading.Thread(target=f).start()
+            random_sleep()
             """ % (w,)
         ret = test.support.run_in_subinterp(code)
         self.assertEqual(ret, 0)
@@ -1164,12 +1239,46 @@ class BoundedSemaphoreTests(lock_tests.BoundedSemaphoreTests):
 class BarrierTests(lock_tests.BarrierTests):
     barriertype = staticmethod(threading.Barrier)
 
+
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         extra = {"ThreadError"}
         blacklist = {'currentThread', 'activeCount'}
         support.check__all__(self, threading, ('threading', '_thread'),
                              extra=extra, blacklist=blacklist)
+
+
+class InterruptMainTests(unittest.TestCase):
+    def test_interrupt_main_subthread(self):
+        # Calling start_new_thread with a function that executes interrupt_main
+        # should raise KeyboardInterrupt upon completion.
+        def call_interrupt():
+            _thread.interrupt_main()
+        t = threading.Thread(target=call_interrupt)
+        with self.assertRaises(KeyboardInterrupt):
+            t.start()
+            t.join()
+        t.join()
+
+    def test_interrupt_main_mainthread(self):
+        # Make sure that if interrupt_main is called in main thread that
+        # KeyboardInterrupt is raised instantly.
+        with self.assertRaises(KeyboardInterrupt):
+            _thread.interrupt_main()
+
+    def test_interrupt_main_noerror(self):
+        handler = signal.getsignal(signal.SIGINT)
+        try:
+            # No exception should arise.
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            _thread.interrupt_main()
+
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+            _thread.interrupt_main()
+        finally:
+            # Restore original handler
+            signal.signal(signal.SIGINT, handler)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/greentest/3.7/test_wsgiref.py
+++ b/src/greentest/3.7/test_wsgiref.py
@@ -780,6 +780,49 @@ class HandlerTests(TestCase):
             b"Hello, world!",
             written)
 
+    def testClientConnectionTerminations(self):
+        environ = {"SERVER_PROTOCOL": "HTTP/1.0"}
+        for exception in (
+            ConnectionAbortedError,
+            BrokenPipeError,
+            ConnectionResetError,
+        ):
+            with self.subTest(exception=exception):
+                class AbortingWriter:
+                    def write(self, b):
+                        raise exception
+
+                stderr = StringIO()
+                h = SimpleHandler(BytesIO(), AbortingWriter(), stderr, environ)
+                h.run(hello_app)
+
+                self.assertFalse(stderr.getvalue())
+
+    def testDontResetInternalStateOnException(self):
+        class CustomException(ValueError):
+            pass
+
+        # We are raising CustomException here to trigger an exception
+        # during the execution of SimpleHandler.finish_response(), so
+        # we can easily test that the internal state of the handler is
+        # preserved in case of an exception.
+        class AbortingWriter:
+            def write(self, b):
+                raise CustomException
+
+        stderr = StringIO()
+        environ = {"SERVER_PROTOCOL": "HTTP/1.0"}
+        h = SimpleHandler(BytesIO(), AbortingWriter(), stderr, environ)
+        h.run(hello_app)
+
+        self.assertIn("CustomException", stderr.getvalue())
+
+        # Test that the internal state of the handler is preserved.
+        self.assertIsNotNone(h.result)
+        self.assertIsNotNone(h.headers)
+        self.assertIsNotNone(h.status)
+        self.assertIsNotNone(h.environ)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Our Appveyor 3.7 build broke, and it turned out to be because they updated to Python 3.7.4 and a newer OpenSSL that supported TLS1.3.

It turns out that the handshake changes in 1.3 change some (mostly) test assumptions *especially* on Appveyor. In the course of debugging that, I found a few things in the socket and ssl implementations that could be improved and shake out some long-standing oddness.

I expect to squash most of the commits.