### PR TITLE
Rework the way Semaphore deals with cross-thread usage

### DIFF
--- a/docs/changes/1698.bugfix
+++ b/docs/changes/1698.bugfix
@@ -1,0 +1,5 @@
+Improve the ability to use monkey-patched locks, and
+`gevent.lock.BoundedSemaphore`, across threads, especially when the
+various threads might not have a gevent hub or any other active
+greenlets. In particular, this handles some cases that previously
+raised ``LoopExit``.

--- a/docs/changes/1698.bugfix
+++ b/docs/changes/1698.bugfix
@@ -2,4 +2,14 @@ Improve the ability to use monkey-patched locks, and
 `gevent.lock.BoundedSemaphore`, across threads, especially when the
 various threads might not have a gevent hub or any other active
 greenlets. In particular, this handles some cases that previously
-raised ``LoopExit``.
+raised ``LoopExit`` or would hang.
+
+The semaphore tries to avoid creating a hub if it seems unnecessary,
+automatically creating one in the single-threaded case when it would
+block, but not in the multi-threaded case. While the differences
+should be correctly detected, it's possible there are corner cases
+where they might not be.
+
+If your application appears to hang acquiring semaphores, but adding a
+call to ``gevent.get_hub()`` in the thread attempting to acquire the
+semaphore before doing so fixes it, please file an issue.

--- a/docs/changes/1698.bugfix
+++ b/docs/changes/1698.bugfix
@@ -2,7 +2,8 @@ Improve the ability to use monkey-patched locks, and
 `gevent.lock.BoundedSemaphore`, across threads, especially when the
 various threads might not have a gevent hub or any other active
 greenlets. In particular, this handles some cases that previously
-raised ``LoopExit`` or would hang.
+raised ``LoopExit`` or would hang. Note that this may not be reliable
+on PyPy on Windows; such an environment is not currently recommended.
 
 The semaphore tries to avoid creating a hub if it seems unnecessary,
 automatically creating one in the single-threaded case when it would

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -45,9 +45,14 @@ else
     echo "Compiling with -Ofast"
     export CFLAGS="-Ofast $GEVENT_WARNFLAGS"
 fi
-# Needed for clock_gettime libc support on this version. This used to be spelled with LDFLAGS,
-# but that is deprecated and produces a warning.
-export LIBS="-lrt"
+# -lrt: Needed for clock_gettime libc support on this version.
+# -pthread: Needed for pthread_atfork (cffi).
+
+# This used to be spelled with LDFLAGS, but that is deprecated and
+# produces a warning on the 2014 image (?). Still needed on the
+# 2010 image.
+export LIBS="-lrt -pthread"
+export LDFLAGS="$LIBS"
 # Be sure that we get the loop we expect by default, and not
 # a fallback loop.
 export GEVENT_LOOP="libev-cext"

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -48,6 +48,9 @@ fi
 # Needed for clock_gettime libc support on this version. This used to be spelled with LDFLAGS,
 # but that is deprecated and produces a warning.
 export LIBS="-lrt"
+# Be sure that we get the loop we expect by default, and not
+# a fallback loop.
+export GEVENT_LOOP="libev-cext"
 
 if [ -d /gevent -a -d /opt/python ]; then
     # Running inside docker
@@ -117,7 +120,10 @@ if [ -d /gevent -a -d /opt/python ]; then
         python -c 'from __future__ import print_function; import gevent; print(gevent, gevent.__version__)'
         python -c 'from __future__ import print_function; from gevent._compat import get_clock_info; print("clock info", get_clock_info("perf_counter"))'
         python -c 'from __future__ import print_function; import greenlet; print(greenlet, greenlet.__version__)'
-        python -c 'from __future__ import print_function; import gevent.core; print("loop", gevent.core.loop)'
+        python -c 'from __future__ import print_function; import gevent.core; print("default loop", gevent.core.loop)'
+        # Other loops we should have
+        GEVENT_LOOP=libuv python -c 'from __future__ import print_function; import gevent.core; print("libuv loop", gevent.core.loop)'
+        GEVENT_LOOP=libev-cffi python -c 'from __future__ import print_function; import gevent.core; print("libev-cffi loop", gevent.core.loop)'
         if [ -z "$GEVENTSETUP_DISABLE_ARES" ]; then
             python -c 'from __future__ import print_function; import gevent.ares; print("ares", gevent.ares)'
         fi

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -324,6 +324,10 @@ class AbstractLinkable(object):
         self._check_and_notify()
         # If we added unswitched greenlets, however, don't add them back to the links yet.
         # We wouldn't be able to call them in this hub anyway.
