### PR TITLE
Fix calling gevent.wait() on a set Event twice

### DIFF
--- a/docs/changes/1540.bugfix
+++ b/docs/changes/1540.bugfix
@@ -1,0 +1,5 @@
+Using ``gevent.wait`` on an ``Event`` more than once, when that Event
+is already set, could previously raise an AssertionError.
+
+As part of this, exceptions raised in the main greenlet will now
+include a more complete traceback from the failing greenlet.

--- a/src/gevent/event.py
+++ b/src/gevent/event.py
@@ -79,8 +79,11 @@ class Event(AbstractLinkable): # pylint:disable=undefined-variable
         self._flag = False
 
     def __str__(self):
-        return '<%s %s _links[%s]>' % (self.__class__.__name__, (self._flag and 'set') or 'clear',
-                                       self.linkcount())
+        return '<%s %s _links[%s]>' % (
+            self.__class__.__name__,
+            'set' if self._flag else 'clear',
+            self.linkcount()
+        )
 
     def is_set(self):
         """Return true if and only if the internal flag is true."""

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -469,7 +469,12 @@ cdef public class loop [object PyGeventLoopObject, type PyGeventLoop_Type]:
                 cb = self._callbacks.popleft()
 
                 libev.ev_unref(self._ptr)
-                gevent_call(self, cb) # XXX: Why is this a C callback, not cython?
+                # On entry, this will set cb.callback to None,
+                # changing cb.pending from True to False; on exit,
+                # this will set cb.args to None, changing bool(cb)
+                # from True to False.
+                # XXX: Why is this a C callback, not cython?
+                gevent_call(self, cb)
                 count -= 1
 
                 if count == 0 and self._callbacks.head is not None:

--- a/src/gevent/testing/testrunner.py
+++ b/src/gevent/testing/testrunner.py
@@ -652,7 +652,7 @@ def _setup_environ(debug=False):
             # dns.zone uses some raw regular expressions
             # without the r'' syntax, leading to DeprecationWarning: invalid
             # escape sequence. This is fixed in 2.0 (Python 3 only).
-            'ignore:::dns.zone',
+            'ignore:::dns.zone:',
         ])
 
     if 'PYTHONFAULTHANDLER' not in os.environ:

--- a/src/gevent/testing/testrunner.py
+++ b/src/gevent/testing/testrunner.py
@@ -627,7 +627,6 @@ def _setup_environ(debug=False):
             and (not sys.warnoptions
                  # Python 3.7 goes from [] to ['default'] for nothing
                  or sys.warnoptions == ['default'])):
-
         # action:message:category:module:line
         os.environ['PYTHONWARNINGS'] = ','.join([
             # Enable default warnings such as ResourceWarning.
@@ -650,6 +649,10 @@ def _setup_environ(debug=False):
             # dns.hash itself is being deprecated, importing it raises the warning;
             # we don't import it, but dnspython still does
             'ignore:::dns.hash:',
+            # dns.zone uses some raw regular expressions
+            # without the r'' syntax, leading to DeprecationWarning: invalid
+            # escape sequence. This is fixed in 2.0 (Python 3 only).
+            'ignore:::dns.zone',
         ])
 
     if 'PYTHONFAULTHANDLER' not in os.environ:

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -272,6 +272,17 @@ class TestEventBasics(greentest.TestCase):
         check.stop()
         check.close()
 
+    def test_gevent_wait_twice_when_already_set(self):
+        event = Event()
+        event.set()
+        # First one works fine.
+        result = gevent.wait([event])
+        self.assertEqual(result, [event])
+        # Second one used to fail with an AssertionError,
+        # now it passes
+        result = gevent.wait([event])
+        self.assertEqual(result, [event])
+
 
 del AbstractGenericGetTestCase
 del AbstractGenericWaitTestCase


### PR DESCRIPTION
The detection of when to de-queue an existing notifier was wrong, leading us to de-queue it while it was running and then promptly re-queue one.