### PR TITLE
More simplification and unification of the file objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@
   consistently text and binary modes. If neither 'b' nor 't' is given
   in the mode, they will read and write native strings. If 't' is
   given, they will always work with unicode strings, and 'b' will
-  always work with byte strings. See :issue:`1441`.
+  always work with byte strings. (FileObjectPosix already worked this
+  way.) See :issue:`1441`.
 
 - The file objects accept *encoding*, *errors* and *newline*
   arguments. On Python 2, these are only used if 't' is in the mode.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@
   ``r``, for consistency with the other file objects and the standard
   ``open`` and ``io.open`` functions.
 
+- Fix ``FilObjectPosix`` improperly being used from multiple
+  greenlets. Previously this was hidden by forcing buffering, which
+  raised ``RuntimeError``.
+
 
 1.5a2 (2019-10-21)
 ==================

--- a/src/gevent/_fileobjectposix.py
+++ b/src/gevent/_fileobjectposix.py
@@ -1,19 +1,20 @@
 from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
-import io
-from io import BufferedReader
-from io import BufferedWriter
+
+
 from io import BytesIO
 from io import DEFAULT_BUFFER_SIZE
+from io import FileIO
 from io import RawIOBase
 from io import UnsupportedOperation
 
 from gevent._compat import reraise
-from gevent._compat import PY2
-from gevent._compat import PY3
 from gevent._fileobjectcommon import cancel_wait_ex
 from gevent._fileobjectcommon import FileObjectBase
+from gevent._fileobjectcommon import OpenDescriptor
+from gevent._hub_primitives import wait_on_watcher
 from gevent.hub import get_hub
 from gevent.os import _read
 from gevent.os import _write
@@ -22,34 +23,35 @@ from gevent.os import make_nonblocking
 
 
 class GreenFileDescriptorIO(RawIOBase):
-
     # Note that RawIOBase has a __del__ method that calls
     # self.close(). (In C implementations like CPython, this is
     # the type's tp_dealloc slot; prior to Python 3, the object doesn't
     # appear to have a __del__ method, even though it functionally does)
 
-    _read_event = None
-    _write_event = None
+    _read_watcher = None
+    _write_watcher = None
     _closed = False
     _seekable = None
+    _keep_alive = None # An object that needs to live as long as we do.
 
     def __init__(self, fileno, mode='r', closefd=True):
-        RawIOBase.__init__(self) # Python 2: pylint:disable=no-member,non-parent-init-called
+        RawIOBase.__init__(self)
 
         self._closefd = closefd
         self._fileno = fileno
+        self.mode = mode
         make_nonblocking(fileno)
-        readable = 'r' in mode
-        writable = 'w' in mode
+        readable = 'r' in mode or '+' in mode
+        writable = 'w' in mode or '+' in mode
 
         self.hub = get_hub()
         io_watcher = self.hub.loop.io
         try:
             if readable:
-                self._read_event = io_watcher(fileno, 1)
+                self._read_watcher = io_watcher(fileno, 1)
 
             if writable:
-                self._write_event = io_watcher(fileno, 2)
+                self._write_watcher = io_watcher(fileno, 2)
         except:
             # If anything goes wrong, it's important to go ahead and
             # close these watchers *now*, especially under libuv, so
@@ -67,11 +69,18 @@ class GreenFileDescriptorIO(RawIOBase):
             self.close()
             raise
 
+    def isatty(self):
+        f = FileIO(self._fileno, 'r', False)
+        try:
+            return f.isatty()
+        finally:
+            f.close()
+
     def readable(self):
-        return self._read_event is not None
+        return self._read_watcher is not None
 
     def writable(self):
-        return self._write_event is not None
+        return self._write_watcher is not None
 
     def seekable(self):
         if self._seekable is None:
@@ -91,10 +100,10 @@ class GreenFileDescriptorIO(RawIOBase):
         return self._closed
 
     def __destroy_events(self):
-        read_event = self._read_event
-        write_event = self._write_event
+        read_event = self._read_watcher
+        write_event = self._write_watcher
         hub = self.hub
-        self.hub = self._read_event = self._write_event = None
+        self.hub = self._read_watcher = self._write_watcher = None
 
         if read_event is not None:
             hub.cancel_wait(read_event, cancel_wait_ex, True)
@@ -110,9 +119,14 @@ class GreenFileDescriptorIO(RawIOBase):
         self._closed = True
         self.__destroy_events()
         fileno = self._fileno
