### PR TITLE
Don't check to see if event is set before waiting

### DIFF
--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -202,9 +202,6 @@ class AbstractLinkable(object):
         return None # pragma: no cover all extent subclasses override
 
     def _wait(self, timeout=None):
-        if self.ready():
-            return self._wait_return_value(False, False)
-
         gotit = self._wait_core(timeout)
         return self._wait_return_value(True, gotit)
 


### PR DESCRIPTION
Should fix #1520.

#1520 details a bug in which a waiter that started waiting on an event after it was set will finish waiting before waiters that started waiting after the event was set. (Try saying that ten times fast.)

I can trace this back to `_wait` in `AbstractLinkable`, which performs a pre-wait check to see if the event is already set:

https://github.com/gevent/gevent/blob/367047681c79e04f96d645e3676c809f16d2ff98/src/gevent/_abstract_linkable.py#L204-L209

This causes it to finish executing before waiters that are actually waiting.

Removing that pre-wait check results in the correct output from the script in #1520:
```
Sending signal with data=data string
Waiting to unfire
Signal recieved with data=data string
Unfiring
```