### PR TITLE
Fix Popen.communicate() to raise exceptions from reading the streams. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ install:
   - echo $BUILD_RUNTIMES/snakepit/$TRAVIS_PYTHON_VERSION.d
   - ls -l $BUILD_RUNTIMES/snakepit/$TRAVIS_PYTHON_VERSION.d
   - python -c 'import gevent; print(gevent.__version__)'
+  - python -c 'from gevent._compat import get_clock_info; print(get_clock_info("perf_counter"))'
 script:
   # The generic script for the matrix expansion is to
   # test the defaults.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,21 @@ Library and Dependency Updates
   with debugging. The event libraries allocate small amounts of memory
   at startup. The allocation functions have to take the GIL, but
   because of the limited amount of actual allocation that gets done
-  this is not expected to be a concern.
+  this is not expected to be a bottleneck.
+
+Other
+-----
+
+- Make `gevent.subprocess.Popen.communicate` raise exceptions raised
+  by reading from the process, like the standard library. In
+  particular, under Python 3, if the process output is being decoded
+  as text, this can now raise ``UnicodeDecodeError``. Reported in
+  :issue:`1510` by Ofer Koren.
+
+- Make `gevent.subprocess.Popen.communicate` be more careful about
+  closing files. Previously if a timeout error happened, a second call
+  to ``communicate`` might not close the pipe.
+
 
 1.5a3 (2020-01-01)
 ==================

--- a/src/gevent/_compat.py
+++ b/src/gevent/_compat.py
@@ -188,7 +188,11 @@ except ImportError:
 try:
     # Python 3.3+ (PEP 418)
     from time import perf_counter
+    from time import get_clock_info
+    from time import monotonic
     perf_counter = perf_counter
+    monotonic = monotonic
+    get_clock_info = get_clock_info
 except ImportError:
     import time
 
@@ -196,7 +200,9 @@ except ImportError:
         perf_counter = time.clock # pylint:disable=no-member
     else:
         perf_counter = time.time
-
+    monotonic = perf_counter
+    def get_clock_info(_):
+        return 'Unknown'
 
 ## Monitoring
 def get_this_psutil_process():

--- a/src/gevent/_fileobjectcommon.py
+++ b/src/gevent/_fileobjectcommon.py
@@ -371,7 +371,13 @@ class FileObjectBase(object):
         return getattr(self._io, name)
 
     def __repr__(self):
-        return '<%s _fobj=%r%s>' % (self.__class__.__name__, self.io, self._extra_repr())
+        return '<%s at 0x%x %s_fobj=%r%s>' % (
+            self.__class__.__name__,
+            id(self),
+            'closed' if self.closed else '',
+            self.io,
+            self._extra_repr()
+        )
 
     def _extra_repr(self):
         return ''

--- a/src/gevent/testing/__init__.py
+++ b/src/gevent/testing/__init__.py
@@ -85,6 +85,7 @@ from .skipping import skipOnPurePython
 from .skipping import skipWithCExtensions
 from .skipping import skipOnLibuvOnTravisOnCPython27
 from .skipping import skipOnPy37
+from .skipping import skipOnPy3
 from .skipping import skipWithoutResource
 from .skipping import skipWithoutExternalNetwork
 from .skipping import skipOnPy2

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -674,6 +674,11 @@ if WIN:
     disabled_tests += [
         # Issue with Unix vs DOS newlines in the file vs from the server
         'test_ssl.ThreadedTests.test_socketserver',
+        # On appveyor, this sometimes produces 'A non-blocking socket
+        # operation could not be completed immediately', followed by
+        # 'No connection could be made because the target machine
+        # actively refused it'
+        'test_socket.NonBlockingTCPTests.testAccept',
     ]
 
     # These are a problem on 3.5; on 3.6+ they wind up getting (accidentally) disabled.
