### PR TITLE
Fix AttributeError when wrapping a FileObject around already-opened text streams

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 ==================
 
 - Make `gevent.lock.RLock.acquire` accept the *timeout* parameter.
+- Fix an ``AttributeError`` when wrapping gevent's ``FileObject``
+  around an opened text stream. Reported in :issue:`1542` by
+  dmrlawson.
 
 
 1.5a4 (2020-03-23)

--- a/src/gevent/_fileobjectcommon.py
+++ b/src/gevent/_fileobjectcommon.py
@@ -222,8 +222,8 @@ class OpenDescriptor(object): # pylint:disable=too-many-instance-attributes
 
     def wrapped(self, raw):
         """
-        Wraps the raw IO object (`RawIOBase`) in buffers, text decoding,
-        and newline handling.
+        Wraps the raw IO object (`RawIOBase` or `io.TextIOBase`) in
+        buffers, text decoding, and newline handling.
         """
         # pylint:disable=too-many-branches
         result = raw
@@ -245,40 +245,59 @@ class OpenDescriptor(object): # pylint:disable=too-many-instance-attributes
         if buffering < 0: # pragma: no cover
             raise ValueError("invalid buffering size")
 
-        if buffering != 0:
-            if self.updating:
-                Buffer = io.BufferedRandom
-            elif self.creating or self.writing or self.appending:
-                Buffer = io.BufferedWriter
-            elif self.reading:
-                Buffer = io.BufferedReader
-            else: # prgama: no cover
-                raise ValueError("unknown mode: %r" % self.mode)
+        if not isinstance(raw, io.BufferedIOBase) and \
+           (not hasattr(raw, 'buffer') or raw.buffer is None):
+            # Need to wrap our own buffering around it. If it
+            # is already buffered, don't do so.
+            if buffering != 0:
+                if self.updating:
+                    Buffer = io.BufferedRandom
+                elif self.creating or self.writing or self.appending:
+                    Buffer = io.BufferedWriter
+                elif self.reading:
+                    Buffer = io.BufferedReader
+                else: # prgama: no cover
+                    raise ValueError("unknown mode: %r" % self.mode)
 
-            try:
-                result = Buffer(raw, buffering)
-            except AttributeError:
-                # Python 2 file() objects don't have the readable/writable
-                # attributes. But they handle their own buffering.
-                result = raw
+                try:
+                    result = Buffer(raw, buffering)
+                except AttributeError:
+                    # Python 2 file() objects don't have the readable/writable
+                    # attributes. But they handle their own buffering.
+                    result = raw
 
         if self.binary:
+            if isinstance(raw, io.TextIOBase):
+                # Can't do it. The TextIO object will have its own buffer, and
+                # trying to read from the raw stream or the buffer without going through
+                # the TextIO object is likely to lead to problems with the codec.
+                raise ValueError("Unable to perform binary IO on top of text IO stream")
             return result
+
+        # Either native or text at this point.
         if PY2 and self.native:
             # Neither text mode nor binary mode specified.
             if self.universal:
                 # universal was requested, e.g., 'rU'
                 result = UniversalNewlineBytesWrapper(result, line_buffering)
         else:
-            result = io.TextIOWrapper(result, self.encoding, self.errors, self.newline,
-                                      line_buffering)
+            # Python 2 and text mode, or Python 3 and either text or native (both are the same)
+            if not isinstance(raw, io.TextIOBase):
+                # Avoid double-wrapping a TextIOBase in another TextIOWrapper.
+                # That tends not to work. See https://github.com/gevent/gevent/issues/1542
+                result = io.TextIOWrapper(result, self.encoding, self.errors, self.newline,
+                                          line_buffering)
 
-        try:
-            result.mode = self.mode
-        except (AttributeError, TypeError):
-            # AttributeError: No such attribute
-            # TypeError: Readonly attribute (py2)
-            pass
+        if result is not raw:
+            # Set the mode, if possible, but only if we created a new
+            # object.
+            try:
+                result.mode = self.mode
+            except (AttributeError, TypeError):
+                # AttributeError: No such attribute
+                # TypeError: Readonly attribute (py2)
+                pass
+
         return result
 
 

--- a/src/gevent/lock.py
+++ b/src/gevent/lock.py
@@ -188,8 +188,9 @@ class DummySemaphore(object):
     def unlink(self, callback):
         pass
 
-    def wait(self, timeout=None):
+    def wait(self, timeout=None): # pylint:disable=unused-argument
         """Waiting for a DummySemaphore returns immediately."""
+        return 1
 
     def acquire(self, blocking=True, timeout=None):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py27,py35,py36,py37,py27-cffi,pypy,pypy3,py27-libuv,lint
 
 [testenv]
+usedevelop = true
 extras =
     test
     events


### PR DESCRIPTION

Fixes #1542