### PR TITLE
Fixes for Fedora Rawhide and SSL

### DIFF
--- a/docs/changes/1637.bugfix
+++ b/docs/changes/1637.bugfix
@@ -1,0 +1,7 @@
+Python 3 ``gevent.ssl.SSLSocket`` objects no longer attempt to catch
+``ConnectionResetError`` and treat it the same as an ``SSLError`` with
+``SSL_ERROR_EOF`` (typically by suppressing it).
+
+This was a difference from the way the standard library behaved (which
+is to raise the exception). It was added to gevent during early
+testing of OpenSSL 1.1 and TLS 1.3.

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -44,6 +44,8 @@ if [ -d /gevent -a -d /opt/python ]; then
     export XDG_CACHE_HOME="/cache"
     ls -ld /cache
     yum -y install libffi-devel ccache
+    # On Fedora Rawhide (F33)
+    # yum install python39 python3-devel gcc kernel-devel kernel-headers make diffutils file
 
     mkdir /tmp/build
     cd /tmp/build

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -612,6 +612,7 @@ class SSLSocket(socket):
             # that with a layer.
             shutdown = self._sslobj.unwrap
 
+        s = self._sock
         while True:
             try:
                 s = shutdown()
@@ -627,6 +628,12 @@ class SSLSocket(socket):
                 if self.timeout == 0.0:
                     raise
                 self._wait(self._write_event)
+            except OSError as e:
+                if e.errno == 0:
+                    # What does this even mean? Seen on 3.7+.
+                    break
+                raise
+
 
         self._sslobj = None
 

--- a/src/gevent/_ssl3.py
+++ b/src/gevent/_ssl3.py
@@ -396,15 +396,15 @@ class SSLSocket(socket):
                 if ex.args[0] == SSL_ERROR_EOF and self.suppress_ragged_eofs:
                     return b'' if buffer is None else len(buffer) - initial_buf_len
                 raise
