### PR TITLE
Set EV_USE_REALTIME, EV_USE_MONOTONIC and EV_USE_FLOOR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,7 @@ jobs:
         # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
         # output (pip install uses a random temporary directory, making this difficult)
         - python setup.py bdist_wheel
+        - cat deps/libev/configure-output.txt
         - ls -l dist
         - twine check dist/*
         - pip uninstall -y gevent

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,7 +184,6 @@ jobs:
         # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
         # output (pip install uses a random temporary directory, making this difficult)
         - python setup.py bdist_wheel
-        - cat deps/libev/configure-output.txt
         - ls -l dist
         - twine check dist/*
         - pip uninstall -y gevent

--- a/_setuplibev.py
+++ b/_setuplibev.py
@@ -88,7 +88,17 @@ def build_extension():
             # libev watchers that we don't use currently:
             ('EV_CLEANUP_ENABLE', '0'),
             ('EV_EMBED_ENABLE', '0'),
-            ("EV_PERIODIC_ENABLE", '0')
+            ("EV_PERIODIC_ENABLE", '0'),
+            # Time keeping. If possible, use the realtime and/or monotonic
+            # clocks. On Linux, this can reduce the number of observable syscalls.
+            # On older linux, such as the version in manylinux2010, this requires
+            # linking to lib rt. We handle this in make-manylinux. Newer versions
+            # generally don't need that.
+            ("EV_USE_REALTIME", "1"),
+            ("EV_USE_MONOTONIC", "1"),
+            # use the builtin floor() function. Every modern platform should
+            # have this, right?
+            ("EV_USE_FLOOR", "1"),
         ]
         CORE.configure = configure_libev
         if os.environ.get('GEVENTSETUP_EV_VERIFY') is not None:

--- a/docs/changes/issue1648.feature
+++ b/docs/changes/issue1648.feature
@@ -1,0 +1,6 @@
+The embedded libev is now asked to detect the availability of
+``clock_gettime`` and use the realtime and/or monotonic clocks, if
+they are available.
+
+On Linux, this can reduce the number of system calls libev makes.
+Originally provided by Josh Snyder.

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -34,7 +34,7 @@ export CCACHE_DIR="/ccache"
 # Disable some warnings produced by libev especially and also some Cython generated code.
 # Note that changing the value of these variables invalidates configure caches
 export CFLAGS="-Ofast -pipe -Wno-strict-aliasing -Wno-comment -Wno-unused-value -Wno-unused-but-set-variable -Wno-sign-compare -Wno-parentheses -Wno-unused-function -Wno-tautological-compare -Wno-strict-prototypes"
-
+export LDFLAGS="-lrt" # Needed for clock_gettime libc support on this version.
 
 if [ -d /gevent -a -d /opt/python ]; then
     # Running inside docker


### PR DESCRIPTION
Supersedes and fixes #1648

libev does both compile and runtime checks for the clocks, so always asking to check for them is not a problem.

It's only ancient linux that needs `-lrt` so only define that specifically for the manylinux build environment.