@@ -803,6 +808,10 @@ if PY3:
             'test_subprocess.ProcessTestCaseNoPoll.test_cwd_with_relative_arg',
             'test_subprocess.ProcessTestCase.test_cwd_with_relative_executable',
 
+            # In 3.7 and 3.8 on Travis CI, this appears to take the full 3 seconds.
+            # Can't reproduce it locally. We have our own copy of this that takes
+            # timing on CI into account.
+            'test_subprocess.RunFuncTestCase.test_run_with_shell_timeout_and_capture_output',
         ]
 
     disabled_tests += [

--- a/src/gevent/testing/skipping.py
+++ b/src/gevent/testing/skipping.py
@@ -43,6 +43,7 @@ skipOnPyPy3 = _do_not_skip
 skipOnPyPyOnWindows = _do_not_skip
 
 skipOnPy2 = unittest.skip if sysinfo.PY2 else _do_not_skip
+skipOnPy3 = unittest.skip if sysinfo.PY3 else _do_not_skip
 skipOnPy37 = unittest.skip if sysinfo.PY37 else _do_not_skip
 
 skipOnPurePython = unittest.skip if sysinfo.PURE_PYTHON else _do_not_skip

--- a/src/gevent/testing/testcase.py
+++ b/src/gevent/testing/testcase.py
@@ -248,6 +248,11 @@ class TestCase(TestCaseMetaClass("NewBase",
     __timeout__ = params.LOCAL_TIMEOUT if not sysinfo.RUNNING_ON_CI else params.CI_TIMEOUT
 
     switch_expected = 'default'
+    #: Set this to true to cause errors that get reported to the hub to
+    #: always get propagated to the main greenlet. This can be done at the
+    #: class or method level.
+    #: .. caution:: This can hide errors and make it look like exceptions
+    #:    are propagated even if they're not.
     error_fatal = True
     uses_handle_error = True
     close_on_teardown = ()
@@ -257,7 +262,7 @@ class TestCase(TestCaseMetaClass("NewBase",
         # pylint:disable=arguments-differ
         if self.switch_expected == 'default':
             self.switch_expected = get_switch_expected(self.fullname)
-        return BaseTestCase.run(self, *args, **kwargs)
+        return super(TestCase, self).run(*args, **kwargs)
 
     def setUp(self):
         super(TestCase, self).setUp()

--- a/src/gevent/testing/testrunner.py
+++ b/src/gevent/testing/testrunner.py
@@ -5,7 +5,6 @@ import sys
 import os
 import glob
 import traceback
-import time
 import importlib
 from datetime import timedelta
 
@@ -135,7 +134,7 @@ class Runner(object):
 
     def _reap_all(self):
         while self._reap() > 0:
-            time.sleep(self.TIME_WAIT_REAP)
+            util.sleep(self.TIME_WAIT_REAP)
 
     def _spawn(self, pool, cmd, options):
         while True:
@@ -144,7 +143,7 @@ class Runner(object):
                 self._running_jobs.append(job)
                 return
 
-            time.sleep(self.TIME_WAIT_SPAWN)
+            util.sleep(self.TIME_WAIT_SPAWN)
 
     def __call__(self):
         util.log("Running tests in parallel with concurrency %s" % (self._worker_count,),)
@@ -153,11 +152,11 @@ class Runner(object):
         # sequentially.
         util.BUFFER_OUTPUT = self._worker_count > 1 or self._quiet
 
-        start = time.time()
+        start = util.perf_counter()
         try:
             self._run_tests()
         except KeyboardInterrupt:
-            self._report(time.time() - start, exit=False)
+            self._report(util.perf_counter() - start, exit=False)
             util.log('(partial results)\n')
             raise
         except:
@@ -165,7 +164,7 @@ class Runner(object):
             raise
 
         self._reap_all()
-        self._report(time.time() - start, exit=True)
+        self._report(util.perf_counter() - start, exit=True)
 
     def _run_tests(self):
         "Runs the tests, produces no report."
@@ -215,7 +214,7 @@ class TravisFoldingRunner(object):
     def __init__(self, runner, travis_fold_msg):
         self._runner = runner
         self._travis_fold_msg = travis_fold_msg
-        self._travis_fold_name = str(int(time.time()))
+        self._travis_fold_name = str(int(util.perf_counter()))
 
         # A zope-style acquisition proxy would be convenient here.
         run_tests = runner._run_tests

--- a/src/gevent/testing/timing.py
+++ b/src/gevent/testing/timing.py
@@ -18,9 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import time
-
 import gevent
+from gevent._compat import perf_counter
 
 from . import sysinfo
 from . import leakcheck
@@ -69,11 +68,11 @@ class _DelayWaitMixin(object):
         seconds = getattr(timeout, 'seconds', timeout)
 
         gevent.get_hub().loop.update_now()
-        start = time.time()
+        start = perf_counter()
         try:
             result = self.wait(timeout)
         finally:
-            self._check_delay_bounds(seconds, time.time() - start,
+            self._check_delay_bounds(seconds, perf_counter() - start,
                                      self._default_delay_min_adj,
                                      self._default_delay_max_adj)
         return result

--- a/src/gevent/testing/util.py
+++ b/src/gevent/testing/util.py
@@ -6,10 +6,11 @@ import traceback
 import unittest
 import threading
 import subprocess
-import time
+from time import sleep
 
 from . import six
 from gevent._config import validate_bool
+from gevent._compat import perf_counter
 from gevent.monkey import get_original
 
 # pylint: disable=broad-except,attribute-defined-outside-init
@@ -391,9 +392,9 @@ def run(command, **kwargs): # pylint:disable=too-many-locals
     name = popen.name
 
     try:
-        time_start = time.time()
+        time_start = perf_counter()
         out, err = popen.communicate()
-        took = time.time() - time_start
+        took = perf_counter() - time_start
         if popen.was_killed or popen.poll() is None:
             result = 'TIMEOUT'
         else:
@@ -611,7 +612,7 @@ class TestServer(ExampleMixin,
 
     def before(self):
         if self.before_delay is not None:
-            time.sleep(self.before_delay)
+            sleep(self.before_delay)
         self.assertIsNone(self.popen.poll(),
                           '%s died with code %s' % (
                               self.example, self.popen.poll(),
@@ -619,7 +620,7 @@ class TestServer(ExampleMixin,
 
     def after(self):
         if self.after_delay is not None:
-            time.sleep(self.after_delay)
+            sleep(self.after_delay)
         self.assertIsNone(self.popen.poll(),
                           '%s died with code %s' % (
                               self.example, self.popen.poll(),
@@ -646,6 +647,6 @@ class alarm(threading.Thread):
         self.start()
 
     def run(self):
-        time.sleep(self.timeout)
+        sleep(self.timeout)
         sys.stderr.write('Timeout.\n')
         os._exit(5)

--- a/src/gevent/tests/test__subprocess.py
+++ b/src/gevent/tests/test__subprocess.py
@@ -510,7 +510,7 @@ class RunFuncTestCase(greentest.TestCase):
     def test_run_with_shell_timeout_and_capture_output(self):
         #Output capturing after a timeout mustn't hang forever on open filehandles
         with self.runs_in_given_time(0.1):
-            with self.assertRaises(subprocess.TimeoutExpired) as c:
+            with self.assertRaises(subprocess.TimeoutExpired):
                 subprocess.run('sleep 3', shell=True, timeout=0.1,
                                capture_output=True)  # New session unspecified.
 


### PR DESCRIPTION
And a general clean up of how the streams are read, ensuring we just have one greenlet. This avoids the 'reentrant call' errors that could prevent closing the streams on time. Some follow on effects from this showed that we weren't truly suppressing BrokenPipeError as expected, so that had to be fixed too.

Includes a refactoring for test__core to avoid a crashing scenario and enable it more places.