### PR TITLE
Make monkey-patching properly remove select.epoll and select.kqueue.

### DIFF
--- a/docs/changes/1570.bugfix
+++ b/docs/changes/1570.bugfix
@@ -1,0 +1,2 @@
+Make monkey-patching properly remove ``select.epoll`` and
+``select.kqueue``. Reported by Kirill Smelkov.

--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -329,7 +329,7 @@ def _gevent_do_monkey_patch(patch_request):
         # modules (e.g. asyncore)  non-blocking, as they use select that we provide
         # when none of these are available.
         patch_request.remove_item(
-            'epoll'
+            'epoll',
             'kqueue',
             'kevent',
             'devpoll',

--- a/src/gevent/tests/test__monkey_select.py
+++ b/src/gevent/tests/test__monkey_select.py
@@ -1,0 +1,32 @@
+# Tests for the monkey-patched select module.
+from gevent import monkey
+monkey.patch_all()
+
+import select
+
+import gevent.testing as greentest
+
+
+class TestSelect(greentest.TestCase):
+
+    def _make_test(name, ns): # pylint:disable=no-self-argument
+        def test(self):
+            self.assertIs(getattr(select, name, self), self)
+            self.assertFalse(hasattr(select, name))
+        test.__name__ = 'test_' + name + '_removed'
+        ns[test.__name__] = test
+
+    for name in (
+            'epoll',
+            'kqueue',
+            'kevent',
+            'devpoll',
+    ):
+        _make_test(name, locals())
+
+    del name
+    del _make_test
+
+
+if __name__ == '__main__':
+    greentest.main()


### PR DESCRIPTION
A missing comma led to string concatenation and a silent bug. I'm surprised this wasn't really tested anywhere.

Fixes #1570