### PR TITLE
Stop building with -Ofast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ env:
   # These are shared between GCC and clang so it must be a minimal set.
   # TODO: Figure out how to set env vars per platform without resorting to inline scripting.
   # Note that changing the value of these variables invalidates configure caches
-  CFLAGS: -Ofast -pipe -Wno-strict-aliasing -Wno-comment
+  CFLAGS: -O2 -pipe -Wno-strict-aliasing -Wno-comment
   CPPFLAGS: -DEV_VERIFY=1
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the

--- a/docs/changes/1864.bugfix
+++ b/docs/changes/1864.bugfix
@@ -1,4 +1,4 @@
-Stop bulding with -Ofast to prevent altering the global state of the process with regard
+Stop building with -Ofast to prevent altering the global state of the process with regard
 to floating point precision (see https://simonbyrne.github.io/notes/fastmath/).
 
 (Previous attempt to keep -Ofast while adding -fno-fast-math proved futile, as both

--- a/docs/changes/1864.bugfix
+++ b/docs/changes/1864.bugfix
@@ -1,0 +1,5 @@
+Stop bulding with -Ofast to prevent altering the global state of the process with regard
+to floating point precision (see https://simonbyrne.github.io/notes/fastmath/).
+
+(Previous attempt to keep -Ofast while adding -fno-fast-math proved futile, as both
+on clang and gcc -Ofast would enable "fast math" regardless.)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,6 @@ install () {
         mkdir -p $SNAKEPIT
         mkdir -p $BASE/versions
         update_pyenv $VERSION
-        # -Ofast makes the build take too long and times out Travis.
         CFLAGS="-O1 -pipe -march=native" $BASE/pyenv/plugins/python-build/bin/python-build $VERSION $DESTINATION
     fi
 

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -42,10 +42,8 @@ if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" -a -n "$GITHUB_ACTI
     export CFLAGS="-O1 $GEVENT_WARNFLAGS"
     SLOW_ARM=1
 else
-    echo "Compiling with -Ofast"
-    # Note: -Ofast includes -ffast-math which affects process-wide floating-point flags (e.g. can affect numpy).
-    #       We opt out of -ffast-math explicitly. Other libraries can still trigger it.
-    export CFLAGS="-Ofast -fno-fast-math $GEVENT_WARNFLAGS"
+    echo "Compiling with -O2"
+    export CFLAGS="-O2 $GEVENT_WARNFLAGS"
 fi
 # -lrt: Needed for clock_gettime libc support on this version.
 # -pthread: Needed for pthread_atfork (cffi).


### PR DESCRIPTION
Stop building with `-Ofast` to prevent altering the global state of the process with regard to floating point precision (see https://simonbyrne.github.io/notes/fastmath/).

Previous attempt in https://github.com/gevent/gevent/pull/1820 to keep `-Ofast` while adding `-fno-fast-math` proved futile, as both on gcc and clang ([ref](https://github.com/llvm/llvm-project/blob/fb9fc79809d5c2c3ab8809f7ff98fbfa8c3a9e7e/clang/lib/Driver/ToolChain.cpp#L1038-L1039)) `-Ofast` would enable "fast math" regardless.

```console
$ echo 'int main() {}' > foo.c
$ gcc -Ofast -fno-fast-math -o foo-gcc foo.c
$ clang -Ofast -fno-fast-math -o foo-clang foo.c
```
and then
```console
$ objdump -d foo-clang | grep fast
00000000004003e0 <set_fast_math>:
$ objdump -d foo-gcc | grep fast
00000000004003f0 <set_fast_math>:
```

Closes #1864.