### PR TITLE
Properly clean up native resources in gevent.signal_handler() 

### DIFF
--- a/docs/changes/1606.bugfix
+++ b/docs/changes/1606.bugfix
@@ -1,0 +1,3 @@
+Fix some potential crashes under libuv when using
+``gevent.signal_handler``. The crashes were seen running the test
+suite and were non-deterministic.


### PR DESCRIPTION
When `cancel` is called.

Fixes #1606

Also fix reporting errors from threadpool tasks, and make waiting for threadpool tasks a bit cheaper. The first was aproblem I ran into debugging this (the traceback never finished printing); the second was part of reducing allocations as I tried to find the allocations that were conflicting.