### PR TITLE
Fix issue 1437 by detecting cross-thread lock usage and using an async watcher

### DIFF
--- a/benchmarks/micro_semaphore.sh
+++ b/benchmarks/micro_semaphore.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e -x
 PYTHON=${PYTHON:=python}
-$PYTHON -mperf timeit  -s'from gevent.lock import Semaphore; s = Semaphore()' 's.release()'
-$PYTHON -mperf timeit  -s'from gevent.lock import Semaphore; from gevent import spawn_raw; s = Semaphore(0)' 'spawn_raw(s.release); s.acquire()'
-$PYTHON -mperf timeit  -s'from gevent.lock import Semaphore; from gevent import spawn_raw; s = Semaphore(0)' 'spawn_raw(s.release); spawn_raw(s.release); spawn_raw(s.release); spawn_raw(s.release); s.acquire(); s.acquire(); s.acquire(); s.acquire()'
+$PYTHON -mpyperf timeit  -s'from gevent.lock import Semaphore; s = Semaphore()' 's.release()'
+$PYTHON -mpyperf timeit  -s'from gevent.lock import Semaphore; from gevent import spawn_raw; s = Semaphore(0)' 'spawn_raw(s.release); s.acquire()'
+$PYTHON -mpyperf timeit  -s'from gevent.lock import Semaphore; from gevent import spawn_raw; s = Semaphore(0)' 'spawn_raw(s.release); spawn_raw(s.release); spawn_raw(s.release); spawn_raw(s.release); s.acquire(); s.acquire(); s.acquire(); s.acquire()'

--- a/docs/changes/issue1437.bugfix
+++ b/docs/changes/issue1437.bugfix
@@ -1,0 +1,3 @@
+The underlying Semaphore always behaves in an atomic fashion (as if
+the GIL was not released) when PURE_PYTHON is set. Previously, it only
+correctly did so on PyPy.

--- a/docs/changes/issue1437.bugfix
+++ b/docs/changes/issue1437.bugfix
@@ -1,3 +1,9 @@
+Make gevent locks that are monkey-patched work across native
+threads as well as across greenlets within a single thread. This
+is expensive, and not a recommended programming pattern, but it can
+happen when using the threadpool. Locks that are only used in a single
+thread do not take a performance hit.
+
 The underlying Semaphore always behaves in an atomic fashion (as if
 the GIL was not released) when PURE_PYTHON is set. Previously, it only
 correctly did so on PyPy.

--- a/docs/changes/issue1437.bugfix
+++ b/docs/changes/issue1437.bugfix
@@ -1,9 +1,19 @@
-Make gevent locks that are monkey-patched work across native
-threads as well as across greenlets within a single thread. This
-is expensive, and not a recommended programming pattern, but it can
-happen when using the threadpool. Locks that are only used in a single
-thread do not take a performance hit.
+Make gevent locks that are monkey-patched usually work across native
+threads as well as across greenlets within a single thread. Locks that
+are only used in a single thread do not take a performance hit. While
+cross-thread locking is relatively expensive, and not a recommended
+programming pattern, it can happen unwittingly, for example when
+using the threadpool and ``logging``.
 
-The underlying Semaphore always behaves in an atomic fashion (as if
-the GIL was not released) when PURE_PYTHON is set. Previously, it only
-correctly did so on PyPy.
+Before, cross-thread lock uses might succeed, or, if the lock was
+contended, raise ``greenlet.error``. Now, in the contended case, if
+the lock has been acquired by the main thread at least once, it should
+correctly block in any thread, cooperating with the event loop of both
+threads. In certain (hopefully rare) cases, it might be possible for
+contended case to raise ``LoopExit`` when previously it would have
+raised ``greenlet.error``; if these cases are a practical concern,
+please open an issue.
+
+Also, the underlying Semaphore always behaves in an atomic fashion (as
+if the GIL was not released) when PURE_PYTHON is set. Previously, it
+only correctly did so on PyPy.

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -27,6 +27,18 @@ class AbstractLinkable(object):
     # protocol common to both repeatable events (Event, Semaphore) and
     # one-time events (AsyncResult).
     #