+        # TODO: Instead of just adding these back to self._links, we should try to detect their
+        # "home" hub and mode the callback to that hub. As it stands, there's a chance that
+        # if no greenlet tries to acquire/release this object in that hub, these objects
+        # will never get to run.
         self._links.extend(unswitched)
 
     def _quiet_unlink_all(self, obj):

--- a/src/gevent/_ffi/loop.py
+++ b/src/gevent/_ffi/loop.py
@@ -763,6 +763,7 @@ class AbstractLoop(object):
             msg += ' fileno=' + repr(fileno)
         #if sigfd is not None and sigfd != -1:
         #    msg += ' sigfd=' + repr(sigfd)
+        msg += ' callbacks=' + str(len(self._callbacks))
         return msg
 
     def fileno(self):

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -51,13 +51,10 @@ cdef class AbstractLinkable(object):
    cpdef unlink(self, callback)
 
    cdef _check_and_notify(self)
-   cdef int _capture_hub(self, bint create) except -1
+   cdef SwitchOutGreenletWithLoop _capture_hub(self, bint create)
    cdef __wait_to_be_notified(self, bint rawlink)
 
    cdef void _quiet_unlink_all(self, obj) # suppress exceptions
-
-   cdef _allocate_lock(self)
-   cdef greenlet _getcurrent(self)
    cdef int _switch_to_hub(self, the_hub) except -1
 
    @cython.nonecheck(False)
@@ -72,3 +69,8 @@ cdef class AbstractLinkable(object):
    cdef _wait_core(self, timeout, catch=*)
    cdef _wait_return_value(self, bint waited, bint wait_success)
    cdef _wait(self, timeout=*)
+
+   # Unreleated utilities
+   cdef _allocate_lock(self)
+   cdef greenlet _getcurrent(self)
+   cdef _get_thread_ident(self)

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -32,6 +32,9 @@ cdef inline void greenlet_init():
 
 cdef void _init()
 
+cdef class _FakeNotifier(object):
+    cdef bint pending
+
 cdef class AbstractLinkable(object):
    # We declare the __weakref__ here in the base (even though
    # that's not really what we want) as a workaround for a Cython
@@ -58,7 +61,7 @@ cdef class AbstractLinkable(object):
    cdef int _switch_to_hub(self, the_hub) except -1
 
    @cython.nonecheck(False)
-   cdef _notify_link_list(self, list links)
+   cdef list _notify_link_list(self, list links)
 
    @cython.nonecheck(False)
    cpdef _notify_links(self, list arrived_while_waiting)

--- a/src/gevent/_gevent_c_semaphore.pxd
+++ b/src/gevent/_gevent_c_semaphore.pxd
@@ -1,7 +1,15 @@
 cimport cython
 
+from gevent._gevent_c_greenlet_primitives cimport SwitchOutGreenletWithLoop
 from gevent._gevent_c_abstract_linkable cimport AbstractLinkable
+from gevent._gevent_c_hub_local cimport get_hub_if_exists
+from gevent._gevent_c_hub_local cimport get_hub_noargs as get_hub
+
 cdef Timeout
+cdef InvalidThreadUseError
+cdef LoopExit
+cdef spawn_raw
+cdef _native_sleep
 
 
 cdef class Semaphore(AbstractLinkable):
@@ -13,9 +21,22 @@ cdef class Semaphore(AbstractLinkable):
     # threadpool uses it
     cpdef _start_notify(self)
     cpdef int wait(self, object timeout=*) except -1000
+    @cython.locals(
+        success=bint,
+        e=Exception,
+        ex=Exception,
+        args=tuple,
+    )
     cpdef bint acquire(self, bint blocking=*, object timeout=*) except -1000
     cpdef __enter__(self)
     cpdef __exit__(self, object t, object v, object tb)
