### PR TITLE
Configure libev to use vdso where it is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
         # know. The env var works for pip 20.
         - PIP_NO_PYTHON_VERSION_WARNING=1
         - PIP_NO_WARN_SCRIPT_LOCATION=1
-        - CC="ccache gcc"
+        - CC="gcc"
         - CCACHE_NOCPP2=true
         - CCACHE_SLOPPINESS=file_macro,time_macros,include_file_ctime,include_file_mtime
         - CCACHE_NOHASHDIR=true

--- a/_setuputils.py
+++ b/_setuputils.py
@@ -23,6 +23,7 @@ THIS_DIR = os.path.dirname(__file__)
 
 PYPY = hasattr(sys, 'pypy_version_info')
 WIN = sys.platform.startswith('win')
+LINUX = sys.platform.startswith('linux')
 
 RUNNING_ON_TRAVIS = os.environ.get('TRAVIS')
 RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')


### PR DESCRIPTION
I noticed numerous time-related syscalls in my interpreter's strace output, and I was wondering whether we can feasibly turn on vDSO. It turns out that it works out of the box in a `manylinux2014` environment, but that in `manylinux2010`, we must force linking against `librt`. I built a `manylinux2010` wheel with this configuration and observed that the `clock_gettime` and `gettimeofday` syscalls vanished.