+    # With a few careful exceptions, instances of this object can only
+    # be used from a single thread. The exception is that certain methods
+    # may be used from multiple threads IFF:
+    #
+    # 1.  They are documented as safe for that purpose; AND
+    # 2a. This object is compiled with Cython and thus is holding the GIL
+    #     for the entire duration of the method; OR
+    # 2b. A subclass ensures that a Python-level native thread lock is held
+    #     for the duration of the method; this is necessary in pure-Python mode.
+    #     The only known implementation of such
+    #     a subclass is for Semaphore.
+    #
     # TODO: As of gevent 1.5, we use the same datastructures and almost
     # the same algorithm as Greenlet. See about unifying them more.
 
@@ -70,7 +82,9 @@ class AbstractLinkable(object):
         # If its false, we only call callbacks as long as ready() returns true.
         self._notify_all = True
         # we don't want to do get_hub() here to allow defining module-level objects
-        # without initializing the hub
+        # without initializing the hub. However, for multiple-thread safety, as soon
+        # as a waiting method is entered, even if it won't have to wait, we
+        # grab the hub.
         self.hub = hub
 
     def linkcount(self):
@@ -148,6 +162,10 @@ class AbstractLinkable(object):
                 break
 
     def _notify_links(self, arrived_while_waiting):
+        # This method must hold the GIL, or be guarded with the lock that guards
+        # this object. Thus, while we are notifying objects, an object from another
+        # thread simply cannot arrive and mutate ``_links`` or ``arrived_while_waiting``
+
         # ``arrived_while_waiting`` is a list of greenlet.switch methods
         # to call. These were objects that called wait() while we were processing,
         # and which would have run *before* those that had actually waited
@@ -170,7 +188,6 @@ class AbstractLinkable(object):
         # became true that it was once true, even though it may not be
         # any more. In that case, we must not keep notifying anyone that's
         # newly added after that, even if we go ready again.
-
         try:
             self._notify_link_list(self._links)
             # Now, those that arrived after we had begun the notification
@@ -187,6 +204,10 @@ class AbstractLinkable(object):
             # same callback while self._notifier is still true.
             assert self._notifier is notifier
             self._notifier = None
+            # TODO: Maybe we should intelligently reset self.hub to
+            # free up thread affinity? In case of a pathological situation where
+            # one object was used from one thread once & first,  but usually is
+            # used by another thread.
 
         # Now we may be ready or not ready. If we're ready, which
         # could have happened during the last link we called, then we
@@ -194,32 +215,123 @@ class AbstractLinkable(object):
         # wakeup.
         self._check_and_notify()
 
-    def _wait_core(self, timeout, catch=Timeout):
-        # The core of the wait implementation, handling
-        # switching and linking. If *catch* is set to (),
-        # a timeout that elapses will be allowed to be raised.
-        # Returns a true value if the wait succeeded without timing out.
-        switch = getcurrent().switch # pylint:disable=undefined-variable
-        self.rawlink(switch)
-        with Timeout._start_new_or_dummy(timeout) as timer:
+    def __unlink_all(self, obj):
+        if obj is None:
+            return
+
+        self.unlink(obj)
+        if self._notifier is not None and self._notifier.args:
             try:
