### PR TITLE
Fix potential crashes in the FFI backends if a watcher was closed and…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,11 @@
   -m gevent.monkey``. Previously it would use greenlets instead of
   native threads. See :issue:`1484`.
 
+- Fix potential crashes in the FFI backends if a watcher was closed
+  and stopped in the middle of a callback from the event loop and then
+  raised an exception. This could happen if the hub's ``handle_error``
+  function was poorly customized, for example. See :issue:`1482`
+
 1.5a2 (2019-10-21)
 ==================
 

--- a/src/gevent/libev/watcher.py
+++ b/src/gevent/libev/watcher.py
@@ -218,7 +218,7 @@ class async_(_base.AsyncMixin, watcher):
 
     @property
     def pending(self):
-        return bool(libev.ev_async_pending(self._watcher))
+        return self._watcher is not None and bool(libev.ev_async_pending(self._watcher))
 
 # Provide BWC for those that have async
 locals()['async'] = async_

--- a/src/gevent/tests/test__hub.py
+++ b/src/gevent/tests/test__hub.py
@@ -337,5 +337,30 @@ class TestLoopInterface(unittest.TestCase):
         verify.verifyObject(ILoop, loop)
 
 
+class TestHandleError(unittest.TestCase):
+
+    def tearDown(self):
+        try:
+            del get_hub().handle_error
+        except AttributeError:
+            pass
+
+    def test_exception_in_custom_handle_error_does_not_crash(self):
+
+        def bad_handle_error(*args):
+            raise AttributeError
+
+        hub = get_hub().handle_error = bad_handle_error
+
+        class MyException(Exception):
+            pass
+
+        def raises():
+            raise MyException
+
+        with self.assertRaises(MyException):
+            gevent.spawn(raises).get()
+
+
 if __name__ == '__main__':
     greentest.main()

--- a/src/gevent/threadpool.py
+++ b/src/gevent/threadpool.py
@@ -521,13 +521,11 @@ class ThreadResult(object):
         aw.stop()
         aw.close()
 
-
         # Typically this is pool.semaphore.release and we have to
         # call this in the Hub; if we don't we get the dreaded
         # LoopExit (XXX: Why?)
-        self._call_when_ready()
-
         try:
+            self._call_when_ready()
             if self.exc_info:
                 self.hub.handle_error(self.context, *self.exc_info)
             self.context = None


### PR DESCRIPTION
… stopped in the middle of a callback from the event loop and then raised an exception.

This could happen if the hub's ``handle_error`` function was poorly customized, for example.

Fixes #1482

Direct error handling through the loop in the unexpected-but-closed case as well, matching what cext does.