### PR TITLE
Improve format run info

### DIFF
--- a/src/gevent/util.py
+++ b/src/gevent/util.py
@@ -97,7 +97,7 @@ def print_run_info(thread_stacks=True, greenlet_stacks=True, limit=_NONE, file=N
     lines = format_run_info(thread_stacks=thread_stacks,
                             greenlet_stacks=greenlet_stacks,
                             limit=limit,
-									 include_ready=include_ready)
+                            include_ready=include_ready)
     file = sys.stderr if file is None else file
     for l in lines:
         print(l, file=file)
@@ -107,7 +107,7 @@ def format_run_info(thread_stacks=True,
                     greenlet_stacks=True,
                     limit=_NONE,
                     current_thread_ident=None,
-						  include_ready=True):
+                    include_ready=True):
     """
     format_run_info(thread_stacks=True, greenlet_stacks=True, limit=None) -> [str]
 


### PR DESCRIPTION
This adds `include_ready` parameter to format_run_info() etc so that the dump can exclude greenlets that are ready. Also, changed the output from labeling such greenlets as `; finished` to labeling them `; ready (finished)` since the code's terminology for a finished greenlet is that it is "ready". Also, the dummy function `_ready()` is renamed `_return_false()` to better self-document its purpose.