### PR TITLE
Let the greenlets be freed when destroying a hub

### DIFF
--- a/docs/changes/1601.bugfix
+++ b/docs/changes/1601.bugfix
@@ -1,0 +1,11 @@
+Destroying a hub after joining it didn't necessarily clean up all
+resources associated with the hub, especially if the hub had been
+created in a secondary thread that was exiting. The hub and its parent
+greenlet could be kept alive.
+
+Now, destroying a hub drops the reference to the hub and ensures it
+cannot be switched to again. (Though using a new blocking API call may
+still create a new hub.)
+
+Joining a hub also cleans up some (small) memory resources that might
+have stuck around for longer before as well.

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -397,18 +397,21 @@ class loop(AbstractLoop):
             del self._fork_watchers
             del self._child_watchers
 
-
+    _HandleState = namedtuple("HandleState",
+                              ['handle',
+                               'type',
+                               'watcher',
+                               'ref',
+                               'active',
+                               'closing'])
     def debug(self):
         """
         Return all the handles that are open and their ref status.
         """
-        handle_state = namedtuple("HandleState",
-                                  ['handle',
-                                   'type',
-                                   'watcher',
-                                   'ref',
-                                   'active',
-                                   'closing'])
+        if not self.ptr:
+            return ["Loop has been destroyed"]
+
+        handle_state = self._HandleState
         handles = []
 
         # XXX: Convert this to a modern callback.

--- a/src/gevent/tests/test__hub_join.py
+++ b/src/gevent/tests/test__hub_join.py
@@ -1,13 +1,15 @@
 import unittest
 
 import gevent
+from gevent.testing import ignores_leakcheck
 
-class Test(unittest.TestCase):
+class TestJoin(unittest.TestCase):
 
-    def test(self):
+    def test_join_many_times(self):
         # hub.join() guarantees that loop has exited cleanly
         res = gevent.get_hub().join()
         self.assertTrue(res)
+        self.assertFalse(gevent.get_hub().dead)
 
         res = gevent.get_hub().join()
         self.assertTrue(res)
@@ -17,6 +19,47 @@ class Test(unittest.TestCase):
 
         res = gevent.get_hub().join()
         self.assertTrue(res)
+
+    @ignores_leakcheck
+    def test_join_in_new_thread_doesnt_leak_hub_or_greenlet(self):
+        # https://github.com/gevent/gevent/issues/1601
+        import threading
+        import gc
+        from gevent._greenlet_primitives import get_reachable_greenlets
+        count_before = len(get_reachable_greenlets())
+
+        def thread_main():
+            g = gevent.Greenlet(run=lambda: 0)
+            g.start()
+            g.join()
+            hub = gevent.get_hub()
+            hub.join()
+            hub.destroy(destroy_loop=True)
+            del hub
+
+        def tester():
+            t = threading.Thread(target=thread_main)
+            t.start()
+            t.join()
+
+            while gc.collect():
+                pass
+
+
+        for _ in range(10):
+            tester()
+
+        del tester
+        del thread_main
+
+        count_after = len(get_reachable_greenlets())
+        if count_after > count_before:
+            # We could be off by exactly 1. Not entirely clear where.
+            # But it only happens the first time.
+            count_after -= 1
+        self.assertEqual(count_after, count_before)
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If it was never switched to after being destroyed, a reference cycle would keep the hub object, and the main greenlet object, alive, and possibly many other things. Since greenlets don't participate in GC, those would never go away.