### PR TITLE
Fix Intel compiler deprecated options

### DIFF
--- a/deps/c-ares/configure
+++ b/deps/c-ares/configure
@@ -21736,8 +21736,8 @@ squeeze() {
       INTEL_UNIX_C)
         #
                         tmp_CFLAGS="$tmp_CFLAGS -std=gnu89"
-                                                tmp_CPPFLAGS="$tmp_CPPFLAGS -we 140,147,165,266"
-                                        tmp_CPPFLAGS="$tmp_CPPFLAGS -wd 279,981,1469"
+                                                tmp_CPPFLAGS="$tmp_CPPFLAGS -diag-error 140,147,165,266"
+                                        tmp_CPPFLAGS="$tmp_CPPFLAGS -diag-disable 279,981,1469"
         ;;
         #
       INTEL_WINDOWS_C)


### PR DESCRIPTION
Options `-we ###` and `-wd ###` should not include a whitespace. They are also deprecated and `-diag-error` and `-diag-disable` are their replacements. 
Intel compiler 2021.6 is not able to be used in configure without the proposed patch.