-        if self._closefd:
-            self._fileno = None
-            os.close(fileno)
+        keep_alive = self._keep_alive
+        self._fileno = self._keep_alive = None
+        try:
+            if self._closefd:
+                os.close(fileno)
+        finally:
+            if hasattr(keep_alive, 'close'):
+                keep_alive.close()
 
     # RawIOBase provides a 'read' method that will call readall() if
     # the `size` was missing or -1 and otherwise call readinto(). We
@@ -122,20 +136,26 @@ class GreenFileDescriptorIO(RawIOBase):
     # this was fixed in Python 3.3, but we still need our workaround for 2.7. See
     # https://github.com/gevent/gevent/issues/675)
     def __read(self, n):
-        if self._read_event is None:
+        if self._read_watcher is None:
             raise UnsupportedOperation('read')
-        while True:
+        while 1:
             try:
                 return _read(self._fileno, n)
             except (IOError, OSError) as ex:
                 if ex.args[0] not in ignored_errors:
                     raise
-            self.hub.wait(self._read_event)
+            wait_on_watcher(self._read_watcher, None, None, self.hub)
 
     def readall(self):
         ret = BytesIO()
         while True:
-            data = self.__read(DEFAULT_BUFFER_SIZE)
+            try:
+                data = self.__read(DEFAULT_BUFFER_SIZE)
+            except cancel_wait_ex:
+                # We were closed while reading. A buffered reader
+                # just returns what it has handy at that point,
+                # so we do to.
+                data = None
             if not data:
                 break
             ret.write(data)
@@ -154,7 +174,7 @@ class GreenFileDescriptorIO(RawIOBase):
         return n
 
     def write(self, b):
-        if self._write_event is None:
+        if self._write_watcher is None:
             raise UnsupportedOperation('write')
         while True:
             try:
@@ -162,7 +182,7 @@ class GreenFileDescriptorIO(RawIOBase):
             except (IOError, OSError) as ex:
                 if ex.args[0] not in ignored_errors:
                     raise
-            self.hub.wait(self._write_event)
+            wait_on_watcher(self._write_watcher, None, None, self.hub)
 
     def seek(self, offset, whence=0):
         try:
@@ -176,16 +196,33 @@ class GreenFileDescriptorIO(RawIOBase):
             # See https://github.com/gevent/gevent/issues/1323
             reraise(IOError, IOError(*ex.args), sys.exc_info()[2])
 
-
-class FlushingBufferedWriter(BufferedWriter):
-
-    def write(self, b):
-        ret = BufferedWriter.write(self, b)
-        self.flush()
-        return ret
+    def __repr__(self):
+        return "<%s at 0x%x fileno=%s mode=%r>" % (
+            type(self).__name__, id(self), self._fileno, self.mode
+        )
 
 
-_marker = object()
+class GreenOpenDescriptor(OpenDescriptor):
+
+    def open_raw(self):
+        if self.is_fd():
+            fileio = GreenFileDescriptorIO(self.fobj, self.fileio_mode, closefd=self.closefd)
+        else:
+            closefd = False
+            # Either an existing file object or a path string (which
+            # we open to get a file object). In either case, the other object
+            # owns the descriptor and we must not close it.
+            closefd = False
+            if hasattr(self.fobj, 'fileno'):
+                raw = self.fobj
+            else:
+                raw = OpenDescriptor.open_raw(self)
+
+            fileno = raw.fileno()
+            fileio = GreenFileDescriptorIO(fileno, self.fileio_mode, closefd=closefd)
+            fileio._keep_alive = raw
+        return fileio
+
 
 class FileObjectPosix(FileObjectBase):
     """
@@ -239,19 +276,28 @@ class FileObjectPosix(FileObjectBase):
     .. versionchanged:: 1.2a1
        Document the ``fileio`` attribute for non-blocking reads.
     .. versionchanged:: 1.5
-       The default value for *mode* was changed from ``rb`` to ``r``.
+       The default value for *mode* was changed from ``rb`` to ``r``. This is consistent
+       with :func:`open`, :func:`io.open`, and :class:`~.FileObjectThread`, which is the
+       default ``FileObject`` on some platforms.
     .. versionchanged:: 1.5
        Support strings and ``PathLike`` objects for ``fobj`` on all versions
        of Python. Note that caution above.
     .. versionchanged:: 1.5
        Add *encoding*, *errors* and *newline* argument.
+    .. versionchanged:: 1.5
+       Accept *closefd* and *buffering* instead of *close* and *bufsize* arguments.
+       The latter remain for backwards compatibility.
+    .. versionchanged:: 1.5
+       Stop forcing buffering. Previously, given a ``buffering=0`` argument,
+       *buffering8 would be set to 1, and ``buffering=1`` would be forced to
+       the default buffer size. This was a workaround for a long-standing concurrency
+       issue. Now the *buffering* argument is interpreted as intended.
     """
 
     #: platform specific default for the *bufsize* parameter
