### PR TITLE
Make gevent.killall do what Greenlet.kill does.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -101,9 +101,10 @@ dummy-variables-rgx=_.*
 generated-members=exc_clear
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set). This supports can work
+# (useful for classes with attributes dynamically set). This can work
 # with qualified names.
 #ignored-classes=SSLContext, SSLSocket, greenlet, Greenlet, parent, dead
+
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,19 @@
   raised an exception. This could happen if the hub's ``handle_error``
   function was poorly customized, for example. See :issue:`1482`
 
+- Make ``gevent.killall`` stop greenlets from running that hadn't been
+  run yet. This make it consistent with ``Greenlet.kill()``. See
+  :issue:`1473` reported by kochelmonster.
+
+- Make ``gevent.spawn_raw`` set the ``loop`` attribute on returned
+  greenlets. This lets them work with more gevent APIs, notably
+  ``gevent.killall()``. They already had dictionaries, but this may
+  make them slightly larger, depending on platform (on CPython 2.7
+  through 3.6 there is no apparent difference for one attribute but on
+  CPython 3.7 and 3.8 dictionaries are initially empty and only
+  allocate space once an attribute is added; they're still smaller
+  than on earlier versions though).
+
 1.5a2 (2019-10-21)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ requires = [
      # 0.28 is faster, and (important!) lets us specify the target module
      # name to be created so that we can have both foo.py and _foo.so
      # at the same time. 0.29 fixes some issues with Python 3.7,
-     # and adds the 3str mode for transition to Python 3. 0.29.12+ is
+     # and adds the 3str mode for transition to Python 3. 0.29.14+ is
      # required for Python 3.8
-     "Cython >= 0.29.13",
+     "Cython >= 0.29.14",
      # See version requirements in setup.py
      "cffi >= 1.12.3 ; platform_python_implementation == 'CPython'",
      # Python 3.7 requires at least 0.4.14, which is ABI incompatible with earlier

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -10,6 +10,7 @@ import functools
 import warnings
 
 from gevent._config import config
+from gevent._util import LazyOnClass
 
 try:
     from tracemalloc import get_object_traceback
@@ -106,26 +107,6 @@ def only_if_watcher(func):
             return func(self)
         return _NoWatcherResult
     return if_w
-
-
-class LazyOnClass(object):
-
-    @classmethod
-    def lazy(cls, cls_dict, func):
-        "Put a LazyOnClass object in *cls_dict* with the same name as *func*"
-        cls_dict[func.__name__] = cls(func)
-
-    def __init__(self, func, name=None):
-        self.name = name or func.__name__
-        self.func = func
-
-    def __get__(self, inst, klass):
-        if inst is None: # pragma: no cover
-            return self
-
-        val = self.func(inst)
-        setattr(klass, self.name, val)
-        return val
 
 
 class AbstractWatcherType(type):

--- a/src/gevent/_greenlet.pxd
+++ b/src/gevent/_greenlet.pxd
@@ -133,6 +133,9 @@ cdef class Greenlet(greenlet):
     cpdef rawlink(self, object callback)
     cpdef str _formatinfo(self)
 
+    # Helper for killall()
+    cpdef bint _maybe_kill_before_start(self, exception)
+
     # This is a helper function for a @property getter;
     # defining locals() for a @property doesn't seem to work.
     @cython.locals(reg=IdentRegistry)
@@ -144,11 +147,13 @@ cdef class Greenlet(greenlet):
     cdef bint __never_started_or_killed(self)
     cdef bint __start_completed(self)
     cdef __handle_death_before_start(self, tuple args)
+    @cython.final
+    cdef inline void __free(self)
 
     cdef __cancel_start(self)
 
-    cdef _report_result(self, object result)
-    cdef _report_error(self, tuple exc_info)
+    cdef inline __report_result(self, object result)
+    cdef inline __report_error(self, tuple exc_info)
     # This is used as the target of a callback
     # from the loop, and so needs to be a cpdef
     cpdef _notify_links(self)

--- a/src/gevent/tests/test__greenletset.py
+++ b/src/gevent/tests/test__greenletset.py
@@ -138,7 +138,7 @@ class Test(greentest.TestCase):
         for g in s:
             assert g.dead
 
-    def test_killall_iterable_argument_timeout(self):
+    def test_killall_iterable_argument_timeout_not_started(self):
         def f():
             try:
                 gevent.sleep(1.5)
@@ -149,6 +149,25 @@ class Test(greentest.TestCase):
         s = set()
         s.add(p1)
         s.add(p2)
+        gevent.killall(s, timeout=0.5)
+
+        for g in s:
+            self.assertTrue(g.dead, g)
+
+    def test_killall_iterable_argument_timeout_started(self):
+        def f():
+            try:
+                gevent.sleep(1.5)
+            except: # pylint:disable=bare-except
+                gevent.sleep(1)
+        p1 = GreenletSubclass.spawn(f)
+        p2 = GreenletSubclass.spawn(f)
+
+        s = set()
+        s.add(p1)
+        s.add(p2)
+        # Get them both running.
+        gevent.sleep(timing.SMALLEST_RELIABLE_DELAY)
         with self.assertRaises(Timeout):
             gevent.killall(s, timeout=0.5)
 

--- a/src/gevent/tests/test__hub.py
+++ b/src/gevent/tests/test__hub.py
@@ -159,6 +159,7 @@ class TestPeriodicMonitoringThread(greentest.TestCase):
         gevent.config.monitor_thread = self.monitor_thread
         self.monitored_hubs = None
         self._reset_hub()
+        super(TestPeriodicMonitoringThread, self).tearDown()
 
     def _monitor(self, hub):
         self.monitor_fired += 1

--- a/src/gevent/tests/test__issue330.py
+++ b/src/gevent/tests/test__issue330.py
@@ -65,7 +65,8 @@ class TestSwitch(greentest.TestCase):
             self.caught = e
 
     def test_kill_exception(self):
-        # Killing with gevent.kill gets the right exception
+        # Killing with gevent.kill gets the right exception,
+        # and we can pass exception objects, not just exception classes.
 
         g = gevent.spawn(self.catcher)
         g.start()

--- a/src/gevent/tests/test__pywsgi.py
+++ b/src/gevent/tests/test__pywsgi.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-# pylint: disable=too-many-lines,unused-argument
+# pylint: disable=too-many-lines,unused-argument,too-many-ancestors
 from __future__ import print_function
 
 from gevent import monkey

--- a/src/gevent/tests/test__server_pywsgi.py
+++ b/src/gevent/tests/test__server_pywsgi.py
@@ -93,13 +93,13 @@ class TestDefaultSpawn(test__server.TestDefaultSpawn):
 class TestSSLSocketNotAllowed(test__server.TestSSLSocketNotAllowed):
     Settings = Settings
 
-class TestRawSpawn(test__server.TestRawSpawn):
+class TestRawSpawn(test__server.TestRawSpawn): # pylint:disable=too-many-ancestors
     Settings = Settings
 
 class TestSSLGetCertificate(test__server.TestSSLGetCertificate):
     Settings = Settings
 
-class TestPoolSpawn(test__server.TestPoolSpawn):
+class TestPoolSpawn(test__server.TestPoolSpawn): # pylint:disable=too-many-ancestors
     Settings = Settings
 
 if __name__ == '__main__':

--- a/src/gevent/tests/test__threadpool_executor_patched.py
+++ b/src/gevent/tests/test__threadpool_executor_patched.py
@@ -9,7 +9,7 @@ import gevent.testing as greentest
 from . import test__threadpool
 
 
-class TestPatchedTPE(test__threadpool.TestTPE):
+class TestPatchedTPE(test__threadpool.TestTPE): # pylint:disable=too-many-ancestors
     MONKEY_PATCHED = True
 
 


### PR DESCRIPTION
And stop a fresh greenlet from even running.

Fixes #1473.

Free user-provided resources as soon as the greenlet is cancelled, if it's not running.