### PR TITLE
AIX: fix compilation of libuv

### DIFF
--- a/src/gevent/libuv/_corecffi_build.py
+++ b/src/gevent/libuv/_corecffi_build.py
@@ -194,11 +194,15 @@ elif sys.platform.startswith('netbsd'):
         _libuv_source('unix/posix-hrtime.c'),
         _libuv_source('unix/bsd-proctitle.c'),
     ]
-
 elif sys.platform.startswith('sunos'):
     LIBUV_SOURCES += [
         _libuv_source('unix/no-proctitle.c'),
         _libuv_source('unix/sunos.c'),
+    ]
+elif sys.platform.startswith('aix'):
+    LIBUV_SOURCES += [
+        _libuv_source('unix/aix.c'),
+        _libuv_source('unix/aix-common.c'),
     ]
 
 
@@ -235,6 +239,9 @@ elif sys.platform.startswith('sunos'):
     _add_library('nsl')
     _add_library('sendfile')
     _add_library('socket')
+elif sys.platform.startswith('aix'):
+    _define_macro('_LINUX_SOURCE_COMPAT', 1)
+    _add_library('perfstat')
 elif WIN:
     _define_macro('_GNU_SOURCE', 1)
     _define_macro('WIN32', 1)


### PR DESCRIPTION
Added the files and libraries needed for compilation.

The macro _LINUX_SOURCE_COMPAT is needed to prevent duplicate error definitions that result in a long error that says:

    deps/libuv/src/uv-common.c:200:36: error: duplicate case value

AIX defines two errors, ENOTEMPTY and EEXIST, as the same value, unless the macro is set.