### PR TITLE
Force "fork" multiprocessing context for test__core_fork

### DIFF
--- a/src/gevent/tests/test__core_fork.py
+++ b/src/gevent/tests/test__core_fork.py
@@ -39,10 +39,13 @@ class Test(unittest.TestCase):
         hub.threadpool.apply(lambda: None)
         self.assertEqual(hub.threadpool.size, 1)
 
+        # Force "fork" context in case the system default was different.
+        mp = multiprocessing.get_context("fork")
+
         # If the Queue is global, q.get() hangs on Windows; must pass as
         # an argument.
-        q = multiprocessing.Queue()
-        p = multiprocessing.Process(target=in_child, args=(q,))
+        q = mp.Queue()
+        p = mp.Process(target=in_child, args=(q,))
         p.start()
         p.join()
         p_val = q.get()


### PR DESCRIPTION
Use the "fork" multiprocessing context explicitly within test__core_fork
as the test does not work correctly when using the "spawn" context.
The latter is likely to become the default in PyPy3.9 due to the issues
that the "fork" method causes with threading.