### PR TITLE
Fix #1464 and fix #1465 by making LockType sleep on failure to non-blocking acquire the lock.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@
   greenlets. Previously this was hidden by forcing buffering, which
   raised ``RuntimeError``.
 
+- Fix using monkey-patched ``threading.Lock`` and ``threading.RLock``
+  objects as spin locks by making them call ``sleep(0)`` if they
+  failed to acquire the lock in a non-blocking call. This lets other
+  callbacks run to release the lock, simulating preemptive threading.
+  Using spin locks is not recommended, but may have been done in code
+  written for threads, especially on Python 3. See :issue:`1464`.
 
 1.5a2 (2019-10-21)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@
   ``r``, for consistency with the other file objects and the standard
   ``open`` and ``io.open`` functions.
 
-- Fix ``FilObjectPosix`` improperly being used from multiple
+- Fix ``FileObjectPosix`` improperly being used from multiple
   greenlets. Previously this was hidden by forcing buffering, which
   raised ``RuntimeError``.
 

--- a/src/gevent/tests/test__threading_vs_settrace.py
+++ b/src/gevent/tests/test__threading_vs_settrace.py
@@ -82,7 +82,6 @@ class TestTrace(unittest.TestCase):
         else:
             old = None
 
-        PY3 = sys.version_info[0] > 2
         lst = []
         # we should be able to use unrelated locks from within the trace function
         l = allocate_lock()
@@ -90,7 +89,7 @@ class TestTrace(unittest.TestCase):
             def trace(frame, ev, _arg):
                 with l:
                     lst.append((frame.f_code.co_filename, frame.f_lineno, ev))
-                print("TRACE: %s:%s %s" % lst[-1])
+                # print("TRACE: %s:%s %s" % lst[-1])
                 return trace
 
             l2 = allocate_lock()
@@ -102,12 +101,8 @@ class TestTrace(unittest.TestCase):
         finally:
             sys.settrace(old)
 
-        if not PY3:
-            # Py3 overrides acquire in Python to do argument checking
-            self.assertEqual(lst, [], "trace not empty")
-        else:
-            # Have an assert so that we know if we miscompile
-            self.assertTrue(lst, "should not compile on pypy")
+        # Have an assert so that we know if we miscompile
+        self.assertTrue(lst, "should not compile on pypy")
 
     @greentest.skipOnPurePython("Locks can be traced in Pure Python")
     def test_untraceable_lock_uses_same_lock(self):
@@ -116,7 +111,7 @@ class TestTrace(unittest.TestCase):
             old = sys.gettrace()
         else:
             old = None
-        PY3 = sys.version_info[0] > 2
+
         lst = []
         e = None
         # we should not be able to use the same lock from within the trace function
@@ -137,13 +132,9 @@ class TestTrace(unittest.TestCase):
         finally:
             sys.settrace(old)
 
-        if not PY3:
-            # Py3 overrides acquire in Python to do argument checking
-            self.assertEqual(lst, [], "trace not empty")
-        else:
-            # Have an assert so that we know if we miscompile
-            self.assertTrue(lst, "should not compile on pypy")
-            self.assertTrue(isinstance(e, LoopExit))
+        # Have an assert so that we know if we miscompile
+        self.assertTrue(lst, "should not compile on pypy")
+        self.assertTrue(isinstance(e, LoopExit))
 
     def run_script(self, more_args=()):
         args = [sys.executable, "-c", script]

--- a/src/gevent/timeout.py
+++ b/src/gevent/timeout.py
@@ -266,12 +266,16 @@ class Timeout(BaseException):
         # Internal use only in 1.1
         # Return an object with a 'cancel' method; if timeout is None,
         # this will be a shared instance object that does nothing. Otherwise,
-        # return an actual Timeout. Because negative values are hard to reason about,
+        # return an actual Timeout. A 0 value is allowed and creates a real Timeout.
+
+        # Because negative values are hard to reason about,
         # and are often used as sentinels in Python APIs, in the future it's likely
         # that a negative timeout will also return the shared instance.
-        # This saves the previously common idiom of 'timer = Timeout.start_new(t) if t is not None else None'
+        # This saves the previously common idiom of
+        # 'timer = Timeout.start_new(t) if t is not None else None'
         # followed by 'if timer is not None: timer.cancel()'.
         # That idiom was used to avoid any object allocations.
+
         # A staticmethod is slightly faster under CPython, compared to a classmethod;
         # under PyPy in synthetic benchmarks it makes no difference.
         if timeout is None:


### PR DESCRIPTION
Using sleep doesn't force a trip around the event loop until the switch interval elapses.