### PR TITLE
Add loop.run_callback_threadsafe and use it in AbstractLinkable

### DIFF
--- a/docs/api/gevent.hub.rst
+++ b/docs/api/gevent.hub.rst
@@ -30,6 +30,7 @@ All implementations of the loop provide a common minimum interface.
 
 .. autointerface:: gevent._interfaces.ILoop
 .. autointerface:: gevent._interfaces.IWatcher
+.. autointerface:: gevent._interfaces.ICallback
 
 Utilities
 =========

--- a/docs/changes/1739.misc
+++ b/docs/changes/1739.misc
@@ -1,4 +1,4 @@
-Make ``AsyncResult`` print a warning when it detects improper
+Make ``gevent.event.AsyncResult`` print a warning when it detects improper
 cross-thread usage instead of hanging.
 
 ``AsyncResult`` has *never* been safe to use from multiple threads.
@@ -18,4 +18,8 @@ are still possible, especially under PyPy 7.3.3.
 At the same time, ``AsyncResult`` is tuned to behave more like it did
 in older versions, meaning that the hang is once again much less
 likely. If you were getting lucky and using ``AsyncResult``
-successfully across threads, this may restore your luck.
+successfully across threads, this may restore your luck. In addition,
+cross-thread wakeups are faster. Note that the gevent hub now uses an
+extra file descriptor to implement this.
+
+Similar changes apply to ``gevent.event.Event`` (see :issue:`1735`).

--- a/setup.py
+++ b/setup.py
@@ -406,6 +406,7 @@ def run_setup(ext_modules):
             'docs': [
                 'repoze.sphinx.autointerface',
                 'sphinxcontrib-programoutput',
+                'zope.schema',
             ],
             # To the extent possible, we should work to make sure
             # our tests run, at least a basic set, without any of

--- a/src/gevent/_ffi/callback.py
+++ b/src/gevent/_ffi/callback.py
@@ -1,10 +1,16 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
+from __future__ import print_function
+
+from zope.interface import implementer
+
+from gevent._interfaces import ICallback
 
 __all__ = [
     'callback',
 ]
 
 
+@implementer(ICallback)
 class callback(object):
 
     __slots__ = ('callback', 'args')

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -69,6 +69,7 @@ cdef class AbstractLinkable(object):
    @cython.nonecheck(False)
    cpdef _notify_links(self, list arrived_while_waiting)
 
+   @cython.locals(hub=SwitchOutGreenletWithLoop)
    cdef _handle_unswitched_notifications(self, list unswitched)
    cdef __print_unswitched_warning(self, link, bint printed_tb)
 

--- a/src/gevent/_semaphore.py
+++ b/src/gevent/_semaphore.py
@@ -405,7 +405,7 @@ class Semaphore(AbstractLinkable): # pylint:disable=undefined-variable
         thread_lock.acquire()
         results = []
 
-        owning_hub.loop.run_callback(
+        owning_hub.loop.run_callback_threadsafe(
             spawn_raw,
             self.__acquire_from_other_thread_cb,
             results,

--- a/src/gevent/libev/corecffi.py
+++ b/src/gevent/libev/corecffi.py
@@ -284,6 +284,7 @@ class loop(AbstractLoop):
         libev.ev_timer_start(self._ptr, self._timer0)
 
     def _stop_aux_watchers(self):
+        super(loop, self)._stop_aux_watchers()
         if libev.ev_is_active(self._prepare):
             self.ref()
             libev.ev_prepare_stop(self._ptr, self._prepare)

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -334,6 +334,7 @@ class loop(AbstractLoop):
 
 
     def _stop_aux_watchers(self):
+        super(loop, self)._stop_aux_watchers()
         assert self._prepare
         assert self._check
         assert self._signal_idle
@@ -456,7 +457,8 @@ class loop(AbstractLoop):
         pass
 
     def break_(self, how=None):
-        libuv.uv_stop(self.ptr)
+        if self.ptr:
+            libuv.uv_stop(self.ptr)
 
     def reinit(self):
         # TODO: How to implement? We probably have to simply

--- a/src/gevent/tests/test__hub.py
+++ b/src/gevent/tests/test__hub.py
@@ -337,6 +337,24 @@ class TestLoopInterface(unittest.TestCase):
 
         verify.verifyObject(ILoop, loop)
 
+    def test_callback_implements_ICallback(self):
+        from gevent.testing import verify
+        from gevent._interfaces import ICallback
+
+        loop = get_hub().loop
+
+        cb = loop.run_callback(lambda: None)
+        verify.verifyObject(ICallback, cb)
+
+    def test_callback_ts_implements_ICallback(self):
+        from gevent.testing import verify
+        from gevent._interfaces import ICallback
+
+        loop = get_hub().loop
+
+        cb = loop.run_callback_threadsafe(lambda: None)
+        verify.verifyObject(ICallback, cb)
+
 
 class TestHandleError(unittest.TestCase):
 


### PR DESCRIPTION
This makes cross-thread wakeups of Event and AsyncResult objects much faster and doesn't rely on the target loop spinning as this wakes it up.

Add tests for this.

Fixes #1735