-            except ConnectionResetError:
-                # Certain versions of Python, built against certain
-                # versions of OpenSSL operating in certain modes,
-                # can produce this instead of SSLError. Notably, it looks
-                # like anything built against 1.1.1c do?
-                if self.suppress_ragged_eofs:
-                    return b'' if buffer is None else len(buffer) - initial_buf_len
-                raise
-
+            # Certain versions of Python, built against certain
+            # versions of OpenSSL operating in certain modes, can
+            # produce ``ConnectionResetError`` instead of
+            # ``SSLError``. Notably, it looks like anything built
+            # against 1.1.1c does that? gevent briefly (from support of TLS 1.3
+            # in Sept 2019 to issue #1637 it June 2020) caught that error and treaded
+            # it just like SSL_ERROR_EOF. But that's not what the standard library does.
+            # So presumably errors that result from unexpected ``ConnectionResetError``
+            # are issues in gevent tests.
 
     def write(self, data):
         """Write DATA to the underlying SSL channel.  Returns

--- a/src/gevent/_sslgte279.py
+++ b/src/gevent/_sslgte279.py
@@ -19,7 +19,7 @@ _ssl = __ssl__._ssl # pylint:disable=no-member
 
 import errno
 from gevent._socket2 import socket
-from gevent._socket2 import AF_INET
+from gevent._socket2 import AF_INET # pylint:disable=no-name-in-module
 from gevent.socket import timeout_default
 from gevent.socket import create_connection
 from gevent.socket import error as socket_error

--- a/src/gevent/_sslgte279.py
+++ b/src/gevent/_sslgte279.py
@@ -564,7 +564,13 @@ class SSLSocket(socket):
         if not self._sslobj:
             raise ValueError("No SSL wrapper around " + str(self))
 
-        s = self._sslobj_shutdown()
+        s = self._sock
+        try:
+            s = self._sslobj_shutdown()
+        except socket_error as ex:
+            if ex.args[0] != 0:
+                raise
+
         self._sslobj = None
         # match _ssl2; critical to drop/reuse here on PyPy
         # XXX: _ssl3 returns an SSLSocket. Is that what the standard lib does on

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -1228,7 +1228,9 @@ if PY37:
 
     if APPVEYOR:
         disabled_tests += [
-
+            # This sometimes produces ``self.assertEqual(1, len(s.select(0))): 1 != 0``.
+            # Probably needs to spin the loop once.
+            'test_selectors.DefaultSelectorTestCase.test_timeout',
         ]
 
 if PY38:
@@ -1283,16 +1285,13 @@ if OSX:
     disabled_tests += [
         # This sometimes produces OSError: Errno 40: Message too long
         'test_socket.RecvmsgIntoTCPTest.testRecvmsgIntoGenerator',
+
+        # These sometime timeout. Cannot reproduce locally.
+        'test_ftp.TestTLS_FTPClassMixin.test_mlsd',
+        'test_ftp.TestTLS_FTPClassMixin.test_retrlines_too_long',
+        'test_ftp.TestTLS_FTPClassMixin.test_storlines',
+        'test_ftp.TestTLS_FTPClassMixin.test_retrbinary_rest',
     ]
-
-    if RUNNING_ON_CI:
-
-        disabled_tests += [
-            # These sometime timeout. Cannot reproduce locally.
-            'test_ftp.TestTLS_FTPClassMixin.test_mlsd',
-            'test_ftp.TestTLS_FTPClassMixin.test_retrlines_too_long',
-            'test_ftp.TestTLS_FTPClassMixin.test_storlines',
-        ]
 
     if RESOLVER_ARES and PY38 and not RUNNING_ON_CI:
         disabled_tests += [

--- a/src/gevent/tests/test__close_backend_fd.py
+++ b/src/gevent/tests/test__close_backend_fd.py
@@ -32,6 +32,13 @@ class Test(unittest.TestCase):
     )
 
     BACKENDS_THAT_WILL_FAIL_TO_CREATE_AT_RUNTIME = (
+        # This fails on the Ubuntu Bionic image, and on
+        # the Fedora Rawhide 33 image. It's not clear why; needs
+        # investigated.
+        'linux_iouring',
+    )
+
+    BACKENDS_THAT_WILL_FAIL_TO_CREATE_AT_RUNTIME += (
         # This can be compiled on any (?) version of
         # linux, but there's a runtime check that you're
         # running at least kernel 4.19, so we can fail to create

--- a/src/gevent/tests/test__server.py
+++ b/src/gevent/tests/test__server.py
@@ -309,6 +309,7 @@ class TestDefaultSpawn(TestCase):
             self.ServerClass(self.get_listener(), backlog=25)
 
     @greentest.skipOnLibuvOnCIOnPyPy("Sometimes times out")
+    @greentest.skipOnAppVeyor("Sometimes times out.")
     def test_backlog_is_accepted_for_address(self):
         self.server = self.ServerSubClass((greentest.DEFAULT_BIND_ADDR, 0), backlog=25)
         self.assertConnectionRefused()

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -225,7 +225,6 @@ class TestTCP(greentest.TestCase):
                             raise
                 log("Client will close")
                 client.close()
-                gevent.idle()
         finally:
             server.join(10)
             assert not server.is_alive()

--- a/src/gevent/tests/test__ssl.py
+++ b/src/gevent/tests/test__ssl.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
-from gevent import monkey; monkey.patch_all()
+from gevent import monkey
+monkey.patch_all()
 import os
 
 import socket

--- a/src/gevent/tests/test__threading_2.py
+++ b/src/gevent/tests/test__threading_2.py
@@ -394,12 +394,12 @@ class ThreadTests(unittest.TestCase):
             warnings.simplefilter('ignore', DeprecationWarning)
             # get/set checkinterval are deprecated in Python 3,
             # and removed in Python 3.9
-            old_interval = sys.getcheckinterval()
+            old_interval = sys.getcheckinterval() # pylint:disable=no-member
             try:
                 for i in xrange(1, 100):
                     # Try a couple times at each thread-switching interval
                     # to get more interleavings.
-                    sys.setcheckinterval(i // 5)
+                    sys.setcheckinterval(i // 5) # pylint:disable=no-member
                     t = threading.Thread(target=lambda: None)
                     t.start()
                     t.join()
@@ -407,7 +407,7 @@ class ThreadTests(unittest.TestCase):
                     self.assertFalse(t in l,
                                      "#1703448 triggered after %d trials: %s" % (i, l))
             finally:
-                sys.setcheckinterval(old_interval)
+                sys.setcheckinterval(old_interval) # pylint:disable=no-member
 
     if not hasattr(sys, 'pypy_version_info'):
         def test_no_refcycle_through_target(self):


### PR DESCRIPTION
- Stop artificially catching ConnectionResetError in ssl3.SSLSocket.read; this seemed only to be a test issue.
- psutil isn't finding all open file descriptors given certain connection states (it compares data in `/proc/net/tcp` to try to match up descriptors and ignores them if not present). So also include data from `/proc/<pid>/fd` when needed.
- Don't try to test the `linux_iouring` libev backend right now.

This also reads like a list of the issues on Ubuntu Bionic (#1623), so that might also be fixed. 