-    default_bufsize = io.DEFAULT_BUFFER_SIZE
+    default_bufsize = DEFAULT_BUFFER_SIZE
 
-    def __init__(self, fobj, mode='r', bufsize=-1, close=True,
-                 encoding=None, errors=None, newline=_marker):
+    def __init__(self, *args, **kwargs):
         # pylint:disable=too-many-locals
         """
         :param fobj: Either an integer fileno, or an object supporting the
@@ -263,7 +309,7 @@ class FileObjectPosix(FileObjectBase):
             if 't' is not in the mode, this will result in returning byte (native) strings;
             putting 't'  in the mode will return text (unicode) strings. This may cause
             :exc:`UnicodeDecodeError` to be raised.
-        :keyword int bufsize: If given, the size of the buffer to use. The default
+        :keyword int buffering: If given, the size of the buffer to use. The default
             value means to use a platform-specific default
             Other values are interpreted as for the :mod:`io` package.
             Buffering is ignored in text mode.
@@ -282,72 +328,11 @@ class FileObjectPosix(FileObjectBase):
            in gevent 1.1 it was flushed when more than one byte was
            written. Note that this may have performance impacts.
         """
-
-        if isinstance(fobj, int):
-            fileno = fobj
-            fobj = None
-        else:
-            # The underlying object, if we have to open it, should be
-            # in binary mode. We'll take care of any coding needed.
-            raw_mode = mode.replace('t', 'b')
-            raw_mode = raw_mode + 'b' if 'b' not in raw_mode else raw_mode
-            new_fobj = self._open_raw(fobj, raw_mode, bufsize, closefd=False)
-            if new_fobj is not fobj:
-                close = True
-                fobj = new_fobj
-            fileno = fobj.fileno()
-
-        self.__fobj = fobj
-        assert isinstance(fileno, int)
-
-        # We want text mode if:
-        # - We're on Python 3, and no 'b' is in the mode.
-        # - A 't' is in the mode on any version.
-        # - We're on Python 2 and no 'b' is in the mode, and an encoding or errors is
-        #   given.
-        text_mode = (
-            't' in mode
-            or (PY3 and 'b' not in mode)
-            or (PY2 and 'b' not in mode and (encoding, errors) != (None, None))
-        )
-        if text_mode:
-            self._translate = True
-            self._translate_newline = os.linesep if newline is _marker else newline
-            self._translate_encoding = encoding
-            self._transalate_errors = errors
-
-        if 'U' in mode:
-            self._translate = True
-            self._translate_newline = None
-
-            if PY2 and not text_mode:
-                self._translate_mode = 'byte_newlines'
-
-        self._orig_bufsize = bufsize
-        if bufsize < 0 or bufsize == 1:
-            bufsize = self.default_bufsize
-        elif bufsize == 0:
-            bufsize = 1
-
-        if mode[0] == 'r':
-            IOFamily = BufferedReader
-        else:
-            assert mode[0] == 'w'
-            IOFamily = BufferedWriter
-            if self._orig_bufsize == 0:
-                # We could also simply pass self.fileio as *io*, but this way
-                # we at least consistently expose a BufferedWriter in our *io*
-                # attribute.
-                IOFamily = FlushingBufferedWriter
-
-
+        descriptor = GreenOpenDescriptor(*args, **kwargs)
 
         # This attribute is documented as available for non-blocking reads.
-        self.fileio = GreenFileDescriptorIO(fileno, mode, closefd=close)
-
-        buffered_fobj = IOFamily(self.fileio, bufsize)
-
-        super(FileObjectPosix, self).__init__(buffered_fobj, close)
+        self.fileio, buffered_fobj = descriptor.open_raw_and_wrapped()
+        super(FileObjectPosix, self).__init__(buffered_fobj, descriptor.closefd)
 
     def _do_close(self, fobj, closefd):
         try:
@@ -355,14 +340,5 @@ class FileObjectPosix(FileObjectBase):
             # self.fileio already knows whether or not to close the
             # file descriptor
             self.fileio.close()