-                if self.hub is None:
-                    self.hub = get_hub()
-                result = self.hub.switch()
-                if result is not self: # pragma: no cover
-                    raise InvalidSwitchError('Invalid switch into Event.wait(): %r' % (result, ))
-                # If we got here, we were automatically unlinked already.
+                self._notifier.args[0].remove(obj)
+            except ValueError:
+                pass
+
+    def __wait_to_be_notified(self, rawlink): # pylint:disable=too-many-branches
+        # We've got to watch where we could potentially release the GIL.
+        # Decisions we make based an the state of this object must be in blocks
+        # that cannot release the GIL.
+        resume_this_greenlet = None
+        watcher = None
+        current_hub = get_hub()
+        send = None
+
+        while 1:
+            my_hub = self.hub
+            if my_hub is current_hub:
+                break
+
+            # We're owned by another hub.
+            if my_hub.dead: # dead is a property, this could have released the GIL.
+                # We have the GIL back. Did anything change?
+                if my_hub is not self.hub:
+                    continue # start over.
+                # The other hub is dead, so we can take ownership.
+                self.hub = current_hub
+                break
+            # Some other hub owns this object. We must ask it to wake us
+            # up. We can't use a Python-level ``Lock`` because
+            # (1) it doesn't support a timeout on all platforms; and
+            # (2) we don't want to block this hub from running. So we need to
+            # do so in a way that cooperates with *two* hubs. That's what an
+            # async watcher is built for.
+            #
+            # Allocating and starting the watcher *could* release the GIL.
+            # with the libev corcext, allocating won't, but starting briefly will.
+            # With other backends, allocating might, and starting might also.
+            # So...XXX: Race condition here, tiny though it may be.
+            watcher = current_hub.loop.async_()
+            send = watcher.send_ignoring_arg
+            if rawlink:
+                # Make direct calls to self.rawlink, the most common case,
+                # so cython can more easily optimize.
+                self.rawlink(send)
+            else:
+                self._notifier.args[0].append(send)
+            watcher.start(getcurrent().switch, self) # pylint:disable=undefined-variable
+            break
+
+        if self.hub is current_hub:
+            resume_this_greenlet = getcurrent().switch # pylint:disable=undefined-variable
+            if rawlink:
+                self.rawlink(resume_this_greenlet)
+            else:
+                self._notifier.args[0].append(resume_this_greenlet)
+
+        try:
+            self._drop_lock_for_switch_out()
+            result = current_hub.switch() # Probably releases
+            # If we got here, we were automatically unlinked already.
+            resume_this_greenlet = None
+            if result is not self: # pragma: no cover
+                raise InvalidSwitchError(
+                    'Invalid switch into %s.wait(): %r' % (
+                        self.__class__.__name__,
+                        result,
+                    )
+                )
+        finally:
+            self._acquire_lock_for_switch_in()
+            self.__unlink_all(resume_this_greenlet)
+            self.__unlink_all(send)
+            if watcher is not None:
+                watcher.stop()
+                watcher.close()
+
+    def _acquire_lock_for_switch_in(self):
+        return
+
+    def _drop_lock_for_switch_out(self):
+        return
+
+    def _wait_core(self, timeout, catch=Timeout):
+        """
+        The core of the wait implementation, handling switching and
+        linking.
+
+        This method is safe to call from multiple threads; it must be holding
+        the GIL for the entire duration, or be protected by a Python-level
+        lock for that to be true.
+
+        ``self.hub`` must be initialized before entering this method.
+        The hub that is set is considered the owner and cannot be changed.
+
+        If *catch* is set to ``()``, a timeout that elapses will be
+        allowed to be raised.
+
+        :return: A true value if the wait succeeded without timing out.
+          That is, a true return value means we were notified and control
+          resumed in this greenlet.
+        """
+        with Timeout._start_new_or_dummy(timeout) as timer: # Might release
+            try:
+                self.__wait_to_be_notified(True) # Use rawlink()
                 return True
             except catch as ex:
-                self.unlink(switch)
                 if ex is not timer:
                     raise
                 # test_set_and_clear and test_timeout in test_threading
                 # rely on the exact return values, not just truthish-ness
                 return False
-            except:
-                self.unlink(switch)
-                raise
 
     def _wait_return_value(self, waited, wait_success):
         # pylint:disable=unused-argument
@@ -228,16 +340,21 @@ class AbstractLinkable(object):
         return None # pragma: no cover all extent subclasses override
 
     def _wait(self, timeout=None):
-        if self.ready():
+        """
+        This method is safe to call from multiple threads, providing
+        the conditions laid out in the class documentation are met.
+        """
+        # Watch where we could potentially release the GIL.
+        if self.hub is None: # no release
+            self.hub = get_hub() # might releases.
+
+        if self.ready(): # *might* release, if overridden in Python.
             result = self._wait_return_value(False, False) # pylint:disable=assignment-from-none
             if self._notifier:
                 # We're already notifying waiters; one of them must have run
-                # and switched to us.
-                switch = getcurrent().switch # pylint:disable=undefined-variable
-                self._notifier.args[0].append(switch)
-                switch_result = self.hub.switch()
-                if switch_result is not self: # pragma: no cover
-                    raise InvalidSwitchError('Invalid switch into Event.wait(): %r' % (result, ))
+                # and switched to this greenlet, which arrived here. Alternately,
+                # we could be in a separate thread (but we're holding the GIL/object lock)
+                self.__wait_to_be_notified(False) # Use self._notifier.args[0] instead of self.rawlink
 
             return result
 

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -554,6 +554,15 @@ class AsyncMixin(object):
     def send(self):
         raise NotImplementedError()
 
