### PR TITLE
Solaris 10: define SUNOS_NO_IFADDRS to make libuv compile correctly

### DIFF
--- a/src/gevent/libuv/_corecffi_build.py
+++ b/src/gevent/libuv/_corecffi_build.py
@@ -7,9 +7,10 @@
 # this file to know what functions are created and available on the generated
 # module.
 from __future__ import absolute_import, print_function
-import sys
 import os
 import os.path # pylint:disable=no-name-in-module
+import platform
+import sys
 
 from cffi import FFI
 
@@ -235,6 +236,9 @@ elif sys.platform.startswith('sunos'):
     _add_library('nsl')
     _add_library('sendfile')
     _add_library('socket')
+    if platform.release() == '5.10':
+        # https://github.com/libuv/libuv/issues/1458
+        _define_macro('SUNOS_NO_IFADDRS', '')
 elif WIN:
     _define_macro('_GNU_SOURCE', 1)
     _define_macro('WIN32', 1)


### PR DESCRIPTION
gevent fails to compile on Solaris 10:

    deps/libuv/src/unix/sunos.c:32:22: fatal error: ifaddrs.h: No such file or directory
     # include <ifaddrs.h>

Solaris 10 doesn't have the "ifaddrs" interface. libuv have a flag to support this platform, we just need to turn it on.
See libuv issue here: https://github.com/libuv/libuv/issues/1458
The detection code is similar to what's in `psutil`, see: https://github.com/giampaolo/psutil/blob/master/setup.py#L298
