### PR TITLE
Refactor _socket2/_socket3 to move more truly common methods into SocketMixin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
       - name: Enable emulation
         run: |
           docker run --rm --privileged hypriot/qemu-register
+        # This one was seen in pyca/bcrypt. What's the difference?
+        # (Other than this one not working.)
+        #run: |
+        #  docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - name: Build and test gevent
         # Skip the bulk of the tests, running them emulated on arm takes
         # forever. Likewise, don't build or even configure c-ares; in the emulated platform
@@ -275,7 +279,7 @@ jobs:
           python -c 'import gevent.ares; print(gevent.ares)'
           ccache -s
       - name: Lint (Python 3.9)
-        if: ${{ matrix.python-version == 3.9 }}
+        if: matrix.python-version == 3.9 && startsWith(runner.os, 'Linux')
         # We only need to do this on one version, and it should be Python 3, because
         # pylint has stopped updating for Python 2.
         # We do this here rather than a separate job to avoid the compilation overhead.

--- a/docs/api/gevent._socket2.rst
+++ b/docs/api/gevent._socket2.rst
@@ -2,5 +2,10 @@
  :mod:`gevent._socket2` -- Python 2 socket module
 ==================================================
 
+.. caution:: Some of the docstrings are automatically generated and
+             may be correct for Python 3 but not Python 2. Please see
+             the standard library documentation.
+
 .. automodule:: gevent._socket2
     :members:
+    :inherited-members:

--- a/docs/api/gevent._socket3.rst
+++ b/docs/api/gevent._socket3.rst
@@ -4,3 +4,4 @@
 
 .. automodule:: gevent._socket3
     :members:
+    :inherited-members:

--- a/docs/api/gevent.socket.rst
+++ b/docs/api/gevent.socket.rst
@@ -52,6 +52,8 @@ Python 2 and Python 3, respectively.
        standard library sockets never have.
 
 
+
+
 .. toctree::
 
    Python 3 interface <gevent._socket3>

--- a/docs/changes/1724.bugfix
+++ b/docs/changes/1724.bugfix
@@ -2,3 +2,6 @@ Remove the ``__dict__`` attribute from `gevent.socket.socket` objects. The
 standard library socket do not have a ``__dict__``.
 
 Noticed by Carson Ip.
+
+As part of this refactoring, share more common socket code between Python 2
+and Python 3.


### PR DESCRIPTION
This reduces the amount of duplicate code by a substantial amount. That should translate into higher test coverage and confidence.