+    def send_ignoring_arg(self, _ignored):
+        """
+        Calling compatibility with ``greenlet.switch(arg)``
+        as used by waiters that have ``rawlink``.
+
+        This is an advanced method, not usually needed.
+        """
+        return self.send()
+
     @property
     def pending(self):
         raise NotImplementedError()

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -2,6 +2,7 @@ cimport cython
 
 from gevent._gevent_c_greenlet_primitives cimport SwitchOutGreenletWithLoop
 from gevent._gevent_c_hub_local cimport get_hub_noargs as get_hub
+from gevent._gevent_c_hub_local cimport get_hub_if_exists
 
 cdef InvalidSwitchError
 cdef Timeout
@@ -48,8 +49,9 @@ cdef class AbstractLinkable(object):
    cpdef unlink(self, callback)
 
    cdef _check_and_notify(self)
+   cdef void _capture_hub(self, bint create)
    cdef __wait_to_be_notified(self, bint rawlink)
-   cdef __unlink_all(self, obj)
+   cdef void __unlink_all(self, obj) # suppress exceptions
 
    @cython.nonecheck(False)
    cdef _notify_link_list(self, list links)

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -48,6 +48,8 @@ cdef class AbstractLinkable(object):
    cpdef unlink(self, callback)
 
    cdef _check_and_notify(self)
+   cdef __wait_to_be_notified(self, bint rawlink)
+   cdef __unlink_all(self, obj)
 
    @cython.nonecheck(False)
    cdef _notify_link_list(self, list links)
@@ -55,6 +57,9 @@ cdef class AbstractLinkable(object):
    @cython.nonecheck(False)
    cpdef _notify_links(self, list arrived_while_waiting)
 
+   cpdef _drop_lock_for_switch_out(self)
+   cpdef _acquire_lock_for_switch_in(self)
+
    cdef _wait_core(self, timeout, catch=*)
    cdef _wait_return_value(self, waited, wait_success)
-   cpdef _wait(self, timeout=*)
+   cdef _wait(self, timeout=*)

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -57,4 +57,4 @@ cdef class AbstractLinkable(object):
 
    cdef _wait_core(self, timeout, catch=*)
    cdef _wait_return_value(self, waited, wait_success)
-   cdef _wait(self, timeout=*)
+   cpdef _wait(self, timeout=*)

--- a/src/gevent/_imap.py
+++ b/src/gevent/_imap.py
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 
 
-from gevent import _semaphore
+from gevent import lock
 from gevent import queue
 
 
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 locals()['Greenlet'] = __import__('gevent').Greenlet
-locals()['Semaphore'] = _semaphore.Semaphore
+locals()['Semaphore'] = lock.Semaphore
 locals()['UnboundQueue'] = queue.UnboundQueue
 
 

--- a/src/gevent/_semaphore.py
+++ b/src/gevent/_semaphore.py
@@ -1,4 +1,12 @@
 # cython: auto_pickle=False,embedsignature=True,always_allow_keywords=False
