### PR TITLE
WIP: Fix #1865 by using importlib instead of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,10 +226,9 @@ install_requires = greenlet_requires + CFFI_REQUIRES + [
     # ultimately be published, but at this writing only the event
     # interfaces are.
     'zope.interface',
-    # setuptools is also used (via pkg_resources) for event
-    # notifications. It's a hard dependency of zope.interface
-    # anyway.
-    'setuptools',
+    # Backport of importlib.metadata.entry_points for older version of Python,
+    # lets us avoid deprecated pkg_resources
+    "backports.entry-points-selectable; python_version<'3.10'"
 ]
 
 # We use headers from greenlet, so it needs to be installed before we
@@ -434,6 +433,9 @@ def run_setup(ext_modules):
                 # The backport for contextvars to test patching. It sadly uses the same
                 # import name as the stdlib module.
                 'contextvars == 2.4 ; python_version > "3.0" and python_version < "3.7"',
+
+                # For pkg_resources until we fully switch to importlib
+                'setuptools',
             ],
         },
         # It's always safe to pass the CFFI keyword, even if

--- a/src/gevent/events.py
+++ b/src/gevent/events.py
@@ -63,6 +63,7 @@ __all__ = [
 
 # pylint:disable=no-self-argument,inherit-non-class
 import platform
+import sys
 
 from zope.interface import Interface
 from zope.interface import Attribute
@@ -71,7 +72,10 @@ from zope.interface import implementer
 from zope.event import subscribers
 from zope.event import notify
 
-from pkg_resources import iter_entry_points
+if sys.version_info < (3,10):
+    from backports.entry_points_selectable import entry_points
+else:
+    from importlib.metadata import entry_points
 
 #: Applications may register for notification of events by appending a
 #: callable to the ``subscribers`` list.
@@ -100,7 +104,7 @@ finally:
 
 def notify_and_call_entry_points(event):
     notify(event)
-    for plugin in iter_entry_points(event.ENTRY_POINT_NAME):
+    for plugin in entry_points(group=event.ENTRY_POINT_NAME):
         subscriber = plugin.load()
         subscriber(event)
 


### PR DESCRIPTION
Freezes in #1685 are caused by new versions of `setuptools` (which is imported by `gevent` early on) vendoring `more_itertools`, which imports `concurrent.futures` before it can be monkey-patched.

Setuptools 60.8.2 fixed that import, but `pkg_resources` is deprecated and should be replaced by `importlib` or appropriate backport.

This is the replacement suggested by setuptools maintainers at https://github.com/pypa/setuptools/issues/3090#issuecomment-1033167013 – it uses stdlib on Python 3.10 and a flexible backport in earlier versions. This is supposed to work in all Python versions supported by gevent.

So far, I was only able to test it on Python 3.9 & 3.10 (and confirm that it fixes the freeze with faulty versions of setuptools). It times out in doctests, which doesn't seem related. I'll try to run more tests when I switch to my other computer.

`pkg_resources` is still used in the test suite. I can work on replacing it there too, but I'd love to hear some feedback first.