### PR TITLE
Make it possible to monkey-patch contextvars of the non-standard back…

### DIFF
--- a/docs/changes/1572.bugfix
+++ b/docs/changes/1572.bugfix
@@ -1,0 +1,4 @@
+Make it possible to monkey-patch :mod:`contextvars` before Python 3.7
+if a non-standard backport that uses the same name as the standard
+library does is installed. Previously this would raise an error.
+Reported by Simon Davy.

--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,10 @@ def run_setup(ext_modules):
 
                 # leak checks. previously we had a hand-rolled version.
                 'objgraph',
+
+                # The backport for contextvars to test patching. It sadly uses the same
+                # import name as the stdlib module.
+                'contextvars == 2.4 ; python_version > "3.0" and python_version < "3.7"',
             ],
         },
         # It's always safe to pass the CFFI keyword, even if

--- a/src/gevent/contextvars.py
+++ b/src/gevent/contextvars.py
@@ -45,7 +45,8 @@ from gevent._compat import PY37
 from gevent._util import _NONE
 from gevent.local import local
 
-__implements__ = __all__ if PY37 else None
+__stdlib_expected__ = __all__
+__implements__ = __stdlib_expected__ if PY37 else None
 
 # In the reference implementation, the interpreter level OS thread state
 # is modified to contain a pointer to the current context. Obviously we can't


### PR DESCRIPTION
…port is installed on Python < 3.7.

Fixes #1572.