### PR TITLE
manylinux: disable -ffast-math

### DIFF
--- a/docs/changes/1820.misc
+++ b/docs/changes/1820.misc
@@ -1,0 +1,3 @@
+Stop compiling manylinux wheels with ``-ffast-math.`` This was
+implicit in ``-Ofast``, but could alter the global state of the
+process. Analysis and fix thanks to Ilya Konstantinov.

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -43,7 +43,9 @@ if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTI
     SLOW_ARM=1
 else
     echo "Compiling with -Ofast"
-    export CFLAGS="-Ofast $GEVENT_WARNFLAGS"
+    # Note: -Ofast includes -ffast-math which affects process-wide floating-point flags (e.g. can affect numpy).
+    #       We opt out of -ffast-math explicitly. Other libraries can still trigger it.
+    export CFLAGS="-Ofast -fno-fast-math $GEVENT_WARNFLAGS"
 fi
 # -lrt: Needed for clock_gettime libc support on this version.
 # -pthread: Needed for pthread_atfork (cffi).


### PR DESCRIPTION
This code runs in under 1 second:
```python
import scipy.stats
import numpy as np

scipy.stats.skellam.sf(np.arange(100), 3.752321119795838e-06, 0.000001)
```

but if you import `gevent`
```python
import gevent
scipy.stats.skellam.sf(np.arange(100), 3.752321119795838e-06, 0.000001)
```
then it takes many seconds to complete.

I don't entirely understand the culprit, i.e. how it affects the execution of scipy's Fortran code. From randomly breaking with gdb, in the 2nd case, the scipy code doesn't seem to use `libm`. I've narrowed it down to gevent being compiled with `-ffast-math` (due to `-Ofast`, introduced in 59478ebb12384403932125d9ffefea4413840ca6, first released in 20.6) and thus changing process-wide floating point flags. The change happens immediately when gevent's shared libraries are loaded, since the C runtime's `set_fast_math` code is set to run as a [library constructor](https://github.com/gcc-mirror/gcc/blob/ec0124e0acb556cdf5dba0e8d0ca6b69d9537fcc/libgcc/config/i386/crtfastmath.c#L82).

I've checked it by running the following function after `import gevent` to "fix" the problem:
```c
void set_slow_math()
{
  unsigned int mxcsr = __builtin_ia32_stmxcsr ();
  // inverse of https://github.com/gcc-mirror/gcc/blob/master/libgcc/config/i386/crtfastmath.c#L94-L96
  mxcsr &= ~(MXCSR_DAZ | MXCSR_FTZ);
  __builtin_ia32_ldmxcsr (mxcsr);
}
```