### PR TITLE
Make gevent.pywsgi stop dealing with chunks when the connection is being upgraded

### DIFF
--- a/docs/changes/1712.bugfix
+++ b/docs/changes/1712.bugfix
@@ -1,0 +1,7 @@
+Make `gevent.pywsgi` trying to enforce the rules for reading chunked input or
+``Content-Length`` terminated input when the connection is being
+upgraded, for example to a websocket connection. Likewise, if the
+protocol was switched by returning a ``101`` status, stop trying to
+automatically chunk the responses.
+
+Reported by Kavindu Santhusa.


### PR DESCRIPTION
Let the application have full control over input and output.

Fixes #1712.