### PR TITLE
Add gevent.selectors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,11 @@ environment:
     # a later point release.
 
     # 64-bit
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.13
+      PYTHON_ARCH: "64"
+      PYTHON_EXE: python
+
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
@@ -47,11 +52,6 @@ environment:
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
-      PYTHON_EXE: python
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.13
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 

--- a/docs/api/gevent.selectors.rst
+++ b/docs/api/gevent.selectors.rst
@@ -1,0 +1,6 @@
+=======================================================
+ :mod:`gevent.selectors` -- High-level IO Multiplexing
+=======================================================
+
+.. automodule:: gevent.selectors
+    :members:

--- a/docs/changes/1532.bugfix
+++ b/docs/changes/1532.bugfix
@@ -1,0 +1,8 @@
+Add ``gevent.selectors`` containing ``GeventSelector``.
+
+This is monkey-patched as ``selectors.DefaultSelector`` by default.
+
+This is available on Python 2 if the ``selectors2`` backport is
+installed. (This backport is installed automatically using the
+``recommended`` extra.) When monkey-patching, ``selectors`` is made
+available as an alias to this module.

--- a/docs/changes/1532.feature
+++ b/docs/changes/1532.feature
@@ -1,4 +1,7 @@
-Add ``gevent.selectors`` containing ``GeventSelector``.
+Add ``gevent.selectors`` containing ``GeventSelector``. This selector
+implementation uses gevent details to attempt to reduce overhead when
+polling many file descriptors, only some of which become ready at any
+given time.
 
 This is monkey-patched as ``selectors.DefaultSelector`` by default.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -146,7 +146,13 @@ monitor
     build on all platforms.)
 
 recommended
-    A shortcut for installing suggested extras together.
+    A shortcut for installing suggested extras together. This includes
+    the non-test extras defined here, plus:
+
+    - `backports.socketpair
+      <https://pypi.org/project/backports.socketpair/>`_ on Python
+      2/Windows (beginning with release 20.6.0);
+    - `selectors2 <https://pypi.org/project/selectors2/>`_ on Python 2 (beginning with release 20.6.0).
 
 test
     Everything needed to run the complete gevent test suite.

