### PR TITLE
Fix an interaction between the switch interval and libuv that could introduce delays for large batches of callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,16 @@
 
 - Remove some undocumented, deprecated functions from the threadpool module.
 
+- libuv: Fix a perceived slowness spawning many greenlets at the same time
+  without yielding to the event loop while having no active IO
+  watchers or timers. If the time spent launching greenlets exceeded
+  the switch interval and there were no other active watchers, then
+  the default IO poll time of about .3s would elapse between spawning
+  batches. This could theoretically apply for any non-switching
+  callbacks. This can be produced in synthetic benchmarks and other
+  special circumstances, but real applications are unlikely to be
+  affected. See :issue:`1493`.
+
 1.5a2 (2019-10-21)
 ==================
 

--- a/benchmarks/bench_spawn.py
+++ b/benchmarks/bench_spawn.py
@@ -106,7 +106,7 @@ def bench_none(options):
 
 
 def bench_gevent(options):
-    from gevent import spawn, sleep, get_hub
+    from gevent import spawn, sleep
     return test(spawn, sleep, options)
 
 
@@ -224,6 +224,7 @@ def main(argv=None):
                                globals()['bench_' + name],
                                Options(sleep=False, join=False, foo=1, bar='hello'),
                                inner_loops=N)
+
 
 if __name__ == '__main__':
     main()

--- a/src/gevent/libuv/_corecffi_cdef.c
+++ b/src/gevent/libuv/_corecffi_cdef.c
@@ -354,22 +354,20 @@ void* memset(void *b, int c, size_t len);
 // call them
 typedef void* GeventWatcherObject;
 extern "Python" {
-	// Standard gevent._ffi.loop callbacks.
-	int python_callback(GeventWatcherObject handle, int revents);
-	void python_handle_error(GeventWatcherObject handle, int revents);
-	void python_stop(GeventWatcherObject handle);
+    // Standard gevent._ffi.loop callbacks.
+    int python_callback(GeventWatcherObject handle, int revents);
+    void python_handle_error(GeventWatcherObject handle, int revents);
+    void python_stop(GeventWatcherObject handle);
 
-	void python_check_callback(uv_check_t* handle);
-	void python_prepare_callback(uv_prepare_t* handle);
-	void python_timer0_callback(uv_check_t* handle);
+    void python_check_callback(uv_check_t* handle);
+    void python_prepare_callback(uv_prepare_t* handle);
+    void python_timer0_callback(uv_check_t* handle);
 
-	// libuv specific callback
-	void _uv_close_callback(uv_handle_t* handle);
-	void python_sigchld_callback(uv_signal_t* handle, int signum);
-	void python_queue_callback(uv_handle_t* handle, int revents);
+    // libuv specific callback
+    void _uv_close_callback(uv_handle_t* handle);
+    void python_sigchld_callback(uv_signal_t* handle, int signum);
+    void python_queue_callback(uv_handle_t* handle, int revents);
 }
-// A variable we fill in.
-static void (*gevent_noop)(void* handle);
 
 static void _gevent_signal_callback1(uv_signal_t* handle, int arg);
 static void _gevent_async_callback0(uv_async_t* handle);

--- a/src/gevent/libuv/_corecffi_source.c
+++ b/src/gevent/libuv/_corecffi_source.c
@@ -1,75 +1,23 @@
 #include <string.h>
+#include <assert.h>
 #include "uv.h"
 
 typedef void* GeventWatcherObject;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wundefined-internal"
+#endif
 
 static int python_callback(GeventWatcherObject handle, int revents);
 static void python_queue_callback(uv_handle_t* watcher_ptr, int revents);
 static void python_handle_error(GeventWatcherObject handle, int revents);
 static void python_stop(GeventWatcherObject handle);
 
-static void _gevent_noop(void* handle) {}
-
-static void (*gevent_noop)(void* handle) = &_gevent_noop;
-
-static void _gevent_generic_callback1_unused(uv_handle_t* watcher, int arg)
-{
-    // Python code may set this to NULL or even change it
-    // out from under us, which would tend to break things.
-    GeventWatcherObject handle = watcher->data;
-    const int cb_result = python_callback(handle, arg);
-    switch(cb_result) {
-        case -1:
-            // in case of exception, call self.loop.handle_error;
-            // this function is also responsible for stopping the watcher
-            // and allowing memory to be freed
-            python_handle_error(handle, arg);
-        break;
-        case 1:
-            // Code to stop the event IF NEEDED. Note that if python_callback
-            // has disposed of the last reference to the handle,
-            // `watcher` could now be invalid/disposed memory!
-            if (!uv_is_active(watcher)) {
-                if (watcher->data != handle) {
-                    if (watcher->data) {
-                        // If Python set the data to NULL, then they
-                        // expected to be stopped. That's fine.
-                        // Otherwise, something weird happened.
-                        fprintf(stderr,
-                                "WARNING: gevent: watcher handle changed in callback "
-                                "from %p to %p for watcher at %p of type %d\n",
-                                handle, watcher->data, watcher, watcher->type);
-                        // There's a very good chance that the object the
-                        // handle referred to has been changed and/or the
-                        // old handle has been deallocated (most common), so
-                        // passing the old handle will crash. Instead we
-                        // pass a sigil to let python distinguish this case.
-                        python_stop(NULL);
-                    }
-                }
-                else {
-                    python_stop(handle);
-                }
-            }
-        break;
-        case 2:
-            // watcher is already stopped and dead, nothing to do.
-        break;
-        default:
-            fprintf(stderr,
-                    "WARNING: gevent: Unexpected return value %d from Python callback "
-                    "for watcher %p (of type %d) and handle %p\n",
-                    cb_result,
-                    watcher, watcher->type, handle);
-            // XXX: Possible leaking of resources here? Should we be
-            // closing the watcher?
-    }
-}
-
-
 static void _gevent_generic_callback1(uv_handle_t* watcher, int arg)
 {
-	python_queue_callback(watcher, arg);
+    python_queue_callback(watcher, arg);
 }
 
 static void _gevent_generic_callback0(uv_handle_t* handle)
@@ -181,3 +129,11 @@ static void gevent_zero_loop(uv_loop_t* handle)
 {
     memset(handle, 0, sizeof(uv_loop_t));
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+/* Local Variables: */
+/* flycheck-clang-include-path: ("../../../deps/libuv/include") */
+/* End: */


### PR DESCRIPTION
Specifically, a .3s (idle signal timer) delay, because UV_RUN_ONCE would pause if there was no other active timer or IO watcher.

Now, if there are still batches of callbacks to run, we explicitly use UV_RUN_NOWAIT to only poll for IO and queue callbacks without waiting at all.

This gets the time for the synthetic greenlet-launching benchmarks to match libev-cffi and be close to libuv-cext.

Fixes #1493