-            if closefd and self.__fobj is not None:
-                try:
-                    self.__fobj.close()
-                except IOError:
-                    pass
         finally:
-            self.__fobj = None
             self.fileio = None
-
-    def __iter__(self):
-        return self._io

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -261,7 +261,9 @@ class socket(object):
         except the only mode characters supported are 'r', 'w' and 'b'.
         The semantics are similar too.
         """
-        # (XXX refactor to share code?)
+        # XXX refactor to share code? We ought to be able to use our FileObject,
+        # adding the appropriate amount of refcounting. At the very least we can use our
+        # OpenDescriptor to handle the parsing.
         for c in mode:
             if c not in {"r", "w", "b"}:
                 raise ValueError("invalid mode %r (only r, w, b allowed)")

--- a/src/gevent/_sslgte279.py
+++ b/src/gevent/_sslgte279.py
@@ -56,14 +56,16 @@ if 'namedtuple' in __all__:
 
 # See notes in _socket2.py. Python 3 returns much nicer
 # `io` object wrapped around a SocketIO class.
-assert not hasattr(__ssl__._fileobject, '__enter__') # pylint:disable=no-member
+if hasattr(__ssl__, '_fileobject'):
+    assert not hasattr(__ssl__._fileobject, '__enter__') # pylint:disable=no-member
 
-class _fileobject(__ssl__._fileobject): # pylint:disable=no-member
+class _fileobject(getattr(__ssl__, '_fileobject', object)): # pylint:disable=no-member
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
+        # pylint:disable=no-member
         if not self.closed:
             self.close()
 
@@ -96,14 +98,14 @@ def create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None,
     context = SSLContext(PROTOCOL_SSLv23)
 
     # SSLv2 considered harmful.
-    context.options |= OP_NO_SSLv2
+    context.options |= OP_NO_SSLv2 # pylint:disable=no-member
 
     # SSLv3 has problematic security and is only required for really old
     # clients such as IE6 on Windows XP
-    context.options |= OP_NO_SSLv3
+    context.options |= OP_NO_SSLv3 # pylint:disable=no-member
 
     # disable compression to prevent CRIME attacks (OpenSSL 1.0+)
-    context.options |= getattr(_ssl, "OP_NO_COMPRESSION", 0)
+    context.options |= getattr(_ssl, "OP_NO_COMPRESSION", 0) # pylint:disable=no-member
 
     if purpose == Purpose.SERVER_AUTH:
         # verify certs and host name in client mode
@@ -112,11 +114,11 @@ def create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None,
     elif purpose == Purpose.CLIENT_AUTH:
         # Prefer the server's ciphers by default so that we get stronger
         # encryption
-        context.options |= getattr(_ssl, "OP_CIPHER_SERVER_PREFERENCE", 0)
+        context.options |= getattr(_ssl, "OP_CIPHER_SERVER_PREFERENCE", 0) # pylint:disable=no-member
 
         # Use single use keys in order to improve forward secrecy
-        context.options |= getattr(_ssl, "OP_SINGLE_DH_USE", 0)
-        context.options |= getattr(_ssl, "OP_SINGLE_ECDH_USE", 0)
+        context.options |= getattr(_ssl, "OP_SINGLE_DH_USE", 0) # pylint:disable=no-member
+        context.options |= getattr(_ssl, "OP_SINGLE_ECDH_USE", 0) # pylint:disable=no-member
 
         # disallow ciphers with known vulnerabilities
         context.set_ciphers(_RESTRICTED_SERVER_CIPHERS)
@@ -146,10 +148,10 @@ def _create_unverified_context(protocol=PROTOCOL_SSLv23, cert_reqs=None,
 
     context = SSLContext(protocol)
     # SSLv2 considered harmful.
-    context.options |= OP_NO_SSLv2
+    context.options |= OP_NO_SSLv2 # pylint:disable=no-member
     # SSLv3 has problematic security and is only required for really old
     # clients such as IE6 on Windows XP
-    context.options |= OP_NO_SSLv3
+    context.options |= OP_NO_SSLv3 # pylint:disable=no-member
 
     if cert_reqs is not None:
         context.verify_mode = cert_reqs

--- a/src/gevent/fileobject.py
+++ b/src/gevent/fileobject.py
@@ -1,10 +1,28 @@
 """
 Wrappers to make file-like objects cooperative.
 