--- a/setup.py
+++ b/setup.py
@@ -315,6 +315,8 @@ EXTRA_MONITOR = [
 EXTRA_RECOMMENDED = [
     # We need this at runtime to use the libev-CFFI and libuv backends
     CFFI_DEP,
+    # Backport of selectors module to Python 2
+    'selectors2 ; python_version == "2.7"',
 ] + EXTRA_DNSPYTHON + EXTRA_EVENTS + EXTRA_MONITOR
 
 

--- a/setup.py
+++ b/setup.py
@@ -317,6 +317,8 @@ EXTRA_RECOMMENDED = [
     CFFI_DEP,
     # Backport of selectors module to Python 2
     'selectors2 ; python_version == "2.7"',
+    # Backport of socket.socketpair to Python 2; only needed on Windows
+    'backports.socketpair ; python_version == "2.7" and sys_platform == "win32"',
 ] + EXTRA_DNSPYTHON + EXTRA_EVENTS + EXTRA_MONITOR
 
 

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -194,6 +194,10 @@ class AbstractLinkable(object):
         # The object itself becomes false in a boolean way as soon
         # as this method returns.
         notifier = self._notifier
+        if notifier is None:
+            # XXX: How did we get here?
+            self._check_and_notify()
+            return
         # Early links are allowed to remove later links, and links
         # are allowed to add more links, thus we must not
         # make a copy of our the ``_links`` list, we must traverse it and

--- a/src/gevent/_patcher.py
+++ b/src/gevent/_patcher.py
@@ -25,6 +25,7 @@ MAPPING = {
     'gevent.local': '_threading_local',
     'gevent.socket': 'socket',
     'gevent.select': 'select',
+    'gevent.selectors': 'selectors' if PY3 else 'selectors2',
     'gevent.ssl': 'ssl',
     'gevent.thread': '_thread' if PY3 else 'thread',
     'gevent.subprocess': 'subprocess',

--- a/src/gevent/_socket2.py
+++ b/src/gevent/_socket2.py
@@ -475,8 +475,8 @@ elif hasattr(__socket__, 'socketpair'):
     # cooperatively automatically if we're monkey-patched,
     # else we must do it ourself.
     _orig_socketpair = __socket__.socketpair
-    def socketpair(*args, **kwargs):
-        one, two = _orig_socketpair(*args, **kwargs)
+    def socketpair(family=_socket.AF_INET, type=_socket.SOCK_STREAM, proto=0):
+        one, two = _orig_socketpair(family, type, proto)
         if not isinstance(one, socket):
             one = socket(_sock=one)
             two = socket(_sock=two)

--- a/src/gevent/_socketcommon.py
+++ b/src/gevent/_socketcommon.py
@@ -128,6 +128,11 @@ if is_macos:
 import _socket
 _realsocket = _socket.socket
 import socket as __socket__
+try:
+    # Provide implementation of socket.socketpair on Windows < 3.5.
+    import backports.socketpair
+except ImportError:
+    pass
 
 _name = _value = None
 __imports__ = copy_globals(__socket__, globals(),

--- a/src/gevent/selectors.py
+++ b/src/gevent/selectors.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2020 gevent contributors.
+"""
+This module provides :class:`GeventSelector`, a high-level IO
+multiplexing mechanism. This is aliased to :class:`DefaultSelector`.
+
+This module provides the same API as the selectors defined in :mod:`selectors`.
+
+On Python 2, this module is only available if the `selectors2
+<https://pypi.org/project/selectors2/>`_ backport is installed.
+
+.. versionadded:: NEXT
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+try:
+    import selectors as __selectors__
+except ImportError:
+    # Probably on Python 2. Do we have the backport?
+    import selectors2 as __selectors__
+    __target__ = 'selectors2'
+
+from gevent._compat import iteritems
+from gevent._util import copy_globals
+
+from gevent.select import poll as Poll
+from gevent.select import POLLIN
+from gevent.select import POLLOUT
+
+__implements__ = [
+    'DefaultSelector',
+]
+__extra__ = [
+    'GeventSelector',
+]
+__all__ = __implements__ + __extra__
+
+__imports__ = copy_globals(
+    __selectors__, globals(),
+    names_to_ignore=__all__,
+    # Copy __all__; __all__ is defined by selectors2 but not Python 3.
+    dunder_names_to_keep=('__all__',)
+)
+
+_POLL_ALL = POLLIN | POLLOUT
+
+EVENT_READ = __selectors__.EVENT_READ
+EVENT_WRITE = __selectors__.EVENT_WRITE
+_ALL_EVENTS = EVENT_READ | EVENT_WRITE
+SelectorKey = __selectors__.SelectorKey
+
+# In 3.4 and selectors2, BaseSelector is a concrete
+# class that can be called. In 3.5 and later, it's an
+# ABC, with the real implementation being
+# passed to _BaseSelectorImpl.
+_BaseSelectorImpl = getattr(
+    __selectors__,
+    '_BaseSelectorImpl',
+    __selectors__.BaseSelector
+)
+
+class GeventSelector(_BaseSelectorImpl):
+    """
+    A selector implementation using gevent primitives.
+    """
+
+    def __init__(self):
+        self._poll = Poll()
+        self._poll._get_started_watchers = self._get_started_watchers
+        # {fd: watcher}
+        self._watchers = {}
+        super(GeventSelector, self).__init__()
+
+    def _get_started_watchers(self, watcher_cb):
+        for fd, watcher in iteritems(self._watchers):
+            watcher.start(watcher_cb, fd, pass_events=True)
+        return list(self._watchers.values())
+
+    @property
+    def loop(self):
+        return self._poll.loop
+
+    def register(self, fileobj, events, data=None):
+        key = _BaseSelectorImpl.register(self, fileobj, events, data)
+
+        if events == _ALL_EVENTS:
+            flags = _POLL_ALL
+        elif events == EVENT_READ:
+            flags = POLLIN
+        else:
+            flags = POLLOUT
+
+        self._poll.register(key.fd, flags)
+
+        loop = self.loop
+        io = loop.io
+        MAXPRI = loop.MAXPRI
+
+        self._watchers[key.fd] = watcher = io(key.fd, self._poll.fds[key.fd])
+        watcher.priority = MAXPRI
+        return key
+
+    def unregister(self, fileobj):
+        key = _BaseSelectorImpl.unregister(self, fileobj)
+        self._poll.unregister(key.fd)
+        self._watchers.pop(key.fd)
+        return key
+
+    # XXX: Can we implement ``modify`` more efficiently than
+    # ``unregister()``+``register()``? We could detect the no-change
+    # case and do nothing; recent versions of the standard library
+    # do that.
+
+    def select(self, timeout=None):
+        # In https://github.com/gevent/gevent/pull/1523/, it was
+        # proposed to (essentially) keep the watchers started even
+        # after the select() call returned *if* the watcher hadn't fired.
+        # (If it fired, it was stopped). Watchers were started as soon as they
+        # were registered.
+        #
+        # The goal was to minimize the amount of time spent adjusting the
+        # underlying kernel (epoll) data structures as watchers are started and
+        # stopped. Events were just collected continually in the background
+        # in the hopes that they would be retrieved by a future call to
+        # ```select()``. This method used an ``Event`` to communicate with
+        # the background ongoing collection of results.
+        #
+        # That becomes a problem if the file descriptor is closed while the watcher
+        # is still active. Certain backends will crash in that case.
+        # However, the selectors documentation says that files must be
+        # unregistered before closing, so that's theoretically not a concern
+        # here.
+        #
+        # Also, stopping the watchers if they fired here was said to be
+        # because "if we did not, someone could call, e.g., gevent.time.sleep and
+        # any unconsumed bytes on our watched fd would prevent the process from
+        # sleeping correctly." It's not clear to me (JAM) why that would be the case
+        # only in the ``select`` method, and not after the watcher was started in
+        # ``register()``. Actually, it's not clear why it would be a problem at any
+        # point.
+
+        # timeout > 0 : block seconds
+        # timeout <= 0 : No blocking.
+        # timeout = None: Block forever
+        #
+        # Meanwhile, for poll():
+        # timeout None: block forever
+        # timeout omitted: block forever
+        # timeout < 0: block forever
+        # timeout anything else: block that long in *milliseconds*
+
+        if timeout is not None:
+            if timeout <= 0:
+                # Asked not to block.
+                timeout = 0
+            else:
+                # Convert seconds to ms.
+                # poll() has a resolution of 1 millisecond, round away from
+                # zero to wait *at least* timeout seconds.
+                timeout = math.ceil(timeout * 1e3)
+
+        poll_events = self._poll.poll(timeout)
+        result = []
+        for fd, event in poll_events:
+            key = self._key_from_fd(fd)
+            if not key:
+                continue
+
+            events = 0
+            if event & POLLOUT:
+                events |= EVENT_WRITE
+            if event & POLLIN:
+                events |= EVENT_READ
+
+            result.append((key, events & key.events))
+        return result
+
+    def close(self):
+        self._poll = None # Nothing to do, just drop it
+        for watcher in self._watchers.values() if self._watchers else ():
+            watcher.stop()
+            watcher.close()
+        self._watchers = None
+        _BaseSelectorImpl.close(self)
+
+
+DefaultSelector = GeventSelector
+
+def _gevent_do_monkey_patch(patch_request):
+    aggressive = patch_request.patch_kwargs['aggressive']
+    target_mod = patch_request.target_module
+
+    patch_request.default_patch_items()
+
+    import sys
+    if 'selectors' not in sys.modules:
+        # Py2: Make 'import selectors' work
+        sys.modules['selectors'] = sys.modules[__name__]
+
+    # Python 3 wants to use `select.select` as a member function,
+    # leading to this error in selectors.py (because
+    # gevent.select.select is not a builtin and doesn't get the
+    # magic auto-static that they do):
+    #
+    #    r, w, _ = self._select(self._readers, self._writers, [], timeout)
+    #    TypeError: select() takes from 3 to 4 positional arguments but 5 were given
+    #
+    # Note that this obviously only happens if selectors was
+    # imported after we had patched select; but there is a code
+    # path that leads to it being imported first (but now we've
+    # patched select---so we can't compare them identically). It also doesn't
+    # happen on Windows, because they define a normal method for _select, to work around
+    # some weirdness in the handling of the third argument.
+    #
+    # The backport doesn't have that.
+    orig_select_select = patch_request.get_original('select', 'select')
+    assert target_mod.select is not orig_select_select
+    selectors = __selectors__
+    SelectSelector = selectors.SelectSelector
+    if hasattr(SelectSelector, '_select') and SelectSelector._select in (
+            target_mod.select, orig_select_select
+    ):
+        from gevent.select import select
+        def _select(self, *args, **kwargs): # pylint:disable=unused-argument
+            return select(*args, **kwargs)
+        selectors.SelectSelector._select = _select
+        _select._gevent_monkey = True # prove for test cases
+
+    if aggressive:
+        # If `selectors` had already been imported before we removed
+        # select.epoll|kqueue|devpoll, these may have been defined in terms
+        # of those functions. They'll fail at runtime.
+        patch_request.remove_item(
+            selectors,
+            'EpollSelector',
+            'KqueueSelector',
+            'DevpollSelector',
+        )
+        selectors.DefaultSelector = DefaultSelector
+
+    # Python 3.7 refactors the poll-like selectors to use a common
+    # base class and capture a reference to select.poll, etc, at
+    # import time. selectors tends to get imported early
+    # (importing 'platform' does it: platform -> subprocess -> selectors),
+    # so we need to clean that up.
+    if hasattr(selectors, 'PollSelector') and hasattr(selectors.PollSelector, '_selector_cls'):
+        selectors.PollSelector._selector_cls = Poll

--- a/src/gevent/tests/known_failures.py
+++ b/src/gevent/tests/known_failures.py
@@ -259,14 +259,6 @@ class Definitions(DefinitionsBase):
         when=APPVEYOR & PY3
     )
 
-    test__socketpair = Ignored(
-        """
-        Py35 added socket.socketpair, all other releases
-        are missing it. No reason to even test it.
-        """,
-        when=WIN & PY2
-    )
-
     test_ftplib = Flaky(
         r"""
         could be a problem of appveyor - not sure

--- a/src/gevent/tests/test__all__.py
+++ b/src/gevent/tests/test__all__.py
@@ -174,7 +174,7 @@ class AbstractTestMixin(object):
             return
         if self.__implements__ is not None and self.stdlib_module is None:
             raise AssertionError(
-                '%s (%r) has __implements__ (%s) but no stdlib counterpart (%s)'
+                '%s (%r) has __implements__ (%s) but no stdlib counterpart module exists (%s)'
                 % (self.modname, self.module, self.__implements__, self.stdlib_name))
 
     @skip_if_no_stdlib_counterpart

--- a/src/gevent/tests/test__selectors.py
+++ b/src/gevent/tests/test__selectors.py
@@ -1,0 +1,95 @@
+# Tests for gevent.selectors in its native form, without
+# monkey-patching.
+
+import gevent
+from gevent import socket
+from gevent import selectors
+
+import gevent.testing as greentest
+
+class SelectorTestMixin(object):
+
+    @staticmethod
+    def run_selector_once(sel):
+        # Run in a background greenlet, leaving the main
+        # greenlet free to send data.
+        events = sel.select(timeout=3)
+        for key, mask in events:
+            key.data(sel, key.fileobj, mask)
+            gevent.sleep()
+
+    unregister_after_send = True
+
+    def read_from_ready_socket_and_reply(self, selector, conn, _events):
+        data = conn.recv(100)  # Should be ready
+        if data:
+            conn.send(data)  # Hope it won't block
+
+        # Must unregister before we close.
+        if self.unregister_after_send:
+            selector.unregister(conn)
+            conn.close()
+
+    def _check_selector(self, sel):
+        server, client = socket.socketpair()
+        try:
+            sel.register(server, selectors.EVENT_READ, self.read_from_ready_socket_and_reply)
+            glet = gevent.spawn(self.run_selector_once, sel)
+            DATA = b'abcdef'
+            client.send(DATA)
+            data = client.recv(50) # here is probably where we yield to the event loop
+            self.assertEqual(data, DATA)
+        finally:
+            sel.close()
+            server.close()
+            client.close()
+            glet.join(10)
+        self.assertTrue(glet.ready())
+
+
+class GeventSelectorTest(SelectorTestMixin,
+                         greentest.TestCase):
+
+    def test_select_using_socketpair(self):
+        # Basic test.
+        with selectors.GeventSelector() as sel:
+            self._check_selector(sel)
+
+    def test_select_many_sockets(self):
+        pairs = [socket.socketpair() for _ in range(10)]
+        clients = [s[1] for s in pairs]
+
+        try:
+            server_sel = selectors.GeventSelector()
+            client_sel = selectors.GeventSelector()
+            for i, pair in enumerate(pairs):
+                server, client = pair
+                server_sel.register(server, selectors.EVENT_READ,
+                                    self.read_from_ready_socket_and_reply)
+                client_sel.register(client, selectors.EVENT_READ, i)
+            # Prime them all to be ready at once.
+            for i, client in enumerate(clients):
+                data = str(i).encode('ascii')
+                client.send(data)
+
+            # Read and reply to all the clients
+            self.run_selector_once(server_sel)
+
+            found = 0
+            for key, _ in client_sel.select(timeout=3):
+                expected = str(key.data).encode('ascii')
+                data = key.fileobj.recv(50)
+                self.assertEqual(data, expected)
+                found += 1
+            self.assertEqual(found, len(pairs))
+        finally:
+            server_sel.close()
+            client_sel.close()
+            for pair in pairs:
+                for s in pair:
+                    s.close()
+
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/tests/test__server.py
+++ b/src/gevent/tests/test__server.py
@@ -308,6 +308,7 @@ class TestDefaultSpawn(TestCase):
         with self.assertRaises(TypeError):
             self.ServerClass(self.get_listener(), backlog=25)
 
+    @greentest.skipOnLibuvOnCIOnPyPy("Sometimes times out")
     def test_backlog_is_accepted_for_address(self):
         self.server = self.ServerSubClass((greentest.DEFAULT_BIND_ADDR, 0), backlog=25)
         self.assertConnectionRefused()

--- a/src/gevent/tests/test__socketpair.py
+++ b/src/gevent/tests/test__socketpair.py
@@ -15,6 +15,8 @@ class TestSocketpair(unittest.TestCase):
         self.assertEqual(msg, read)
         y.close()
 
+    @unittest.skipUnless(hasattr(socket, 'fromfd'),
+                         'Needs socket.fromfd')
     def test_fromfd(self):
         msg = b'hello world'
         x, y = socket.socketpair()

--- a/src/gevent/tests/test__threadpool.py
+++ b/src/gevent/tests/test__threadpool.py
@@ -438,7 +438,7 @@ class TestMaxsize(TestCase):
         pool.spawn(sleep, 0.2)
         pool.spawn(sleep, 0.3)
         gevent.sleep(0.2)
-        self.assertEqual(pool.size, 3)
+        self.assertGreaterEqual(pool.size, 2)
         pool.maxsize = 0
         gevent.sleep(0.2)
         self.assertEqualFlakyRaceCondition(pool.size, 0)

--- a/src/gevent/threadpool.py
+++ b/src/gevent/threadpool.py
@@ -743,8 +743,9 @@ else:
                 future = self._threadpool.spawn(fn, *args, **kwargs)
                 return _FutureProxy(future)
 
-        def shutdown(self, wait=True):
-            super(ThreadPoolExecutor, self).shutdown(wait)
+        def shutdown(self, wait=True, **kwargs): # pylint:disable=arguments-differ
+            # In 3.9, this added ``cancel_futures=False``
+            super(ThreadPoolExecutor, self).shutdown(wait, **kwargs)
             # XXX: We don't implement wait properly
             kill = getattr(self._threadpool, 'kill', None)
             if kill: # pylint:disable=using-constant-test


### PR DESCRIPTION
Fixes #1532 

Includes the optimizations from #1523 to reduce churn in the underlying kernel poll mechanism.

Optionally depends on the backport of `selectors2` on Python 2, and also adds support for the backport `backports.socketpair` on Python2 (Windows).