+
+    @cython.locals(
+        hub_for_this_thread=SwitchOutGreenletWithLoop,
+        owning_hub=SwitchOutGreenletWithLoop,
+    )
+    cdef __acquire_from_other_thread(self, tuple args, bint blocking, timeout)
+    cpdef __acquire_from_other_thread_cb(self, list results, bint blocking, timeout, thread_lock)
 
 cdef class BoundedSemaphore(Semaphore):
     cdef readonly int _initial_value

--- a/src/gevent/_semaphore.py
+++ b/src/gevent/_semaphore.py
@@ -16,8 +16,9 @@ __all__ = [
 
 from time import sleep as _native_sleep
 
-from gevent.exceptions import LoopExit
+from gevent._compat import monotonic
 from gevent.exceptions import InvalidThreadUseError
+from gevent.exceptions import LoopExit
 from gevent.timeout import Timeout
 
 def _get_linkable():
@@ -30,7 +31,16 @@ from gevent._hub_local import get_hub_if_exists
 from gevent._hub_local import get_hub
 from gevent.hub import spawn_raw
 
+class _LockReleaseLink(object):
+    __slots__ = (
+        'lock',
+    )
 
+    def __init__(self, lock):
+        self.lock = lock
+
+    def __call__(self, _):
+        self.lock.release()
 
 class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
     """
@@ -61,10 +71,17 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
     .. versionchanged:: 1.5a3
        The low-level ``rawlink`` method (most users won't use this) now automatically
        unlinks waiters before calling them.
+    .. versionchanged:: NEXT
+       Improved support for multi-threaded usage. When multi-threaded usage is detected,
+       instances will no longer create the thread's hub if it's not present.
     """
 
     __slots__ = (
         'counter',
+        # Integer. Set to 0 initially. Set to the ident of the first
+        # thread that acquires us. If we later see a different thread
+        # ident, set to -1.
+        '_multithreaded',
     )
 
     def __init__(self, value=1, hub=None):
@@ -73,6 +90,7 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
             raise ValueError("semaphore initial value must be >= 0")
         super(Semaphore, self).__init__(hub)
         self._notify_all = False
+        self._multithreaded = 0
 
     def __str__(self):
         return '<%s at 0x%x counter=%s _links[%s]>' % (
@@ -176,21 +194,29 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
            the semaphore was acquired, False will be returned. (Note that this can still
            raise a ``Timeout`` exception, if some other caller had already started a timer.)
         """
+        # pylint:disable=too-many-return-statements,too-many-branches
+        # Sadly, the body of this method is rather complicated.
+        if self._multithreaded == 0:
+            self._multithreaded = self._get_thread_ident()
+        elif self._multithreaded != self._get_thread_ident():
+            self._multithreaded = -1
+
         # We conceptually now belong to the hub of the thread that
         # called this, whether or not we have to block. Note that we
         # cannot force it to be created yet, because Semaphore is used
         # by importlib.ModuleLock which is used when importing the hub
         # itself! This also checks for cross-thread issues.
+        invalid_thread_use = None
         try:
             self._capture_hub(False)
         except InvalidThreadUseError as e:
             # My hub belongs to some other thread. We didn't release the GIL/object lock
             # by raising the exception, so we know this is still true.
-            args = e.args
+            invalid_thread_use = e.args
             e = None
             if not self.counter and blocking:
                 # We would need to block. So coordinate with the main hub.
-                return self.__acquire_from_other_thread(args, blocking, timeout)
+                return self.__acquire_from_other_thread(invalid_thread_use, blocking, timeout)
 
         if self.counter > 0:
             self.counter -= 1
@@ -198,6 +224,19 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
 
         if not blocking:
             return False
+
+        if self._multithreaded != -1 and self.hub is None: # pylint:disable=access-member-before-definition
+            self.hub = get_hub() # pylint:disable=attribute-defined-outside-init
+
+        if self.hub is None and not invalid_thread_use:
+            # Someone else is holding us. There's not a hub here,
+            # nor is there a hub in that thread. We'll need to use regular locks.
+            # This will be unfair to yet a third thread that tries to use us with greenlets.
+            return self.__acquire_from_other_thread(
+                (None, None, self._getcurrent(), "NoHubs"),
+                blocking,
+                timeout
+            )
 
         # self._wait may drop both the GIL and the _lock_lock.
         # By the time we regain control, both have been reacquired.
@@ -237,8 +276,13 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
     def __exit__(self, t, v, tb):
         self.release()
 
+    def __add_link(self, link):
+        if not self._notifier:
+            self.rawlink(link)
+        else:
+            self._notifier.args[0].append(link)
+
     def __acquire_from_other_thread(self, ex_args, blocking, timeout):
-        # pylint:disable=too-many-branches
         assert blocking
         # Some other hub owns this object. We must ask it to wake us
         # up. In general, we can't use a Python-level ``Lock`` because
@@ -248,6 +292,9 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
         #
         # So we need to do so in a way that cooperates with *two*
         # hubs. That's what an async watcher is built for.
+        #
+        # Of course, if we don't actually have two hubs, then we must find some other
+        # solution. That involves using a lock.
 
         # We have to take an action that drops the GIL and drops the object lock
         # to allow the main thread (the thread for our hub) to advance.
@@ -255,45 +302,27 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
         hub_for_this_thread = ex_args[1]
         current_greenlet = ex_args[2]
 
-        if hub_for_this_thread is None and timeout is None:
+        if owning_hub is None and hub_for_this_thread is None:
+            return self.__acquire_without_hubs(timeout)
+
+        if hub_for_this_thread is None:
             # Probably a background worker thread. We don't want to create
             # the hub if not needed, and since it didn't exist there are no
             # other greenlets that we could yield to anyway, so there's nothing
             # to block and no reason to try to avoid blocking, so using a native
             # lock is the simplest way to go.
-            thread_lock = self._allocate_lock()
-            thread_lock.acquire()
-            results = []
+            return self.__acquire_using_other_hub(owning_hub, timeout)
 
-            owning_hub.loop.run_callback(
-                spawn_raw,
-                self.__acquire_from_other_thread_cb,
-                results,
-                blocking,
-                timeout,
-                thread_lock)
-
-            # This can't actually do anything until we drop the object lock.
-            self._drop_lock_for_switch_out()
-            # We MUST use a blocking acquire here, or at least be sure we keep going
-            # until we acquire it. If we timed out waiting here,
-            # just before the callback runs, then we would be out of sync.
-            # However, Python 2 has terrible behaviour where lock acquires can't
-            # be interrupted, so we use a spin loop
-            try:
-                while not thread_lock.acquire(0):
-                    _native_sleep(0.005)
-            finally:
-                self._acquire_lock_for_switch_in()
-            return results[0]
-
-        # We either already had a hub, or we wanted a timeout, in which case
-        # we need to use the hub.
-        if hub_for_this_thread is None:
-            hub_for_this_thread = get_hub()
         # We have a hub we don't want to block. Use an async watcher
         # and ask the next releaser of this object to wake us up.
+        return self.__acquire_using_two_hubs(hub_for_this_thread,
+                                             current_greenlet,
+                                             timeout)
 
+    def __acquire_using_two_hubs(self,
+                                 hub_for_this_thread,
+                                 current_greenlet,
+                                 timeout):
         # Allocating and starting the watcher *could* release the GIL.
         # with the libev corcext, allocating won't, but starting briefly will.
         # With other backends, allocating might, and starting might also.
@@ -312,10 +341,7 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
                             assert self.counter >= 0, (self,)
                             return True
 
-                        if not self._notifier:
-                            self.rawlink(send)
-                        else:
-                            self._notifier.args[0].append(send)
+                        self.__add_link(send)
 
                         # Releases the object lock
                         self._switch_to_hub(hub_for_this_thread)
@@ -343,6 +369,76 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
             thread_lock.release()
         return result
 
+    def __acquire_using_other_hub(self, owning_hub, timeout):
+        assert owning_hub is not get_hub_if_exists()
+        thread_lock = self._allocate_lock()
+        thread_lock.acquire()
+        results = []
+
+        owning_hub.loop.run_callback(
+            spawn_raw,
+            self.__acquire_from_other_thread_cb,
+            results,
+            1,       # blocking,
+            timeout, # timeout,
+            thread_lock)
+
+        # We MUST use a blocking acquire here, or at least be sure we keep going
+        # until we acquire it. If we timed out waiting here,
+        # just before the callback runs, then we would be out of sync.
+        self.__spin_on_native_lock(thread_lock, None)
+        return results[0]
+
+    def __acquire_without_hubs(self, timeout):
+        thread_lock = self._allocate_lock()
+        thread_lock.acquire()
+        absolute_expiration = 0
+        begin = 0
+        if timeout:
+            absolute_expiration = monotonic() + timeout
+
+        # Cython won't compile a lambda here
+        link = _LockReleaseLink(thread_lock)
+        while 1:
+            self.__add_link(link)
+            if absolute_expiration:
+                begin = monotonic()
+
+            got_native = self.__spin_on_native_lock(thread_lock, timeout)
+            self._quiet_unlink_all(link)
+            if got_native:
+                if self.acquire(0):
+                    return True
+            if absolute_expiration:
+                now = monotonic()
+                if now >= absolute_expiration:
+                    return False
+                duration = now - begin
+                timeout -= duration
+                if timeout <= 0:
+                    return False
+
+    def __spin_on_native_lock(self, thread_lock, timeout):
+        expiration = 0
+        if timeout:
+            expiration = monotonic() + timeout
+
+        self._drop_lock_for_switch_out()
+        try:
+            # TODO: When timeout is given and the lock supports that
+            # (Python 3), pass that.
+            # Python 2 has terrible behaviour where lock acquires can't
+            # be interrupted, so we use a spin loop
+            while not thread_lock.acquire(0):
+                if expiration and monotonic() >= expiration:
+                    return False
+
+                _native_sleep(0.001)
+            return True
+        finally:
+            self._acquire_lock_for_switch_in()
+
+
 class BoundedSemaphore(Semaphore):
     """
     BoundedSemaphore(value=1) -> BoundedSemaphore
@@ -355,6 +451,10 @@ class BoundedSemaphore(Semaphore):
 
     If not given, *value* defaults to 1.
     """
+
+    __slots__ = (
+        '_initial_value',
+    )
 
     #: For monkey-patching, allow changing the class of error we raise
     _OVER_RELEASE_ERROR = ValueError
@@ -370,7 +470,6 @@ class BoundedSemaphore(Semaphore):
         """
         if self.counter >= self._initial_value:
             raise self._OVER_RELEASE_ERROR("Semaphore released too many times")
-
         counter = Semaphore.release(self)
         # When we are absolutely certain that no one holds this semaphore,
         # release our hub and go back to floating. This assists in cross-thread

--- a/src/gevent/exceptions.py
+++ b/src/gevent/exceptions.py
@@ -36,12 +36,28 @@ class LoopExit(Exception):
 
     """
 
+    @property
+    def hub(self):
+        """
+        The (optional) hub that raised the error.
+
+        .. versionadded:: NEXT
+        """
+        # XXX: Note that semaphore.py does this manually.
+        if len(self.args) == 3: # From the hub
+            return self.args[1]
+
     def __repr__(self):
         # pylint:disable=unsubscriptable-object
         if len(self.args) == 3: # From the hub
             import pprint
-            return "%s\n\tHub: %s\n\tHandles:\n%s" % (
-                self.args[0], self.args[1],
+            return (
+                "%s\n"
+                "\tHub: %s\n"
+                "\tHandles:\n%s"
+            ) % (
+                self.args[0],
+                self.args[1],
                 pprint.pformat(self.args[2])
             )
         return Exception.__repr__(self)

--- a/src/gevent/libev/corecffi.py
+++ b/src/gevent/libev/corecffi.py
@@ -294,6 +294,10 @@ class loop(AbstractLoop):
             libev.ev_timer_stop(self._timer0)
 
     def _setup_for_run_callback(self):
+        # XXX: libuv needs to start the callback timer to be sure
+        # that the loop wakes up and calls this. Our C version doesn't
+        # do this.
+        # self._start_callback_timer()
         self.ref() # we should go through the loop now
 
     def destroy(self):

--- a/src/gevent/testing/__init__.py
+++ b/src/gevent/testing/__init__.py
@@ -93,6 +93,7 @@ from .skipping import skipOnCI
 from .skipping import skipOnPyPy3OnCI
 from .skipping import skipOnPyPy
 from .skipping import skipOnPyPyOnCI
+from .skipping import skipOnPyPyOnWindows
 from .skipping import skipOnPyPy3
 from .skipping import skipIf
 from .skipping import skipUnless

--- a/src/gevent/tests/test__lock.py
+++ b/src/gevent/tests/test__lock.py
@@ -11,6 +11,9 @@ from gevent.tests import test__semaphore
 
 class TestRLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
 
+    # For some reason, the tests are extremely flaky on Python 2.
+    dueling_thread_tests_are_too_flaky = greentest.PY2
+
     def _makeOne(self):
         # If we don't set the hub before returning,
         # there's a potential race condition, if the implementation
@@ -23,6 +26,11 @@ class TestRLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
         #
         # So we deliberately don't set the hub to help test that condition.
         return lock.RLock()
+
+    def assertOneHasNoHub(self, sem):
+        self.assertIsNone(sem._block.hub)
+
+
 
 if __name__ == '__main__':
     greentest.main()

--- a/src/gevent/tests/test__lock.py
+++ b/src/gevent/tests/test__lock.py
@@ -11,9 +11,6 @@ from gevent.tests import test__semaphore
 
 class TestRLockMultiThread(test__semaphore.TestSemaphoreMultiThread):
 
-    # For some reason, the tests are extremely flaky on Python 2.
-    dueling_thread_tests_are_too_flaky = greentest.PY2
-
     def _makeOne(self):
         # If we don't set the hub before returning,
         # there's a potential race condition, if the implementation

--- a/src/gevent/tests/test__semaphore.py
+++ b/src/gevent/tests/test__semaphore.py
@@ -238,13 +238,8 @@ class TestSemaphoreMultiThread(greentest.TestCase):
     def assertOneHasNoHub(self, sem):
         self.assertIsNone(sem.hub, sem)
 
-    dueling_thread_tests_are_too_flaky = False
-
     def test_dueling_threads(self, acquire_args=(), create_hub=None):
         # pylint:disable=too-many-locals,too-many-statements
-
-        if self.dueling_thread_tests_are_too_flaky:
-            self.skipTest("Described as too flaky")
 
         # Threads doing nothing but acquiring and releasing locks, without
         # having any other greenlets to switch to.

--- a/src/gevent/tests/test__semaphore.py
+++ b/src/gevent/tests/test__semaphore.py
@@ -108,6 +108,8 @@ class TestSemaphoreMultiThread(greentest.TestCase):
                 thread_acquired.set()
         return thread_main
 
+    IDLE_ITERATIONS = 5
+
     def _do_test_acquire_in_one_then_another(self,
                                              release=True,
                                              require_thread_acquired_to_finish=False,
@@ -144,7 +146,7 @@ class TestSemaphoreMultiThread(greentest.TestCase):
             # that get run (including time-based) the notifier may or
             # may not be immediately ready to run, so this can take up
             # to two iterations.)
-            for _ in range(3):
+            for _ in range(self.IDLE_ITERATIONS):
                 gevent.idle()
                 if thread_acquired.wait(timing.LARGE_TICK):
                     break
@@ -155,11 +157,12 @@ class TestSemaphoreMultiThread(greentest.TestCase):
             # Spin the loop to be sure that the timeout has a chance to
             # process. Interleave this with something that drops the GIL
             # so the background thread has a chance to notice that.
-            for _ in range(3):
+            for _ in range(self.IDLE_ITERATIONS):
                 gevent.idle()
                 if thread_acquired.wait(timing.LARGE_TICK):
                     break
         thread_acquired.wait(timing.LARGE_TICK * 5)
+
         if require_thread_acquired_to_finish:
             self.assertTrue(thread_acquired.is_set())
         try:

--- a/src/gevent/tests/test__semaphore.py
+++ b/src/gevent/tests/test__semaphore.py
@@ -238,6 +238,7 @@ class TestSemaphoreMultiThread(greentest.TestCase):
     def assertOneHasNoHub(self, sem):
         self.assertIsNone(sem.hub, sem)
 
+    @greentest.skipOnPyPyOnWindows("Flaky there; can't reproduce elsewhere")
     def test_dueling_threads(self, acquire_args=(), create_hub=None):
         # pylint:disable=too-many-locals,too-many-statements
 

--- a/src/gevent/thread.py
+++ b/src/gevent/thread.py
@@ -60,6 +60,7 @@ from gevent._hub_local import get_hub_if_exists
 from gevent.greenlet import Greenlet
 from gevent.lock import BoundedSemaphore
 from gevent.local import local as _local
+from gevent.exceptions import LoopExit
 
 if hasattr(__thread__, 'RLock'):
     assert PY3 or PYPY
@@ -115,7 +116,25 @@ class LockType(BoundedSemaphore):
             if timeout > self._TIMEOUT_MAX:
                 raise OverflowError('timeout value is too large')
 
-        acquired = BoundedSemaphore.acquire(self, blocking, timeout)
+        acquired = BoundedSemaphore.acquire(self, 0)
+        if not acquired and getcurrent() is not get_hub_if_exists() and blocking and not timeout:
+            # If we would block forever, and we're not in the hub, and a trivial non-blocking
+            # check didn't get us the lock, then try to run pending callbacks that might
+            # release the lock.
+            sleep()
+
+        if not acquired:
+            try:
+                acquired = BoundedSemaphore.acquire(self, blocking, timeout)
+            except LoopExit:
+                # Raised when the semaphore was not trivially ours, and we needed
+                # to block. Some other thread presumably owns the semaphore, and there are no greenlets
+                # running in this thread to switch to. So the best we can do is
+                # release the GIL and try again later.
+                if blocking: # pragma: no cover
+                    raise
+                acquired = False
+
         if not acquired and not blocking and getcurrent() is not get_hub_if_exists():
             # Run other callbacks. This makes spin locks works.
             # We can't do this if we're in the hub, which we could easily be:

--- a/src/gevent/thread.py
+++ b/src/gevent/thread.py
@@ -116,24 +116,17 @@ class LockType(BoundedSemaphore):
             if timeout > self._TIMEOUT_MAX:
                 raise OverflowError('timeout value is too large')
 
-        acquired = BoundedSemaphore.acquire(self, 0)
-        if not acquired and getcurrent() is not get_hub_if_exists() and blocking and not timeout:
-            # If we would block forever, and we're not in the hub, and a trivial non-blocking
-            # check didn't get us the lock, then try to run pending callbacks that might
-            # release the lock.
-            sleep()
 
-        if not acquired:
-            try:
-                acquired = BoundedSemaphore.acquire(self, blocking, timeout)
-            except LoopExit:
-                # Raised when the semaphore was not trivially ours, and we needed
-                # to block. Some other thread presumably owns the semaphore, and there are no greenlets
-                # running in this thread to switch to. So the best we can do is
-                # release the GIL and try again later.
-                if blocking: # pragma: no cover
-                    raise
-                acquired = False
+        try:
+            acquired = BoundedSemaphore.acquire(self, blocking, timeout)
+        except LoopExit:
+            # Raised when the semaphore was not trivially ours, and we needed
+            # to block. Some other thread presumably owns the semaphore, and there are no greenlets
+            # running in this thread to switch to. So the best we can do is
+            # release the GIL and try again later.
+            if blocking: # pragma: no cover
+                raise
+            acquired = False
 
         if not acquired and not blocking and getcurrent() is not get_hub_if_exists():
             # Run other callbacks. This makes spin locks works.

--- a/src/gevent/util.py
+++ b/src/gevent/util.py
@@ -162,7 +162,6 @@ def _format_thread_info(lines, thread_stacks, limit, current_thread_ident):
     import threading
 
     threads = {th.ident: th for th in threading.enumerate()}
-
     lines.append('*' * 80)
     lines.append('* Threads')
 


### PR DESCRIPTION
I hope this should be far more robust and handle LoopExit and the like better.

Fixes #1698. The supplied test script runs correctly, as do some permutations of it I tested. I added all those permutations to the test suite.

We now explicitly detect and handle a variety of cases:

- Using the lock from more than one thread, ever.
- Held by one thread, wanting to block in another thread, when there are:
* 0 hubs
* 1 hub
* 2 hubs

Only Semaphore now handles this. It turned out that trying to do it in the middle of `_wait` didn't safely work without the knowledge of the object involved. So the half-baked support that was inherited by, e.g., `Event` for the simple case (which probably never worked anyway) is now gone. Still, there's something that could be generalized there eventually if needed.

Incidentally fixes a build issue with the manylinux wheels I found during this process.