-.. class:: FileObject
+.. class:: FileObject(fobj, mode='r', buffering=-1, closefd=True, encoding=None, errors=None, newline=None)
 
-   The main entry point to the file-like gevent-compatible behaviour. It will be defined
-   to be the best available implementation.
+    The main entry point to the file-like gevent-compatible behaviour. It
+    will be defined to be the best available implementation.
+
+    All the parameters are as for :func:`io.open`.
+
+    :param fobj: Usually a file descriptor of a socket. Can also be
+        another object with a ``fileno()`` method, or an object that can
+        be passed to ``io.open()`` (e.g., a file system path). If the object
+        is not a socket, the results will vary based on the platform and the
+        type of object being opened.
+
+        All supported versions of Python allow :class:`os.PathLike` objects.
+
+    .. versionchanged:: 1.5
+       Accept str and ``PathLike`` objects for *fobj* on all versions of Python.
+    .. versionchanged:: 1.5
+       Add *encoding*, *errors* and *newline* arguments.
+    .. versionchanged:: 1.5
+       Accept *closefd* and *buffering* instead of *close* and *bufsize* arguments.
+       The latter remain for backwards compatibility.
 
 There are two main implementations of ``FileObject``. On all systems,
 there is :class:`FileObjectThread` which uses the built-in native
@@ -12,9 +30,11 @@ threadpool to avoid blocking the entire interpreter. On UNIX systems
 (those that support the :mod:`fcntl` module), there is also
 :class:`FileObjectPosix` which uses native non-blocking semantics.
 
-A third class, :class:`FileObjectBlock`, is simply a wrapper that executes everything
-synchronously (and so is not gevent-compatible). It is provided for testing and debugging
-purposes.
+A third class, :class:`FileObjectBlock`, is simply a wrapper that
+executes everything synchronously (and so is not gevent-compatible).
+It is provided for testing and debugging purposes.
+
+All classes have the same signature; some may accept extra keyword arguments.
 
 Configuration
 =============
@@ -27,8 +47,10 @@ You may also set it to the fully qualified class name of another
 object that implements the file interface to use one of your own
 objects.
 
-.. note:: The environment variable must be set at the time this module
-   is first imported.
+.. note::
+
+    The environment variable must be set at the time this module
+    is first imported.
 
 Classes
 =======
@@ -58,4 +80,6 @@ from gevent._fileobjectcommon import FileObjectBlock
 
 # None of the possible objects can live in this module because
 # we would get an import cycle and the config couldn't be set from code.
+# TODO: zope.hookable would be great for allowing this to be imported
+# without requiring configuration but still being very fast.
 FileObject = config.fileobject

--- a/src/gevent/testing/sysinfo.py
+++ b/src/gevent/testing/sysinfo.py
@@ -24,9 +24,13 @@ import sys
 import gevent.core
 from gevent import _compat as gsysinfo
 
+VERBOSE = sys.argv.count('-v') > 1
+
+# Python implementations
 PYPY = gsysinfo.PYPY
 CPYTHON = not PYPY
-VERBOSE = sys.argv.count('-v') > 1
+
+# Platform/operating system
 WIN = gsysinfo.WIN
 LINUX = gsysinfo.LINUX
 OSX = gsysinfo.OSX

--- a/src/gevent/tests/test__monkey_queue.py
+++ b/src/gevent/tests/test__monkey_queue.py
@@ -57,7 +57,7 @@ class BlockingTestMixin(object):
             self.fail("blocking function '%r' appeared not to block" %
                       block_func)
         self.t.join(10) # make sure the thread terminates
-        if self.t.isAlive():
+        if self.t.is_alive():
             self.fail("trigger function '%r' appeared to not return" %
                       trigger_func)
         return self.result
@@ -72,7 +72,7 @@ class BlockingTestMixin(object):
                 block_func(*block_args)
         finally:
             self.t.join(10) # make sure the thread terminates
-            if self.t.isAlive():
+            if self.t.is_alive():
                 self.fail("trigger function '%r' appeared to not return" %
                           trigger_func)
             if not self.t.startedEvent.isSet():


### PR DESCRIPTION
Keeping control this way simplifies and unifies the implementations.

- Bring in an implementation of `io.open` for full control. No more weird corner cases where stuff is different.
- FileObjectPosix handles read+write modes.
- Fix a concurrency bug in FileObjectPosix that we were hiding with buffering and a RuntimeError.
- Add all the error checking the stdlib does, with a few exceptions that make sense.

See #1441.