### PR TITLE
Python 2, subprocess: Let unbuffered binary writes to popen.stdin loop to write all the data

### DIFF
--- a/docs/changes/1711.bugfix
+++ b/docs/changes/1711.bugfix
@@ -1,0 +1,6 @@
+Python 2: Make ``gevent.subprocess.Popen.stdin`` objects have a
+``write`` method that guarantees to write the entire argument in
+binary, unbuffered mode. This may require multiple trips around the
+event loop, but more closely matches the behaviour of the Python 2
+standard library (and gevent prior to 1.5). The number of bytes
+written is still returned (instead of ``None``).


### PR DESCRIPTION
More like what Python 2 standard library does. Beware of relying on that though during an upgrade.

Fixes #1711

Deliberately kept extremely limited in scope.