### PR TITLE
Pass addresses through inet_pton before getaddrinfo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 clone_depth: 50
 max_jobs: 8
 shallow_clone: true
-build:
-  parallel: true
-  verbosity: minimal
+# Beginning May 29, 2020, having a `build` section
+# overrides the `build_script` section, causing
+# an error about no Visual Studio file for the default
+# 'MSBuild' mode.
+# build:
+#   parallel: true
+#   verbosity: minimal
 
 environment:
   global:

--- a/docs/changes/1634.bugfix
+++ b/docs/changes/1634.bugfix
@@ -1,0 +1,2 @@
+``gevent.socket.create_connection`` and
+``gevent.socket.socket.connect`` no longer ignore IPv6 scope IDs.

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -251,6 +251,14 @@ class socket(_socketcommon.SocketMixin):
         return isinstance(self._sock, _closedsocket)
 
     def connect(self, address):
+        """
+        Connect to *address*.
+
+        .. versionchanged:: NEXT
+            If the host part of the address includes an IPv6 scope ID,
+            it will be used instead of ignored, if the platform supplies
+            :func:`socket.inet_pton`.
+        """
         if self.timeout == 0.0:
             return self._sock.connect(address)
 

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -389,10 +389,17 @@ class socket(_socketcommon.SocketMixin):
         return sock.detach()
 
     def connect(self, address):
+        """
+        Connect to *address*.
+
+        .. versionchanged:: NEXT
+            If the host part of the address includes an IPv6 scope ID,
+            it will be used instead of ignored, if the platform supplies
+            :func:`socket.inet_pton`.
+        """
         if self.timeout == 0.0:
             return _socket.socket.connect(self._sock, address)
         address = _socketcommon._resolve_addr(self._sock, address)
-
         with Timeout._start_new_or_dummy(self.timeout, timeout("timed out")):
             while True:
                 err = self.getsockopt(SOL_SOCKET, SO_ERROR)

--- a/src/gevent/socket.py
+++ b/src/gevent/socket.py
@@ -75,6 +75,11 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT, source_address=N
     must be a tuple of (host, port) for the socket to bind as a source
     address before making the connection. A host of '' or port 0 tells
     the OS to use the default.
+
+    .. versionchanged:: NEXT
+        If the host part of the address includes an IPv6 scope ID,
+        it will be used instead of ignored, if the platform supplies
+        :func:`socket.inet_pton`.
     """
 
     host, port = address
@@ -85,7 +90,7 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT, source_address=N
         raise error("getaddrinfo returns an empty list")
 
     for res in addrs:
-        af, socktype, proto, _, sa = res
+        af, socktype, proto, _canonname, sa = res
         sock = None
         try:
             sock = socket(af, socktype, proto)

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -562,6 +562,19 @@ class TestFunctions(greentest.TestCase):
             exclude.append('gethostbyaddr')
         self.assertMonkeyPatchedFuncSignatures('socket', exclude=exclude)
 
+    def test_resolve_ipv6_scope_id(self):
+        from gevent import _socketcommon as SC
+        if not SC.__socket__.has_ipv6:
+            self.skipTest("Needs IPv6") # pragma: no cover
+        if not hasattr(SC.__socket__, 'inet_pton'):
+            self.skipTest("Needs inet_pton") # pragma: no cover
+
+        # A valid IPv6 address, with a scope.
+        addr = ('2607:f8b0:4000:80e::200e', 80, 0, 9)
+        # Mock socket
+        class sock(object):
+            family = SC.AF_INET6 # pylint:disable=no-member
+        self.assertIs(addr, SC._resolve_addr(sock, addr))
 
 class TestSocket(greentest.TestCase):
 


### PR DESCRIPTION
On `connect()` and thus `create_connection`. Fixes #1634. 

Currently a WIP because [for some reason appveyor stopped running](https://help.appveyor.com/discussions/problems/27457-appveyoryml-suddenly-not-being-read-no-matrix-expansion-msbuild-mode-error-back-despite-build_script-setting), and I'd really like to run these tests on Windows (and I'm too lazy to fire up local virtual machines right now).