### PR TITLE
Implement gevent.select.epoll

### DIFF
--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -314,7 +314,7 @@ class poll(object):
 
 if _original_epoll is not _NONE:
     class epoll(object):
-        def __init__(self, sizehint=-1, flags=0):
+        def __init__(self, sizehint=-1, flags=0):  # pylint:disable=unused-argument
             self._watchers = dict()
             self._results = dict()
             self._inactive_watchers = set()
@@ -340,7 +340,7 @@ if _original_epoll is not _NONE:
             self._epoll_for_testing_fds.close()
 
             while self._watchers:
-                fd, watch = self._watchers.popitem()
+                _, watch = self._watchers.popitem()
                 watch.close()
 
             self._closed = True

--- a/src/gevent/tests/test__monkey_selectors.py
+++ b/src/gevent/tests/test__monkey_selectors.py
@@ -29,14 +29,14 @@ class TestSelectors(greentest.TestCase):
         self.assertIn('_gevent_monkey', dir(_select))
 
     @greentest.skipUnless(
-        hasattr(selectors, 'PollSelector'),
+        hasattr(selectors, 'EpollSelector'),
         "Needs gevent.select.poll"
     )
     def test_poll_is_default(self):
         # Depending on the order of imports, gevent.select.poll may be defined but
         # selectors.PollSelector may not be defined.
         # https://github.com/gevent/gevent/issues/1466
-        self.assertIs(selectors.DefaultSelector, selectors.PollSelector)
+        self.assertIs(selectors.DefaultSelector, selectors.EpollSelector)
 
     def _check_selector(self, sel):
         def read(conn, _mask):

--- a/src/greentest/3.5/test_selectors.py
+++ b/src/greentest/3.5/test_selectors.py
@@ -263,10 +263,16 @@ class BaseSelectorTestCase(unittest.TestCase):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        if hasattr(s, 'fileno'):
+        if not hasattr(s, 'fileno'):
+            return
+
+        try:
             fd = s.fileno()
-            self.assertTrue(isinstance(fd, int))
-            self.assertGreaterEqual(fd, 0)
+        except NotImplementedError:
+            return
+
+        self.assertTrue(isinstance(fd, int))
+        self.assertGreaterEqual(fd, 0)
 
     def test_selector(self):
         s = self.SELECTOR()

--- a/src/greentest/3.6/test_selectors.py
+++ b/src/greentest/3.6/test_selectors.py
@@ -263,10 +263,16 @@ class BaseSelectorTestCase(unittest.TestCase):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        if hasattr(s, 'fileno'):
+        if not hasattr(s, 'fileno'):
+            return
+
+        try:
             fd = s.fileno()
-            self.assertTrue(isinstance(fd, int))
-            self.assertGreaterEqual(fd, 0)
+        except NotImplementedError:
+            return
+
+        self.assertTrue(isinstance(fd, int))
+        self.assertGreaterEqual(fd, 0)
 
     def test_selector(self):
         s = self.SELECTOR()

--- a/src/greentest/3.7/test_selectors.py
+++ b/src/greentest/3.7/test_selectors.py
@@ -290,10 +290,16 @@ class BaseSelectorTestCase(unittest.TestCase):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        if hasattr(s, 'fileno'):
+        if not hasattr(s, 'fileno'):
+            return
+
+        try:
             fd = s.fileno()
-            self.assertTrue(isinstance(fd, int))
-            self.assertGreaterEqual(fd, 0)
+        except NotImplementedError:
+            return
+
+        self.assertTrue(isinstance(fd, int))
+        self.assertGreaterEqual(fd, 0)
 
     def test_selector(self):
         s = self.SELECTOR()

--- a/src/greentest/3.8/test_selectors.py
+++ b/src/greentest/3.8/test_selectors.py
@@ -290,10 +290,16 @@ class BaseSelectorTestCase(unittest.TestCase):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        if hasattr(s, 'fileno'):
+        if not hasattr(s, 'fileno'):
+            return
+
+        try:
             fd = s.fileno()
-            self.assertTrue(isinstance(fd, int))
-            self.assertGreaterEqual(fd, 0)
+        except NotImplementedError:
+            return
+
+        self.assertTrue(isinstance(fd, int))
+        self.assertGreaterEqual(fd, 0)
 
     def test_selector(self):
         s = self.SELECTOR()


### PR DESCRIPTION
When running with gevent monkeypatching beneath an asyncio eventloop, gevent provides asyncio with PollSelector since 3d4404d (before that, it provided SelectSelector). Both implementations are "stateless": they do not cache io watchers, so they must re-add the watchers each time their respective `poll()` functions are called, burning CPU time on `epoll_ctl` syscalls. An `epoll` interface can keep a stable set of I/O watchers. By doing so, it minimizes syscalls.

uvicorn workload before:

```
epoll_wait(6, [], 262, 0)               = 0
getpid()                                = 27041
getpid()                                = 27041
epoll_ctl(6, EPOLL_CTL_ADD, 9, {EPOLLIN, {u32=9, u64=339302416393}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 17, {EPOLLIN, {u32=17, u64=12884901905}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 21, {EPOLLIN, {u32=21, u64=8589934613}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 23, {EPOLLIN, {u32=23, u64=8589934615}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 24, {EPOLLIN, {u32=24, u64=8589934616}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 26, {EPOLLIN, {u32=26, u64=8589934618}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 27, {EPOLLIN, {u32=27, u64=8589934619}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 28, {EPOLLIN, {u32=28, u64=8589934620}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 29, {EPOLLIN, {u32=29, u64=8589934621}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 31, {EPOLLIN, {u32=31, u64=8589934623}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 32, {EPOLLIN, {u32=32, u64=8589934624}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 34, {EPOLLIN, {u32=34, u64=8589934626}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 36, {EPOLLIN, {u32=36, u64=8589934628}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 37, {EPOLLIN, {u32=37, u64=8589934629}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 38, {EPOLLIN, {u32=38, u64=8589934630}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 39, {EPOLLIN, {u32=39, u64=8589934631}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 40, {EPOLLIN, {u32=40, u64=8589934632}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 41, {EPOLLIN, {u32=41, u64=8589934633}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 42, {EPOLLIN, {u32=42, u64=8589934634}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 43, {EPOLLIN, {u32=43, u64=8589934635}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 44, {EPOLLIN, {u32=44, u64=8589934636}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 45, {EPOLLIN, {u32=45, u64=8589934637}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 46, {EPOLLIN, {u32=46, u64=8589934638}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 47, {EPOLLIN, {u32=47, u64=8589934639}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 48, {EPOLLIN, {u32=48, u64=8589934640}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 49, {EPOLLIN, {u32=49, u64=8589934641}}) = -1 EEXIST (File exists)
epoll_ctl(6, EPOLL_CTL_ADD, 50, {EPOLLIN, {u32=50, u64=8589934642}}) = -1 EEXIST (File exists)
[hundreds more lines]
```

uvicorn workload after:

```
epoll_wait(6, [], 64, 0)                = 0
getpid()                                = 13661
getpid()                                = 13661
epoll_wait(6, [], 64, 100)              = 0
getpid()                                = 13661
epoll_wait(6, [], 64, 0)                = 0
```