### PR TITLE
Fix build for IBM i (remove libperfstat linking)

### DIFF
--- a/src/gevent/libuv/_corecffi_build.py
+++ b/src/gevent/libuv/_corecffi_build.py
@@ -272,7 +272,8 @@ elif sys.platform.startswith('sunos'): # pragma: no cover
         _define_macro('SUNOS_NO_IFADDRS', '')
 elif sys.platform.startswith('aix'): # pragma: no cover
     _define_macro('_LINUX_SOURCE_COMPAT', 1)
-    _add_library('perfstat')
+    if os.uname().sysname != 'OS400':
+        _add_library('perfstat')
 elif WIN:
     _define_macro('_GNU_SOURCE', 1)
     _define_macro('WIN32', 1)


### PR DESCRIPTION
IBM i is an AIX derivative and even identifies 'AIX` in `sys.platform`. 
However, IBM i does not have or use a `perfstat` library, so builds got broken here: https://github.com/gevent/gevent/commit/b9ed4e2130d9b15a9d040f1346a76aeb80c038fa