### PR TITLE
Avoid closing the same libuv watcher object twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ jobs:
         # First, the build dependencies (see setup.cfg)
         # so that we don't have to use build isolation and can better use the cache;
         # Note that we can't use -U for cffi and greenlet on PyPy.
-        - &build-gevent-deps pip install -U setuptools wheel twine && pip install -U 'cffi;platform_python_implementation=="CPython"' cython 'greenlet;platform_python_implementation=="CPython"'
+        - &build-gevent-deps pip install -U setuptools wheel twine && pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"' 'cffi;platform_python_implementation=="CPython"' cython 'greenlet;platform_python_implementation=="CPython"'
         # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
         # output (pip install uses a random temporary directory, making this difficult)
         - python setup.py bdist_wheel

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,9 @@ pylint>=1.8.0 ; python_version < "3.4"
 pylint >= 2.5.0 ; python_version >= "3.4"  and platform_python_implementation == "CPython"
 astroid >= 2.4.0 ; python_version >= "3.4" and platform_python_implementation == "CPython"
 
+# backport of faulthandler
+faulthandler ; python_version == "2.7"  and platform_python_implementation == "CPython"
+
 # For generating CHANGES.rst
 towncrier
 # For making releases

--- a/docs/changes/1587.bugfix
+++ b/docs/changes/1587.bugfix
@@ -1,0 +1,3 @@
+Avoid closing the same Python libuv watcher IO object twice. Under
+some circumstances (only seen on Windows), that could lead to program
+crashes.

--- a/src/gevent/_ffi/loop.py
+++ b/src/gevent/_ffi/loop.py
@@ -92,7 +92,7 @@ class AbstractCallbacks(object):
           :func:`_python_handle_error` to deal with it. The Python watcher
           object will have the exception tuple saved in ``_exc_info``.
         - 1
-          Everything went according to plan. You should check to see if the libev
+          Everything went according to plan. You should check to see if the native
           watcher is still active, and call :func:`python_stop` if it is not. This will
           clean up the memory. Finding the watcher still active at the event loop level,
           but not having stopped itself at the gevent level is a buggy scenario and
@@ -182,8 +182,9 @@ class AbstractCallbacks(object):
                     and the_watcher in the_watcher.loop._keepaliveset
                     and the_watcher._watcher is orig_ffi_watcher):
                 # It didn't stop itself, *and* it didn't stop itself, reset
-                # its watcher, and start itself again. libuv's io watchers MAY
-                # do that.
+                # its watcher, and start itself again. libuv's io watchers
+                # multiplex and may do this.
+
                 # The normal, expected scenario when we find the watcher still
                 # in the keepaliveset is that it is still active at the event loop
                 # level, so we don't expect that python_stop gets called.

--- a/src/gevent/testing/__init__.py
+++ b/src/gevent/testing/__init__.py
@@ -28,9 +28,21 @@ import unittest
 # It's important to do this ASAP, because if we're monkey patched,
 # then importing things like the standard library test.support can
 # need to construct the hub (to check for IPv6 support using a socket).
+# We can't do it in the testrunner, as the testrunner spaws new, unrelated
+# processes.
 from .hub import QuietHub
 import gevent.hub
 gevent.hub.set_default_hub_class(QuietHub)
+
+try:
+    import faulthandler
+except ImportError:
+    # The backport isn't installed.
+    pass
+else:
+    # Enable faulthandler for stack traces. We have to do this here
+    # for the same reasons as above.
+    faulthandler.enable()
 
 from .sysinfo import VERBOSE
 from .sysinfo import WIN

--- a/src/gevent/tests/test__execmodules.py
+++ b/src/gevent/tests/test__execmodules.py
@@ -40,4 +40,7 @@ class Test(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    # This should not be combined with other tests in the same process
+    # because it messes with global shared state.
+    # pragma: testrunner-no-combine
     main()


### PR DESCRIPTION
Fixes the crash in #1587 in the small reproducer found there (verified in a local VM, which is a major pain…). I have no idea why I couldn't get it to crash in FFI code on any other platform, but I didn't go into details of how the server is actually working there (it uses socketserver) or try to write a smaller more independent reproducer. Allowing threads to be monkey-patched also solved the crash, so I have suspicions about other underlying issues. 

This is a short-term fix and I'll look into memory management at a higher level as a follow-up; I'm not happy with how many handles the libuv code is creating and destroying.