### PR TITLE
Rework the way the in-place patcher works.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,10 @@ Other
   glibc Linux, it has a hardcoded limitation of only working with file
   descriptors < 1024). See :issue:`1466` reported by Sam Wong.
 
+- Make the dnspython resolver work if dns python had been imported
+  before the gevent resolver was initialized. Reported in
+  :issue:`1526` by Chris Utz and Josh Zuech.
+
 1.5a3 (2020-01-01)
 ==================
 

--- a/src/gevent/_patcher.py
+++ b/src/gevent/_patcher.py
@@ -42,39 +42,55 @@ _PATCH_PREFIX = '__g_patched_module_'
 class _SysModulesPatcher(object):
 
     def __init__(self, importing, extra_all=lambda mod_name: ()):
-        self._saved = {}
+        # Permanent state.
         self.extra_all = extra_all
         self.importing = importing
-        self.green_modules = {
+        # green modules, replacing regularly imported modules.
+        # This begins as the gevent list of modules, and
+        # then gets extended with green things from the tree we import.
+        self._green_modules = {
             stdlib_name: importlib.import_module(gevent_name)
             for gevent_name, stdlib_name
             in iteritems(MAPPING)
         }
-        self.orig_imported = frozenset(sys.modules)
+
+        ## Transient, reset each time we're called.
+        # The set of things imported before we began.
+        self._t_modules_to_restore = {}
 
     def _save(self):
-        self.orig_imported = frozenset(sys.modules)
+        self._t_modules_to_restore = {}
 
-        for modname in self.green_modules:
-            self._saved[modname] = sys.modules.get(modname, None)
+        # Copy all the things we know we are going to overwrite.
+        for modname in self._green_modules:
+            self._t_modules_to_restore[modname] = sys.modules.get(modname, None)
 
-        self._saved[self.importing] = sys.modules.get(self.importing, None)
-        # Anything we've already patched regains its original name during this
-        # process; anything imported in the original namespace is temporarily withdrawn.
-        for mod_name, mod in iteritems(sys.modules):
-            if mod_name.startswith(_PATCH_PREFIX):
-                orig_mod_name = mod_name[len(_PATCH_PREFIX):]
-                self._saved[mod_name] = sys.modules.get(orig_mod_name, None)
-                self.green_modules[orig_mod_name] = mod
+        # Copy anything else in the import tree.
+        for modname, mod in list(iteritems(sys.modules)):
+            if modname.startswith(self.importing):
+                self._t_modules_to_restore[modname] = mod
+                # And remove it. If it had been imported green, it will
+                # be put right back. Otherwise, it was imported "manually"
+                # outside this process and isn't green.
+                del sys.modules[modname]
 
-    def _replace(self):
         # Cover the target modules so that when you import the module it
         # sees only the patched versions
-        for name, mod in iteritems(self.green_modules):
+        for name, mod in iteritems(self._green_modules):
             sys.modules[name] = mod
 
     def _restore(self):
-        for modname, mod in iteritems(self._saved):
+        # Anything from the same package tree we imported this time
+        # needs to be saved so we can restore it later, and so it doesn't
+        # leak into the namespace.
+
+        for modname, mod in list(iteritems(sys.modules)):
+            if modname.startswith(self.importing):
+                self._green_modules[modname] = mod
+                del sys.modules[modname]
+
+        # Now, what we saved at the beginning needs to be restored.
+        for modname, mod in iteritems(self._t_modules_to_restore):
             if mod is not None:
                 sys.modules[modname] = mod
             else:
@@ -82,38 +98,35 @@ class _SysModulesPatcher(object):
                     del sys.modules[modname]
                 except KeyError:
                     pass
-        # Anything from the same package tree we imported this time
-        # needs to be saved so we can restore it later, and so it doesn't
-        # leak into the namespace.
-        pkg_prefix = self.importing.split('.', 1)[0]
-        for modname, mod in list(iteritems(sys.modules)):
-            if (modname not in self.orig_imported
-                    and modname != self.importing
-                    and not modname.startswith(_PATCH_PREFIX)
-                    and modname.startswith(pkg_prefix)):
-                sys.modules[_PATCH_PREFIX + modname] = mod
-                del sys.modules[modname]
 
     def __exit__(self, t, v, tb):
         try:
             self._restore()
         finally:
             imp_release_lock()
+            self._t_modules_to_restore = None
+
 
     def __enter__(self):
         imp_acquire_lock()
         self._save()
-        self._replace()
         return self
 
     module = None
 
-    def __call__(self):
+    def __call__(self, after_import_hook):
         if self.module is None:
-            self.module = self.import_one(self.importing)
+            with self:
+                self.module = self.import_one(self.importing, after_import_hook)
+                # Circular reference. Someone must keep a reference to this module alive
+                # for it to be visible. We record it in sys.modules to be that someone, and
+                # to aid debugging. In the past, we worked with multiple completely separate
+                # invocations of `import_patched`, but we no longer do.
+                self.module.__gevent_patcher__ = self
+                sys.modules[_PATCH_PREFIX + self.importing] = self.module
         return self
 
-    def import_one(self, module_name):
+    def import_one(self, module_name, after_import_hook):
         patched_name = _PATCH_PREFIX + module_name
         if patched_name in sys.modules:
             return sys.modules[patched_name]
@@ -123,28 +136,31 @@ class _SysModulesPatcher(object):
 
         module = g_import(module_name, {}, {}, module_name.split('.')[:-1])
         self.module = module
-        sys.modules[patched_name] = module
         # On Python 3, we could probably do something much nicer with the
         # import machinery? Set the __loader__ or __finder__ or something like that?
         self._import_all([module])
+        after_import_hook(module)
         return module
 
     def _import_all(self, queue):
         # Called while monitoring for patch changes.
         while queue:
             module = queue.pop(0)
-            for attr_name in tuple(getattr(module, '__all__', ())) + self.extra_all(module.__name__):
+            name = module.__name__
+            mod_all = tuple(getattr(module, '__all__', ())) + self.extra_all(name)
+            for attr_name in mod_all:
                 try:
                     getattr(module, attr_name)
                 except AttributeError:
                     module_name = module.__name__ + '.' + attr_name
-                    sys.modules.pop(module_name, None)
                     new_module = g_import(module_name, {}, {}, attr_name)
                     setattr(module, attr_name, new_module)
                     queue.append(new_module)
 
 
-def import_patched(module_name, extra_all=lambda mod_name: ()):
+def import_patched(module_name,
+                   extra_all=lambda mod_name: (),
+                   after_import_hook=lambda module: None):
     """
     Import *module_name* with gevent monkey-patches active,
     and return an object holding the greened module as *module*.
@@ -158,13 +174,17 @@ def import_patched(module_name, extra_all=lambda mod_name: ()):
        recursively. The order of ``__all__`` is respected. Anything passed in
        *extra_all* (which must be in the same namespace tree) is also imported.
 
+    .. versionchanged:: 1.5a4
+       You must now do all patching for a given module tree
+       with one call to this method, or at least by using the returned
+       object.
     """
 
     with cached_platform_architecture():
         # Save the current module state, and restore on exit,
         # capturing desirable changes in the modules package.
-        with _SysModulesPatcher(module_name, extra_all) as patcher:
-            patcher()
+        patcher = _SysModulesPatcher(module_name, extra_all)
+        patcher(after_import_hook)
     return patcher
 
 

--- a/src/gevent/_patcher.py
+++ b/src/gevent/_patcher.py
@@ -18,7 +18,7 @@ from gevent._compat import imp_acquire_lock
 from gevent._compat import imp_release_lock
 
 
-from gevent.builtins import __import__ as _import
+from gevent.builtins import __import__ as g_import
 
 
 MAPPING = {
@@ -41,8 +41,9 @@ _PATCH_PREFIX = '__g_patched_module_'
 
 class _SysModulesPatcher(object):
 
-    def __init__(self, importing):
+    def __init__(self, importing, extra_all=lambda mod_name: ()):
         self._saved = {}
+        self.extra_all = extra_all
         self.importing = importing
         self.green_modules = {
             stdlib_name: importlib.import_module(gevent_name)
@@ -52,12 +53,14 @@ class _SysModulesPatcher(object):
         self.orig_imported = frozenset(sys.modules)
 
     def _save(self):
+        self.orig_imported = frozenset(sys.modules)
+
         for modname in self.green_modules:
             self._saved[modname] = sys.modules.get(modname, None)
 
         self._saved[self.importing] = sys.modules.get(self.importing, None)
         # Anything we've already patched regains its original name during this
-        # process
+        # process; anything imported in the original namespace is temporarily withdrawn.
         for mod_name, mod in iteritems(sys.modules):
             if mod_name.startswith(_PATCH_PREFIX):
                 orig_mod_name = mod_name[len(_PATCH_PREFIX):]
@@ -101,28 +104,112 @@ class _SysModulesPatcher(object):
         imp_acquire_lock()
         self._save()
         self._replace()
+        return self
+
+    module = None
+
+    def __call__(self):
+        if self.module is None:
+            self.module = self.import_one(self.importing)
+        return self
+
+    def import_one(self, module_name):
+        patched_name = _PATCH_PREFIX + module_name
+        if patched_name in sys.modules:
+            return sys.modules[patched_name]
+
+        assert module_name.startswith(self.importing)
+        sys.modules.pop(module_name, None)
+
+        module = g_import(module_name, {}, {}, module_name.split('.')[:-1])
+        self.module = module
+        sys.modules[patched_name] = module
+        # On Python 3, we could probably do something much nicer with the
+        # import machinery? Set the __loader__ or __finder__ or something like that?
+        self._import_all([module])
+        return module
+
+    def _import_all(self, queue):
+        # Called while monitoring for patch changes.
+        while queue:
+            module = queue.pop(0)
+            for attr_name in tuple(getattr(module, '__all__', ())) + self.extra_all(module.__name__):
+                try:
+                    getattr(module, attr_name)
+                except AttributeError:
+                    module_name = module.__name__ + '.' + attr_name
+                    sys.modules.pop(module_name, None)
+                    new_module = g_import(module_name, {}, {}, attr_name)
+                    setattr(module, attr_name, new_module)
+                    queue.append(new_module)
 
 
-def import_patched(module_name):
+def import_patched(module_name, extra_all=lambda mod_name: ()):
     """
     Import *module_name* with gevent monkey-patches active,
-    and return the greened module.
+    and return an object holding the greened module as *module*.
 
     Any sub-modules that were imported by the package are also
     saved.
 
+    .. versionchanged:: 1.5a4
+       If the module defines ``__all__``, then each of those
+       attributes/modules is also imported as part of the same transaction,
+       recursively. The order of ``__all__`` is respected. Anything passed in
+       *extra_all* (which must be in the same namespace tree) is also imported.
+
     """
-    patched_name = _PATCH_PREFIX + module_name
-    if patched_name in sys.modules:
-        return sys.modules[patched_name]
+
+    with cached_platform_architecture():
+        # Save the current module state, and restore on exit,
+        # capturing desirable changes in the modules package.
+        with _SysModulesPatcher(module_name, extra_all) as patcher:
+            patcher()
+    return patcher
 
 
-    # Save the current module state, and restore on exit,
-    # capturing desirable changes in the modules package.
-    with _SysModulesPatcher(module_name):
-        sys.modules.pop(module_name, None)
+class cached_platform_architecture(object):
+    """
+    Context manager that caches ``platform.architecture``.
 
-        module = _import(module_name, {}, {}, module_name.split('.')[:-1])
-        sys.modules[patched_name] = module
+    Some things that load shared libraries (like Cryptodome, via
+    dnspython) invoke ``platform.architecture()`` for each one. That
+    in turn wants to fork and run commands , which in turn wants to
+    call ``threading._after_fork`` if the GIL has been initialized.
+    All of that means that certain imports done early may wind up
+    wanting to have the hub initialized potentially much earlier than
+    before.
 
-    return module
+    Part of the fix is to observe when that happens and delay
+    initializing parts of gevent until as late as possible (e.g., we
+    delay importing and creating the resolver until the hub needs it,
+    unless explicitly configured).
+
+    The rest of the fix is to avoid the ``_after_fork`` issues by
+    first caching the results of platform.architecture before doing
+    patched imports.
+
+    (See events.py for similar issues with platform, and
+    test__threading_2.py for notes about threading._after_fork if the
+    GIL has been initialized)
+    """
+
+    _arch_result = None
+    _orig_arch = None
+    _platform = None
+
+    def __enter__(self):
+        import platform
+        self._platform = platform
+        self._arch_result = platform.architecture()
+        self._orig_arch = platform.architecture
+        def arch(*args, **kwargs):
+            if not args and not kwargs:
+                return self._arch_result
+            return self._orig_arch(*args, **kwargs)
+        platform.architecture = arch
+        return self
+
+    def __exit__(self, *_args):
+        self._platform.architecture = self._orig_arch
+        self._platform = None

--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -27,10 +27,21 @@ if sys.platform.startswith('win32'):
 else:
     _original_select = _real_original_select
 
-# These will be replaced by copy_globals
+# These will be replaced by copy_globals if they are defined by the
+# platform. They're not defined on Windows, but we still provide
+# poll() there. We only pay attention to POLLIN and POLLOUT.
 POLLIN = 1
+POLLPRI = 2
 POLLOUT = 4
+POLLERR = 8
+POLLHUP = 16
 POLLNVAL = 32
+
+POLLRDNORM = 64
+POLLRDBAND = 128
+POLLWRNORM = 4
+POLLWRBAND = 256
+
 __implements__ = [
     'select',
 ]

--- a/src/gevent/tests/monkey_package/__init__.py
+++ b/src/gevent/tests/monkey_package/__init__.py
@@ -2,6 +2,10 @@
 """
 Make a package.
 
+This file has no other functionality. Individual modules in this package
+are used for testing, often being run with 'python -m ...' in individual
+test cases (functions).
+
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/src/gevent/tests/monkey_package/issue1526_no_monkey.py
+++ b/src/gevent/tests/monkey_package/issue1526_no_monkey.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Test for issue #1526:
+- dnspython is imported first;
+- no monkey-patching is done.
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import dns
+assert dns
+import gevent.socket as socket
+socket.getfqdn() # create the resolver
+
+from gevent.resolver.dnspython import dns as gdns
+import dns.rdtypes
+
+assert dns is not gdns, (dns, gdns)
+assert dns.rdtypes is not gdns.rdtypes
+import sys
+print(sorted(sys.modules))

--- a/src/gevent/tests/monkey_package/issue1526_with_monkey.py
+++ b/src/gevent/tests/monkey_package/issue1526_with_monkey.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Test for issue #1526:
+- dnspython is imported first;
+- monkey-patching happens early
+"""
+from __future__ import print_function, absolute_import
+
+from gevent import monkey
+monkey.patch_all()
+
+import dns
+assert dns
+
+import socket
+import sys
+
+socket.getfqdn()
+
+import gevent.resolver.dnspython
+from gevent.resolver.dnspython import dns as gdns
+from dns import rdtypes # NOT import dns.rdtypes
+assert hasattr(dns, 'rdtypes')
+assert gevent.resolver.dnspython.dns is gdns
+assert gdns is not dns, (gdns, dns, "id dns", id(dns))
+assert gdns.rdtypes is not rdtypes, (gdns.rdtypes, rdtypes)
+print(sorted(sys.modules))

--- a/src/gevent/tests/monkey_package/issue1526_with_monkey.py
+++ b/src/gevent/tests/monkey_package/issue1526_with_monkey.py
@@ -20,8 +20,9 @@ socket.getfqdn()
 import gevent.resolver.dnspython
 from gevent.resolver.dnspython import dns as gdns
 from dns import rdtypes # NOT import dns.rdtypes
-assert hasattr(dns, 'rdtypes')
+
 assert gevent.resolver.dnspython.dns is gdns
 assert gdns is not dns, (gdns, dns, "id dns", id(dns))
 assert gdns.rdtypes is not rdtypes, (gdns.rdtypes, rdtypes)
+assert hasattr(dns, 'rdtypes')
 print(sorted(sys.modules))

--- a/src/gevent/tests/test__resolver_dnspython.py
+++ b/src/gevent/tests/test__resolver_dnspython.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Tests explicitly using the DNS python resolver.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import unittest
+import subprocess
+import os
+
+from gevent import testing as greentest
+
+class TestDnsPython(unittest.TestCase):
+
+    def _run_one(self, mod_name):
+        cmd = [
+            sys.executable,
+            '-m',
+            'gevent.tests.monkey_package.' + mod_name
+        ]
+
+        env = dict(os.environ)
+        env['GEVENT_RESOLVER'] = 'dnspython'
+
+        output = subprocess.check_output(cmd, env=env)
+        self.assertIn(b'_g_patched_module_dns', output)
+        self.assertNotIn(b'_g_patched_module_dns.rdtypes', output)
+        return output
+
+    def test_import_dns_no_monkey_patch(self):
+        self._run_one('issue1526_no_monkey')
+
+    def test_import_dns_with_monkey_patch(self):
+        self._run_one('issue1526_with_monkey')
+
+if __name__ == '__main__':
+    greentest.main()


### PR DESCRIPTION
It now handles multiple imports better and doesn't pollute the namespace of an original module object if it happened to be pre-imported.

Fixes #1526