### PR TITLE
docs(dev): Removes no-longer useful warning about pep 19.1

### DIFF
--- a/docs/development/getting_started.rst
+++ b/docs/development/getting_started.rst
@@ -51,11 +51,6 @@ can be done in one line by installing the ``dev-requirements.txt`` file::
 
   (gevent-env) $ pip install -r dev-requirements.txt
 
-.. warning::
-
-   This pip command does not work with pip 19.1. Either use pip 19.0
-   or below, or use pip 19.1.1 with ``--no-use-pep517``. See `issue
-   1412 <https://github.com/gevent/gevent/issues/1412>`_.
 
 Making Changes
 ==============


### PR DESCRIPTION
The underlying issue is fixed in pip v21 (at least) and it is reasonable
to expect people to be on some good-working pip version now.

The warning is also a false-negative/misleading when you're looking at
install and deps issues as it wastes time, suggesting pip is the issue.