### PR TITLE
Fix #1663 by more gracefully handling non-type arguments.

### DIFF
--- a/docs/changes/1663.bugfix
+++ b/docs/changes/1663.bugfix
@@ -1,0 +1,3 @@
+Incorrectly passing an exception *instance* instead of an exception
+*type* to `gevent.Greenlet.kill` or `gevent.killall` no longer prints
+an exception to stderr.

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -223,6 +223,12 @@ class AbstractLinkable(object):
         # links in order. Lets the ``links`` list be mutated,
         # and only notifies up to the last item in the list, in case
         # objects are added to it.
+        if not links:
+            # HMM. How did we get here? Running two threads at once?
+            # Seen once on Py27/Win/Appveyor
+            # https://ci.appveyor.com/project/jamadden/gevent/builds/36875645/job/9wahj9ft4h4qa170
+            return []
+
         only_while_ready = not self._notify_all
         final_link = links[-1]
         done = set() # of ids


### PR DESCRIPTION
The documentation specifically says that kill, killall, etc, all take a a type, but
allow passing exception instances.

Also allow passing arbitrary objects; this is also not documented, and not recommended.
The result will be raising a BaseException in the greenlet. That should be better than
silently printing something to stderr, which is what happened before.