+###
+# This file is ``gevent._semaphore`` so that it can be compiled by Cython
+# individually. However, this is not the place to import from. Everyone,
+# gevent internal code included, must import from ``gevent.lock``.
+# The only exception are .pxd files which need access to the
+# C code; the PURE_PYTHON things that have to happen and which are
+# handled in ``gevent.lock``, do not apply to them.
+###
 from __future__ import print_function, absolute_import, division
 
 __all__ = [
@@ -44,6 +52,10 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
        The low-level ``rawlink`` method (most users won't use this) now automatically
        unlinks waiters before calling them.
     """
+
+    __slots__ = (
+        'counter',
+    )
 
     def __init__(self, value=1, hub=None):
         if value < 0:

--- a/src/gevent/event.py
+++ b/src/gevent/event.py
@@ -326,6 +326,9 @@ class AsyncResult(AbstractLinkable): # pylint:disable=undefined-variable
             # Not ready and not blocking, so immediately timeout
             raise Timeout()
 
+        if self.hub is None: # pylint:disable=access-member-before-definition
+            self.hub = get_hub() # pylint:disable=attribute-defined-outside-init
+
         # Wait, raising a timeout that elapses
         self._wait_core(timeout, ())
 

--- a/src/gevent/event.py
+++ b/src/gevent/event.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from gevent._util import _NONE
 from gevent._compat import reraise
 from gevent._tblib import dump_traceback, load_traceback
+from gevent._hub_local import get_hub_noargs as get_hub
 
 from gevent.timeout import Timeout
 

--- a/src/gevent/event.py
+++ b/src/gevent/event.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 from gevent._util import _NONE
 from gevent._compat import reraise
 from gevent._tblib import dump_traceback, load_traceback
-from gevent._hub_local import get_hub_noargs as get_hub
 
 from gevent.timeout import Timeout
 
@@ -327,8 +326,7 @@ class AsyncResult(AbstractLinkable): # pylint:disable=undefined-variable
             # Not ready and not blocking, so immediately timeout
             raise Timeout()
 
-        if self.hub is None: # pylint:disable=access-member-before-definition
-            self.hub = get_hub() # pylint:disable=attribute-defined-outside-init
+        self._capture_hub(True)
 
         # Wait, raising a timeout that elapses
         self._wait_core(timeout, ())

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -1199,6 +1199,9 @@ cdef public class async_(watcher) [object PyGeventAsyncObject, type PyGeventAsyn
         _check_loop(self.loop)
         libev.ev_async_send(self.loop._ptr, &self._watcher)
 
+    def send_ignoring_arg(self, _ignored):
+        return self.send()
+
 async = async_
 
 cdef start_and_stop child_ss = make_ss(<void*>libev.ev_child_start, <void*>libev.ev_child_stop)

--- a/src/gevent/lock.py
+++ b/src/gevent/lock.py
@@ -127,7 +127,7 @@ class _AtomicSemaphoreMixin(object):
     # on exit. acquire and wait can call _wait, which must release it on entry
     # and re-acquire it for them on exit.
     #
-    # Note that this does *NOT* make semaphores safe to use from multiple threads
+    # Note that this does *NOT*, in-and-of itself, make semaphores safe to use from multiple threads
     def __init__(self, *args, **kwargs):
         self._lock_lock = _OwnedLock()
         super(_AtomicSemaphoreMixin, self).__init__(*args, **kwargs)
@@ -271,8 +271,12 @@ class RLock(object):
         '__weakref__',
     )
 
-    def __init__(self):
-        self._block = Semaphore(1)
+    def __init__(self, hub=None):
+        """
+        .. versionchanged:: NEXT
+           Add the ``hub`` argument.
+        """
+        self._block = Semaphore(1, hub)
         self._owner = None
         self._count = 0
 

--- a/src/gevent/lock.py
+++ b/src/gevent/lock.py
@@ -10,8 +10,12 @@ infinite bounds (:class:`DummySemaphore`), along with a reentrant lock
 from __future__ import absolute_import
 
 from gevent.hub import getcurrent
-from gevent._compat import PYPY
-from gevent._semaphore import Semaphore, BoundedSemaphore # pylint:disable=no-name-in-module,import-error
+from gevent._compat import PURE_PYTHON
+# This is the one exception to the rule of where to
+# import Semaphore, obviously
+from gevent import monkey
+from gevent._semaphore import Semaphore
+from gevent._semaphore import BoundedSemaphore
 
 
 __all__ = [
@@ -27,53 +31,60 @@ __all__ = [
 # unsafe state (only when we _do_wait do we call back into Python and
 # allow switching threads). Simulate that here through the use of a manual
 # lock. (We use a separate lock for each semaphore to allow sys.settrace functions
-# to use locks *other* than the one being traced.)
-if PYPY:
-    # TODO: Need to use monkey.get_original?
-    try:
-        from _thread import allocate_lock as _allocate_lock # pylint:disable=import-error,useless-suppression
-        from _thread import get_ident as _get_ident # pylint:disable=import-error,useless-suppression
-    except ImportError:
-        # Python 2
-        from thread import allocate_lock as _allocate_lock # pylint:disable=import-error,useless-suppression
-        from thread import get_ident as _get_ident # pylint:disable=import-error,useless-suppression
-    _sem_lock = _allocate_lock()
+# to use locks *other* than the one being traced.) This, of course, must also
+# hold for PURE_PYTHON mode when no optional C extensions are used.
 
-    def untraceable(f):
-        # Don't allow re-entry to these functions in a single thread, as can
-        # happen if a sys.settrace is used
-        def wrapper(self):
-            me = _get_ident()
-            try:
-                count = self._locking[me]
-            except KeyError:
-                count = self._locking[me] = 1
-            else:
-                count = self._locking[me] = count + 1
-            if count:
+_allocate_lock, _get_ident = monkey.get_original(
+    ('_thread', 'thread'),
+    ('allocate_lock', 'get_ident')
+)
+
+
+class _OwnedLock(object):
+    __slots__ = (
+        '_owner',
+        '_block',
+        '_locking',
+        '_count',
+    )
+
+    def __init__(self):
+        self._owner = None
+        self._block = _allocate_lock()
+        self._locking = {}
+        self._count = 0
+
+    # Don't allow re-entry to these functions in a single thread, as can
+    # happen if a sys.settrace is used.
+
+    def __begin(self):
+        # Return (me, count) if we should proceed, otherwise return
+        # None. The function should exit in that case.
+        # In either case, it must call __end.
+        me = _get_ident()
+        try:
+            count = self._locking[me]
+        except KeyError:
+            count = self._locking[me] = 1
+        else:
+            count = self._locking[me] = count + 1
+        return (me, count) if not count else (None, None)
+
+    def __end(self, me, count):
+        if me is None:
+            return
+        count = count - 1
+        if not count:
+            del self._locking[me]
+        else:
+            self._locking[me] = count
+
+    def __enter__(self):
+        me, lock_count = self.__begin()
+        try:
+            if me is None:
                 return
 
-            try:
-                return f(self)
-            finally:
-                count = count - 1
-                if not count:
-                    del self._locking[me]
-                else:
-                    self._locking[me] = count
-        return wrapper
-
-    class _OwnedLock(object):
-
-        def __init__(self):
-            self._owner = None
-            self._block = _allocate_lock()
-            self._locking = {}
-            self._count = 0
-
-        @untraceable
-        def acquire(self):
-            me = _get_ident()
             if self._owner == me:
                 self._count += 1
                 return
@@ -81,55 +92,70 @@ if PYPY:
             self._owner = me
             self._block.acquire()
             self._count = 1
+        finally:
+            self.__end(me, lock_count)
 
-        @untraceable
-        def release(self):
+    def __exit__(self, t, v, tb):
+        self.release()
+
+    acquire = __enter__
+
+    def release(self):
+        me, lock_count = self.__begin()
+        try:
+            if me is None:
+                return
+
             self._count = count = self._count - 1
             if not count:
                 self._block.release()
                 self._owner = None
+        finally:
+            self.__end(me, lock_count)
 
+
+class _AtomicSemaphore(Semaphore):
+    # Behaves as though the GIL was held for the duration of acquire, wait,
+    # and release, just as if we were in Cython.
+    #
     # acquire, wait, and release all acquire the lock on entry and release it
-    # on exit. acquire and wait can call _do_wait, which must release it on entry
+    # on exit. acquire and wait can call _wait, which must release it on entry
     # and re-acquire it for them on exit.
-    class _around(object):
-        __slots__ = ('before', 'after')
-
-        def __init__(self, before, after):
-            self.before = before
-            self.after = after
-
-        def __enter__(self):
-            self.before()
-
-        def __exit__(self, t, v, tb):
-            self.after()
-
-    def _decorate(func, cmname):
-        # functools.wrap?
-        def wrapped(self, *args, **kwargs):
-            with getattr(self, cmname):
-                return func(self, *args, **kwargs)
-        return wrapped
-
-    Semaphore._py3k_acquire = Semaphore.acquire = _decorate(Semaphore.acquire, '_lock_locked')
-    Semaphore.release = _decorate(Semaphore.release, '_lock_locked')
-    Semaphore.wait = _decorate(Semaphore.wait, '_lock_locked')
-    Semaphore._wait = _decorate(Semaphore._wait, '_lock_unlocked')
-
-    _Sem_init = Semaphore.__init__
-
+    #
+    # Note that this does *NOT* make semaphores safe to use from multiple threads
+    __slots__ = (
+        '_lock_lock',
+    )
     def __init__(self, *args, **kwargs):
-        l = self._lock_lock = _OwnedLock()
-        self._lock_locked = _around(l.acquire, l.release)
-        self._lock_unlocked = _around(l.release, l.acquire)
+        self._lock_lock = _OwnedLock()
 
-        _Sem_init(self, *args, **kwargs)
+        super(_AtomicSemaphore, self).__init__(*args, **kwargs)
 
-    Semaphore.__init__ = __init__
+    def _wait(self, *args, **kwargs):
+        self._lock_lock.release()
+        try:
+            return super(_AtomicSemaphore, self)._wait(*args, **kwargs)
+        finally:
+            self._lock_lock.acquire()
 
-    del _decorate
-    del untraceable
+    def release(self):
+        with self._lock_lock:
+            return super(_AtomicSemaphore, self).release()
+
+    def acquire(self, blocking=True, timeout=None):
+        with self._lock_lock:
+            return super(_AtomicSemaphore, self).acquire(blocking, timeout)
+
+    _py3k_acquire = acquire
+
+    def wait(self, timeout=None):
+        with self._lock_lock:
+            return super(_AtomicSemaphore, self).wait(timeout)
+
+
+
+if PURE_PYTHON:
+    Semaphore = _AtomicSemaphore
 
 
 class DummySemaphore(object):

--- a/src/gevent/monkey.py
+++ b/src/gevent/monkey.py
@@ -250,7 +250,9 @@ def get_original(mod_name, item_name):
     retrieved.
 
     :param str mod_name: The name of the standard library module,
-        e.g., ``'socket'``.
+        e.g., ``'socket'``. Can also be a sequence of standard library
+        modules giving alternate names to try, e.g., ``('thread', '_thread')``;
+        the first importable module will supply all *item_name* items.
     :param item_name: A string or sequence of strings naming the
         attribute(s) on the module ``mod_name`` to return.
 
@@ -258,10 +260,22 @@ def get_original(mod_name, item_name):
              ``item_name`` or a sequence of original values if a
              sequence was passed.
     """
+    mod_names = [mod_name] if isinstance(mod_name, string_types) else mod_name
     if isinstance(item_name, string_types):
-        return _get_original(mod_name, [item_name])[0]
-    return _get_original(mod_name, item_name)
+        item_names = [item_name]
+        unpack = True
+    else:
+        item_names = item_name
+        unpack = False
 
+    for mod in mod_names:
+        try:
+            result = _get_original(mod, item_names)
+        except ImportError:
+            if mod is mod_names[-1]:
+                raise
+        else:
+            return result[0] if unpack else result
 
 _NONE = object()
 

--- a/src/gevent/testing/leakcheck.py
+++ b/src/gevent/testing/leakcheck.py
@@ -207,6 +207,7 @@ def wrap_refcount(method):
             self.skipTest("This method ignored during leakchecks")
         return _method_skipped_during_leakcheck
 
+
     @wraps(method)
     def wrapper(self, *args, **kwargs): # pylint:disable=too-many-branches
         if getattr(self, 'ignore_leakcheck', False):

--- a/src/gevent/testing/leakcheck.py
+++ b/src/gevent/testing/leakcheck.py
@@ -89,7 +89,6 @@ class _RefCountChecker(object):
             return False
         return True
 
-
     def _growth(self):
         return objgraph.growth(limit=None, peak_stats=self.peak_stats, filter=self._ignore_object_p)
 
@@ -198,14 +197,15 @@ class _RefCountChecker(object):
 
 
 def wrap_refcount(method):
-    if objgraph is None:
-        import warnings
-        warnings.warn("objgraph not available, leakchecks disabled")
-        return method
 
-    if getattr(method, 'ignore_leakcheck', False):
-        return method
-
+    if objgraph is None or getattr(method, 'ignore_leakcheck', False):
+        if objgraph is None:
+            import warnings
+            warnings.warn("objgraph not available, leakchecks disabled")
+        @wraps(method)
+        def _method_skipped_during_leakcheck(self, *_args, **_kwargs):
+            self.skipTest("This method ignored during leakchecks")
+        return _method_skipped_during_leakcheck
 
     @wraps(method)
     def wrapper(self, *args, **kwargs): # pylint:disable=too-many-branches

--- a/src/gevent/tests/lock_tests.py
+++ b/src/gevent/tests/lock_tests.py
@@ -435,7 +435,7 @@ class BaseSemaphoreTests(BaseTestCase):
     def test_constructor(self):
         self.assertRaises(ValueError, self.semtype, value=-1)
         # Py3 doesn't have sys.maxint
-        self.assertRaises(ValueError, self.semtype,
+        self.assertRaises((ValueError, OverflowError), self.semtype,
                           value=-getattr(sys, 'maxint', getattr(sys, 'maxsize', None)))
 
     def test_acquire(self):

--- a/src/gevent/tests/test__lock.py
+++ b/src/gevent/tests/test__lock.py
@@ -5,7 +5,13 @@ from __future__ import print_function
 from gevent import lock
 
 import gevent.testing as greentest
+from gevent.tests import test__semaphore
 
+
+class TestLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
+
+    def _makeOne(self):
+        return lock.RLock()
 
 if __name__ == '__main__':
     greentest.main()

--- a/src/gevent/tests/test__lock.py
+++ b/src/gevent/tests/test__lock.py
@@ -4,13 +4,24 @@ from __future__ import print_function
 
 from gevent import lock
 
+
 import gevent.testing as greentest
 from gevent.tests import test__semaphore
 
 
-class TestLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
+class TestRLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
 
     def _makeOne(self):
+        # If we don't set the hub before returning,
+        # there's a potential race condition, if the implementation
+        # isn't careful. If it's the background hub that winds up capturing
+        # the hub, it will ask the hub to switch back to itself and
+        # then switch to the hub, which will raise LoopExit (nothing
+        # for the background thread to do). What is supposed to happen
+        # is that the background thread realizes it's the background thread,
+        # starts an async watcher and then switches to the hub.
+        #
+        # So we deliberately don't set the hub to help test that condition.
         return lock.RLock()
 
 if __name__ == '__main__':

--- a/src/gevent/tests/test__lock.py
+++ b/src/gevent/tests/test__lock.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from gevent import lock
+
+import gevent.testing as greentest
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/tests/test__semaphore.py
+++ b/src/gevent/tests/test__semaphore.py
@@ -282,7 +282,6 @@ def release_then_spawn(sem, should_quit):
 
 class TestSemaphoreFair(greentest.TestCase):
 
-    @greentest.ignores_leakcheck
     def test_fair_or_hangs(self):
         # If the lock isn't fair, this hangs, spinning between
         # the last two greenlets.
@@ -301,6 +300,12 @@ class TestSemaphoreFair(greentest.TestCase):
         self.assertTrue(keep_going2.dead, keep_going2)
         self.assertFalse(keep_going1.dead, keep_going1)
 
+        sem.release()
+        keep_going1.kill()
+        keep_going2.kill()
+        exiting.kill()
+
+        gevent.idle()
 
 if __name__ == '__main__':
     greentest.main()

--- a/src/gevent/tests/test__thread.py
+++ b/src/gevent/tests/test__thread.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
+from gevent.thread import allocate_lock
+
+import gevent.testing as greentest
+
+try:
+    from _thread import allocate_lock as std_allocate_lock
+except ImportError: # Py2
+    from thread import allocate_lock as std_allocate_lock
+
+
+class TestLock(greentest.TestCase):
+
+    def test_release_unheld_lock(self):
+        std_lock = std_allocate_lock()
+        g_lock = allocate_lock()
+        with self.assertRaises(Exception) as exc:
+            std_lock.release()
+        std_exc = exc.exception
+
+        with self.assertRaises(Exception) as exc:
+            g_lock.release()
+        g_exc = exc.exception
+
+        self.assertIsInstance(g_exc, type(std_exc))
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -203,7 +203,8 @@ if hasattr(__threading__, '_CRLock'):
     # which in turn used _allocate_lock. Now, it wants to use
     # threading._CRLock, which is imported from _thread.RLock and as such
     # is implemented in C. So it bypasses our _allocate_lock function.
-    # Fortunately they left the Python fallback in place.
+    # Fortunately they left the Python fallback in place and use it
+    # if the imported _CRLock is None; this arranges for that to be the case.
 
     # This was also backported to PyPy 2.7-7.0
     assert PY3 or PYPY, "Unsupported Python version"


### PR DESCRIPTION
The normal case (not cross-thread) is essentially unaffected; benchmarks/micro_semaphore.py shows no appreciable difference. 

The cross-thread case is probably slow, but before it didn't work at all.

Relies on the details of Cython + GIL, or, in pure-Python mode, a per-object native lock (not benchmarked). The per-object native lock is expanded from just PyPy to wherever Cython isn't used.

Fixes #1437 