### PR TITLE
Add Python 3.11 alpha 6 support

### DIFF
--- a/_setuputils.py
+++ b/_setuputils.py
@@ -244,6 +244,10 @@ def cythonize1(ext):
                 'infer_types': True,
                 'nonecheck': False,
             },
+            compile_time_env={
+                'PY39B1': sys.hexversion >= 0x030900B1,
+                'PY311A6': sys.hexversion >= 0x030B00A6,
+            },
             # The common_utility_include_dir (not well documented)
             # causes Cython to emit separate files for much of the
             # static support code. Each of the modules then includes

--- a/deps/greenlet/greenlet.h
+++ b/deps/greenlet/greenlet.h
@@ -14,6 +14,10 @@ extern "C" {
 /* This is deprecated and undocumented. It does not change. */
 #define GREENLET_VERSION "1.0.0"
 
+#if PY_VERSION_HEX < 0x30B00A6
+#  define _PyCFrame CFrame
+#endif
+
 typedef struct _greenlet {
     PyObject_HEAD
     char* stack_start;
@@ -39,7 +43,7 @@ typedef struct _greenlet {
     PyObject* context;
 #endif
 #if PY_VERSION_HEX >= 0x30A00B1
-    CFrame* cframe;
+    _PyCFrame* cframe;
 #endif
 } PyGreenlet;
 

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -58,6 +58,9 @@ locals()['get_generic_parent'] = lambda s: s.parent
 # Frame access
 locals()['get_f_back'] = lambda frame: frame.f_back
 locals()['get_f_lineno'] = lambda frame: frame.f_lineno
+locals()['set_f_lineno'] = lambda frame, lineno: setattr(frame, 'f_lineno', lineno)
+locals()['get_f_code'] = lambda frame: frame.f_code
+locals()['set_f_code'] = lambda frame, code: setattr(frame, 'f_code', code)
 
 if _PYPY:
     import _continuation # pylint:disable=import-error
@@ -157,8 +160,8 @@ def _extract_stack(limit):
         # Arguments are always passed to the constructor as Python objects,
         # meaning we wind up boxing the f_lineno just to unbox it if we pass it.
         # It's faster to simply assign once the object is created.
-        older_Frame.f_code = frame.f_code
-        older_Frame.f_lineno = get_f_lineno(frame) # pylint:disable=undefined-variable
+        set_f_code(older_Frame.f_code, get_f_code(frame))
+        set_f_lineno(older_Frame.f_lineno, get_f_lineno(frame)) # pylint:disable=undefined-variable
         if newer_Frame is not None:
             newer_Frame.f_back = older_Frame
         newer_Frame = older_Frame


### PR DESCRIPTION
* On Python 3.11a6 and newer, get the PyFrameObject structure from
  the internal C API ("internal/pycore_frame.h").
* On Python 3.9 and newer, use PyFrame_GetBack() and
  PyFrame_GetCode().
* Add frame getter and setter functions to greenlet:

  * get_f_code(frame)
  * set_f_lineno(frame, lineno)
  * set_f_code(frame, code)

* greenlet.h: the CFrame type has been renamed to _PyCFrame.