### PR TITLE
manylinux: Truly disable the effect of -Ofast/-ffast-math

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ env:
   # These are shared between GCC and clang so it must be a minimal set.
   # TODO: Figure out how to set env vars per platform without resorting to inline scripting.
   # Note that changing the value of these variables invalidates configure caches
-  CFLAGS: -Ofast -pipe -Wno-strict-aliasing -Wno-comment
+  CFLAGS: -O3 -pipe -Wno-strict-aliasing -Wno-comment
   CPPFLAGS: -DEV_VERIFY=1
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,7 +64,7 @@ install () {
         mkdir -p $BASE/versions
         update_pyenv $VERSION
         # -Ofast makes the build take too long and times out Travis. It also affects
-        # process-wide floating-point flags - see: scripts/releases/make-manylinux
+        # process-wide floating-point flags - see: https://github.com/gevent/gevent/pull/1864
         CFLAGS="-O1 -pipe -march=native" $BASE/pyenv/plugins/python-build/bin/python-build $VERSION $DESTINATION
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,8 @@ install () {
         mkdir -p $SNAKEPIT
         mkdir -p $BASE/versions
         update_pyenv $VERSION
-        # -Ofast makes the build take too long and times out Travis.
+        # -Ofast makes the build take too long and times out Travis. It also affects
+        # process-wide floating-point flags - see: scripts/releases/make-manylinux
         CFLAGS="-O1 -pipe -march=native" $BASE/pyenv/plugins/python-build/bin/python-build $VERSION $DESTINATION
     fi
 

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -36,8 +36,8 @@ export CCACHE_DIR="/ccache"
 GEVENT_WARNFLAGS="-Wno-strict-aliasing -Wno-comment -Wno-unused-value -Wno-unused-but-set-variable -Wno-sign-compare -Wno-parentheses -Wno-unused-function -Wno-tautological-compare -Wno-strict-prototypes -Wno-return-type -Wno-misleading-indentation"
 OPTIMIZATION_FLAGS="-pipe"
 if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTIONS" ]; then
-    # Compiling with -Ofast on the arm emulator takes hours. The default settings have -O3,
-    # and adding -Os doesn't help much. So maybe -O1 will.
+    # Compiling with -Ofast is a no-go because of the regression it causes (#1864).
+    # The default settings have -O3, and adding -Os doesn't help much. So maybe -O1 will.
     echo "Compiling with -O1"
     OPTIMIZATION_FLAGS="-pipe -O1"
     SLOW_ARM=1

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -43,14 +43,6 @@ if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTI
     SLOW_ARM=1
 else
     echo "Compiling with -O3"
-    # Caution against using -Ofast:
-    # -Ofast includes -ffast-math which affects process-wide floating-point flags (e.g. can affect numpy).
-    # -fno-fast-math disables *some* features of -ffast-math, but as long as -Ofast is specified,
-    # it still affects floating-point flags:
-    # https://github.com/gcc-mirror/gcc/blob/releases/gcc-11.2.0/gcc/config/i386/gnu-user-common.h#L50
-    #
-    # We *could* turn on other flags that are included in -Ofast individually, but for gevent's usecase, it's not
-    # a priority to enable aggressive optimizations at the expense of possibly violating language standards.
     OPTIMIZATION_FLAGS="-pipe -O3"
 fi
 export CFLAGS="$OPTIMIZATION_FLAGS $GEVENT_WARNFLAGS"

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -42,10 +42,16 @@ if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTI
     export CFLAGS="-O1 $GEVENT_WARNFLAGS"
     SLOW_ARM=1
 else
-    echo "Compiling with -Ofast"
-    # Note: -Ofast includes -ffast-math which affects process-wide floating-point flags (e.g. can affect numpy).
-    #       We opt out of -ffast-math explicitly. Other libraries can still trigger it.
-    export CFLAGS="-Ofast -fno-fast-math $GEVENT_WARNFLAGS"
+    echo "Compiling with -O3"
+    # Caution against using -Ofast:
+    # -Ofast includes -ffast-math which affects process-wide floating-point flags (e.g. can affect numpy).
+    # -fno-fast-math disables *some* features of -ffast-math, but as long as -Ofast is specified,
+    # it still affects floating-point flags:
+    # https://github.com/gcc-mirror/gcc/blob/releases/gcc-11.2.0/gcc/config/i386/gnu-user-common.h#L50
+    #
+    # We *could* turn on other flags that are included in -Ofast individually, but for gevent's usecase, it's not
+    # a priority to enable aggressive optimizations at the expense of possibly violating language standards.
+    export CFLAGS="-O3 $GEVENT_WARNFLAGS"
 fi
 # -lrt: Needed for clock_gettime libc support on this version.
 # -pthread: Needed for pthread_atfork (cffi).

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -33,13 +33,13 @@ export BUILD_LIBS=$HOME/.libs
 export CCACHE_DIR="/ccache"
 # Disable some warnings produced by libev especially and also some Cython generated code.
 # Note that changing the value of these variables invalidates configure caches
-GEVENT_WARNFLAGS="-pipe -Wno-strict-aliasing -Wno-comment -Wno-unused-value -Wno-unused-but-set-variable -Wno-sign-compare -Wno-parentheses -Wno-unused-function -Wno-tautological-compare -Wno-strict-prototypes -Wno-return-type -Wno-misleading-indentation"
-export CFLAGS="$GEVENT_WARNFLAGS"
+GEVENT_WARNFLAGS="-Wno-strict-aliasing -Wno-comment -Wno-unused-value -Wno-unused-but-set-variable -Wno-sign-compare -Wno-parentheses -Wno-unused-function -Wno-tautological-compare -Wno-strict-prototypes -Wno-return-type -Wno-misleading-indentation"
+OPTIMIZATION_FLAGS="-pipe"
 if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTIONS" ]; then
     # Compiling with -Ofast on the arm emulator takes hours. The default settings have -O3,
     # and adding -Os doesn't help much. So maybe -O1 will.
     echo "Compiling with -O1"
-    export CFLAGS="-O1 $GEVENT_WARNFLAGS"
+    OPTIMIZATION_FLAGS="-pipe -O1"
     SLOW_ARM=1
 else
     echo "Compiling with -O3"
@@ -51,8 +51,9 @@ else
     #
     # We *could* turn on other flags that are included in -Ofast individually, but for gevent's usecase, it's not
     # a priority to enable aggressive optimizations at the expense of possibly violating language standards.
-    export CFLAGS="-O3 $GEVENT_WARNFLAGS"
+    OPTIMIZATION_FLAGS="-pipe -O3"
 fi
+export CFLAGS="$OPTIMIZATION_FLAGS $GEVENT_WARNFLAGS"
 # -lrt: Needed for clock_gettime libc support on this version.
 # -pthread: Needed for pthread_atfork (cffi).
 

--- a/src/gevent/testing/__init__.py
+++ b/src/gevent/testing/__init__.py
@@ -66,6 +66,9 @@ from .sysinfo import PY2
 from .sysinfo import PY3
 from .sysinfo import PY36
 from .sysinfo import PY37
+from .sysinfo import PY38
+from .sysinfo import PY39
+from .sysinfo import PY310
 
 from .sysinfo import PYPY
 from .sysinfo import PYPY3

--- a/src/gevent/tests/test__issue1864.py
+++ b/src/gevent/tests/test__issue1864.py
@@ -1,0 +1,21 @@
+import math
+import unittest
+
+from gevent.testing import PY39
+
+
+class TestSubnormalFloatsAreNotDisabled(unittest.TestCase):
+    """
+    Enabling the -Ofast compiler flag resulted in subnormal floats getting
+    disabled the moment when gevent was imported. This impacted libraries
+    that expect subnormal floats to be enabled.
+    """
+    @unittest.skipUnless(PY39, "Need math.nextafter()")
+    def test_subnormal_is_not_zero(self):
+        import gevent
+
+        assert math.nextafter(0, 1) != 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/gevent/tests/test__issue1864.py
+++ b/src/gevent/tests/test__issue1864.py
@@ -1,7 +1,5 @@
-import math
+import sys
 import unittest
-
-from gevent.testing import PY39
 
 
 class TestSubnormalFloatsAreNotDisabled(unittest.TestCase):
@@ -10,11 +8,13 @@ class TestSubnormalFloatsAreNotDisabled(unittest.TestCase):
     disabled the moment when gevent was imported. This impacted libraries
     that expect subnormal floats to be enabled.
     """
-    @unittest.skipUnless(PY39, "Need math.nextafter()")
     def test_subnormal_is_not_zero(self):
         import gevent
 
-        assert math.nextafter(0, 1) != 0
+        # `sys.float_info.min` is the minimum representable positive normalized
+        # float, so dividing it by two gives us a positive subnormal float,
+        # as long as subnormals floats are not disabled.
+        assert (sys.float_info.min / 2) > 0
 
 
 if __name__ == "__main__":

--- a/src/gevent/tests/tests_that_dont_do_leakchecks.txt
+++ b/src/gevent/tests/tests_that_dont_do_leakchecks.txt
@@ -7,3 +7,4 @@ test__close_backend_fd.py
 test__hub_join.py
 test__hub_join_timeout.py
 test__issue112.py
+test__issue1864.py

--- a/src/gevent/tests/tests_that_dont_monkeypatch.txt
+++ b/src/gevent/tests/tests_that_dont_monkeypatch.txt
@@ -15,6 +15,7 @@ test__examples.py
 test__getaddrinfo_import.py
 test__hub_join.py
 test__hub_join_timeout.py
+test__issue1864.py
 test__issue330.py
 test__iwait.py
 test__monkey_scope.py

--- a/src/gevent/tests/tests_that_dont_use_resolver.txt
+++ b/src/gevent/tests/tests_that_dont_use_resolver.txt
@@ -34,6 +34,7 @@ test__hub_join.py
 test__hub_join_timeout.py
 # uses socket test__hub.py
 test__issue112.py
+test__issue1864.py
 test__joinall.py
 test__local.py
 test__loop_callback.py


### PR DESCRIPTION
## Context
Commit history and issue history leading up to this PR:

- https://github.com/gevent/gevent/commit/59478ebb12384403932125d9ffefea4413840ca6 added `-Ofast` to `CFLAGS`
- #1820 added `-fno-fast-math` to `CFLAGS` in order to prevent process-wide floating-point flags from being set as an effect of `-Ofast`, which enables `-ffast-math`
- It was discovered in https://github.com/HypothesisWorks/hypothesis/issues/3092 that importing gevent still enables the floating-point flags

## Minimally reproducible example

Running `mxcsr_test/test.sh` from my [sscce-no-fast-math branch](https://github.com/ento/gevent/compare/master...sscce-no-fast-math) prints the status of floating-point flags after importing gevent (version 21.12.0):

```
$ ./test.sh
Requirement already satisfied: gevent==21.12.0 in ./env/lib/python3.10/site-packages (from -r requirements.txt (line 1)) (21.12.0)
Requirement already satisfied: zope.interface in ./env/lib/python3.10/site-packages (from gevent==21.12.0->-r requirements.txt (line 1)) (5.4.0)
Requirement already satisfied: setuptools in ./env/lib/python3.10/site-packages (from gevent==21.12.0->-r requirements.txt (line 1)) (56.0.0)
Requirement already satisfied: greenlet<2.0,>=1.1.0 in ./env/lib/python3.10/site-packages (from gevent==21.12.0->-r requirements.txt (line 1)) (1.1.2)
Requirement already satisfied: zope.event in ./env/lib/python3.10/site-packages (from gevent==21.12.0->-r requirements.txt (line 1)) (4.5.0)
running build_ext
copying build/lib.linux-x86_64-3.10/mxcsr.cpython-310-x86_64-linux-gnu.so -> 
daz_enabled=True
ftz_enabled=True
Did not expect DAZ nor FTZ to be enabled
```

## Why does not `-fno-fast-math` take effect?

gcc's [crtfastmath.c](https://github.com/gcc-mirror/gcc/blob/releases/gcc-11.2.0/libgcc/config/i386/crtfastmath.c#L95-L96) is the code responsible for enabling the floating-point flags, and it appears to be that it gets linked whenever `-Ofast`, `-ffast-math`, or `-funsafe-math-optimizations` is specified: https://github.com/gcc-mirror/gcc/blob/releases/gcc-11.2.0/gcc/config/i386/gnu-user-common.h#L50

Running `cd gcc_test; make; cat result.txt` in my [sscce-no-fast-math branch](https://github.com/ento/gevent/compare/master...sscce-no-fast-math) demonstrates that `-fno-fast-math` cancels out `-ffast-math` but not `-Ofast` when it comes to preventing `crtfastmath.c` from being linked.

```
$ cat result.txt 
./check_ofast
DAZ enabled: yes
FTZ enabled: yes
./check_fm
DAZ enabled: yes
FTZ enabled: yes
./check_ofast_nofm
DAZ enabled: yes
FTZ enabled: yes
./check_fm_nofm
DAZ enabled: no
FTZ enabled: no
./check_ofast_fm_nofm
DAZ enabled: yes
FTZ enabled: yes
```

`./check_ofast` is an executable compiled with `-Ofast`, `./check_fm` with `-ffast-math`, `./check_ofast_nofm` with `-Ofast -fno-fast-math`, and so on.

## This PR's changes

From gcc's documentation: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

> -Ofast [..] enables optimizations that are not valid for all standard-compliant programs
 
The commit that introduced `-Ofast`, 59478ebb12384403932125d9ffefea4413840ca6, only mentions build time, and enabling this level of optimization that can break standard-compliance didn't seem to be the intention. So this PR sets the optimization level to `-O3` to avoid any other unexpected behavior.

The behavior of `-fno-fast-math` described above may be a bug on gcc's end, but I figured we can simply go with `-O3` here.