### PR TITLE
Aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -295,18 +295,18 @@ jobs:
         - mkdir -p $HOME/.cache/pip
         - chmod a+rwx $HOME/.cache/pip
 
-    - stage: test
-      name: 32-bit manylinux wheels (all Pythons)
-      language: python
-      services: docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_i686 PRE_CMD=linux32
-      install: docker pull $DOCKER_IMAGE
-      script: bash scripts/releases/make-manylinux
-      before_script:
-        - python -mpip install -U pip twine
-        - chmod a+rwx $HOME/.cache
-        - mkdir -p $HOME/.cache/pip
-        - chmod a+rwx $HOME/.cache/pip
+    # - stage: test
+    #   name: 32-bit manylinux wheels (all Pythons)
+    #   language: python
+    #   services: docker
+    #   env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_i686 PRE_CMD=linux32
+    #   install: docker pull $DOCKER_IMAGE
+    #   script: bash scripts/releases/make-manylinux
+    #   before_script:
+    #     - python -mpip install -U pip twine
+    #     - chmod a+rwx $HOME/.cache
+    #     - mkdir -p $HOME/.cache/pip
+    #     - chmod a+rwx $HOME/.cache/pip
 
     # Lint the code. Because this is a separate job, even if it fails fast
     # the tests will still run. Put it at the top for fast feedback.

--- a/.travis.yml
+++ b/.travis.yml
@@ -280,6 +280,22 @@ jobs:
         - chmod a+w $HOME/.cache/pip
 
     - stage: test
+      name: arm64 manylinux wheels (all Pythons)
+      language: python
+      services: docker
+      group: edge
+      arch: arm64
+      virt: lxd
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
+      install: docker pull $DOCKER_IMAGE
+      script: bash scripts/releases/make-manylinux
+      before_script:
+        - python -mpip install -U pip twine
+        - chmod a+rwx $HOME/.cache
+        - mkdir -p $HOME/.cache/pip
+        - chmod a+rwx $HOME/.cache/pip
+
+    - stage: test
       name: 32-bit manylinux wheels (all Pythons)
       language: python
       services: docker

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -37,6 +37,7 @@ export CFLAGS="-Ofast -pipe -Wno-strict-aliasing -Wno-comment -Wno-unused-value 
 export LDFLAGS="-lrt" # Needed for clock_gettime libc support on this version.
 
 if [ -d /gevent -a -d /opt/python ]; then
+    PLATFORM=$1
     # Running inside docker
 
     # Set a cache directory for pip. This was
@@ -49,7 +50,9 @@ if [ -d /gevent -a -d /opt/python ]; then
     export XDG_CACHE_HOME="/cache"
     ls -ld /cache
     ls -ld /cache/pip
+    yum -y install epel-release || true
     yum -y install libffi-devel ccache
+
     # On Fedora Rawhide (F33)
     # yum install python39 python3-devel gcc kernel-devel kernel-headers make diffutils file
 
@@ -74,7 +77,7 @@ if [ -d /gevent -a -d /opt/python ]; then
         # it, and auditwheel is installed in one of these environments.
         python -mpip install -U "cython >= 3.0a5" cffi greenlet setuptools
         time (python setup.py bdist_wheel -q > /dev/null)
-        PATH="$OPATH" auditwheel repair --plat manylinux2010_x86_64 dist/gevent*.whl
+        PATH="$OPATH" auditwheel repair --plat $PLATFORM dist/gevent*.whl
         cp wheelhouse/gevent*.whl /gevent/wheelhouse
 
         python -mpip install -U --no-compile `ls dist/gevent*whl`[test]
@@ -106,5 +109,5 @@ echo Sharing ccache dir at $HOME/.ccache
 if [ ! -d $HOME/.ccache ]; then
     mkdir $HOME/.ccache
 fi
-docker run --rm -ti -v "$(pwd):/gevent" -v "$LCACHE:/cache" -v "$HOME/.ccache:/ccache" quay.io/pypa/manylinux2010_x86_64 /gevent/scripts/releases/$(basename $0)
+docker run --rm -t -v "$(pwd):/gevent" -v "$LCACHE:/cache" -v "$HOME/.ccache:/ccache" $DOCKER_IMAGE /gevent/scripts/releases/$(basename $0) `basename $DOCKER_IMAGE`
 ls -l wheelhouse

--- a/src/gevent/testing/sysinfo.py
+++ b/src/gevent/testing/sysinfo.py
@@ -178,12 +178,13 @@ def libev_supports_linux_aio():
     return system() == 'Linux' and LooseVersion(release() or '0') >= LooseVersion('4.19')
 
 def libev_supports_linux_iouring():
-    # libev requires kernel XXX to be able to support linux io_uring.
-    # It fails with the kernel in fedora rawhide (4.19.76) but
-    # works (doesn't fail catastrophically when asked to create one)
-    # with kernel 5.3.0 (Ubuntu Bionic)
+    # linux iouring supported since kernel 5.1.
+    # It is blocked by default in docker
     from distutils.version import LooseVersion
     from platform import system
     from platform import release
 
-    return system() == 'Linux' and LooseVersion(release() or '0') >= LooseVersion('5.3')
+    if system() == 'Linux' and LooseVersion(release() or '0') >= LooseVersion('5.1'):
+        return not os.path.exists('/.dockerenv')
+
+    return False


### PR DESCRIPTION
This adds aarch64 wheels to gevent.

I made a few fixes to the make-manylinux script, which previously only created x86_64 wheels.
Without the fix, i686 rule in travis just recreate the same x86_64 wheels. With the fix, the 32bit wheel creation fails with a cython int overflow that I wasn't able to locate, which is why I commented the test out.

Using aarch64 required defining edge and virt properties, as described in the travis blog: https://blog.travis-ci.com/2020-09-11-arm-on-aws

Would be very happy to hear what you think.
Thank you!
Tsahi