### PR TITLE
Fix various build and test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           pip install -q -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install -q -U 'cffi;platform_python_implementation=="CPython"'
           pip install -q -U 'cython>=3.0a9'
-          pip install 'greenlet>=1.0a1;platform_python_implementation=="CPython"'
+          pip install 'greenlet>=1.0a1,<2;platform_python_implementation=="CPython"'
 
       - name: Build gevent
         run: |
@@ -447,7 +447,7 @@ jobs:
           pip install -q -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install -q -U 'cffi;platform_python_implementation=="CPython"'
           pip install -q -U 'cython>=3.0a5'
-          pip install 'greenlet>=1.0a1;platform_python_implementation=="CPython"'
+          pip install 'greenlet>=1.0a1,<2;platform_python_implementation=="CPython"'
 
       - name: build libs and gevent
         env:

--- a/.pylintrc
+++ b/.pylintrc
@@ -55,6 +55,8 @@ limit-inference-results=1
 # Pylint 2.4 adds self-assigning-variable. But we do *that* to avoid unused-import when we
 # "export" the variable and don't have a __all__.
 # Pylint 2.6+ adds some python-3-only things that don't apply: raise-missing-from, super-with-arguments, consider-using-f-string, redundant-u-string-prefix
+# unnecessary-lambda-assignment: New check introduced in v2.14.0
+# unnecessary-dunder-call: New check introduced in v2.14.0
 disable=wrong-import-position,
     wrong-import-order,
     missing-docstring,
@@ -80,7 +82,9 @@ disable=wrong-import-position,
     raise-missing-from,
     super-with-arguments,
     consider-using-f-string,
-    redundant-u-string-prefix
+    redundant-u-string-prefix,
+    unnecessary-lambda-assignment,
+    unnecessary-dunder-call
 
 [FORMAT]
 # duplicated from setup.cfg

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[MAIN]
+load-plugins=pylint.extensions.bad_builtin
+
 [MASTER]
 extension-pkg-whitelist=gevent.greenlet,gevent.libuv._corecffi,gevent.libev._corecffi,gevent.libev._corecffi.lib,gevent.local,gevent._ident
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -26,7 +26,6 @@ limit-inference-results=1
 
 # invalid-name, ; We get lots of these, especially in scripts. should fix many of them
 # protected-access, ; We have many cases of this; legit ones need to be examinid and commented, then this removed
-# no-self-use, ; common in superclasses with extension points
 # too-few-public-methods, ; Exception and marker classes get tagged with this
 # exec-used, ; should tag individual instances with this, there are some but not too many
 # global-statement,     ; should tag individual instances
@@ -62,7 +61,6 @@ disable=wrong-import-position,
     ungrouped-imports,
     invalid-name,
     protected-access,
-    no-self-use,
     too-few-public-methods,
     exec-used,
     global-statement,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,11 @@ environment:
     # know.
     PIP_NO_PYTHON_VERSION_WARNING: 1
     PIP_UPGRADE_STRATEGY: eager
+    # Stay on the legacy implementation of editable installs.
+    # Recent versions of setuptools has changed how editable installs work,
+    # which broke Appveyor builds.
+    # For a relevant upstream issue, see https://github.com/pypa/setuptools/issues/3557
+    SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
     # Enable this if debugging a resource leak. Otherwise
     # it slows things down.
     # PYTHONTRACEMALLOC: 10

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -66,7 +66,7 @@ __all__ = [
 ]
 
 try:
-    ResourceWarning
+    ResourceWarning # pylint:disable=used-before-assignment
 except NameError:
     class ResourceWarning(Warning):
         "Python 2 fallback"

--- a/src/gevent/_sslgte279.py
+++ b/src/gevent/_sslgte279.py
@@ -47,7 +47,7 @@ __imports__ = copy_globals(__ssl__, globals(),
                            dunder_names_to_keep=())
 
 try:
-    _delegate_methods
+    _delegate_methods # pylint:disable=used-before-assignment
 except NameError: # PyPy doesn't expose this detail
     _delegate_methods = ('recv', 'recvfrom', 'recv_into', 'recvfrom_into', 'send', 'sendto')
 

--- a/src/gevent/local.py
+++ b/src/gevent/local.py
@@ -574,7 +574,7 @@ def _local_find_descriptors(self):
 # (e.g., on PyPy). So we set it at runtime. Cython
 # will raise an error if we're compiled.
 def __new__(cls, *args, **kw):
-    self = super(local, cls).__new__(cls)
+    self = super(local, cls).__new__(cls) # pylint:disable=no-value-for-parameter
     # We get the cls in *args for some reason
     # too when we do it this way....except on PyPy3, which does
     # not *unless* it's wrapped in a classmethod (which it is)

--- a/src/gevent/resolver/dnspython.py
+++ b/src/gevent/resolver/dnspython.py
@@ -270,7 +270,7 @@ class _HostsResolver(object):
         # gethostbyname_ex so it's probably fine.
         aliases = self.hosts_file.aliases
         result = []
-        if hostname in aliases:
+        if hostname in aliases: # pylint:disable=consider-using-get
             cannon = aliases[hostname]
         else:
             cannon = hostname

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -280,7 +280,7 @@ else:
     from gevent.os import fork_and_watch
 
 try:
-    BrokenPipeError
+    BrokenPipeError # pylint:disable=used-before-assignment
 except NameError: # Python 2
     class BrokenPipeError(Exception):
         "Never raised, never caught."

--- a/src/gevent/testing/leakcheck.py
+++ b/src/gevent/testing/leakcheck.py
@@ -127,7 +127,7 @@ class _RefCountChecker(object):
         if 'urlparse' in sys.modules:
             sys.modules['urlparse'].clear_cache()
         if 'urllib.parse' in sys.modules:
-            sys.modules['urllib.parse'].clear_cache()
+            sys.modules['urllib.parse'].clear_cache() # pylint:disable=no-member
 
         return self._growth()
 

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -269,12 +269,14 @@ class TestAsyncResultCrossThread(greentest.TestCase):
                 gevent.get_hub().destroy(destroy_loop=True)
 
         thread = Thread()
+        glet = None
         try:
             glet = gevent.spawn(thread.start)
             result = thread.async_result.wait(self.BG_WAIT_DELAY)
         finally:
             thread.join(DELAY * 15)
-            glet.join(DELAY)
+            if glet is not None:
+                glet.join(DELAY)
         self._check_result(result)
 
     @greentest.ignores_leakcheck

--- a/src/gevent/tests/test__fileobject.py
+++ b/src/gevent/tests/test__fileobject.py
@@ -25,7 +25,7 @@ import gevent.testing as greentest
 from gevent.testing import sysinfo
 
 try:
-    ResourceWarning
+    ResourceWarning # pylint:disable=used-before-assignment
 except NameError:
     class ResourceWarning(Warning):
         "Python 2 fallback"

--- a/src/gevent/tests/test__issue6.py
+++ b/src/gevent/tests/test__issue6.py
@@ -29,7 +29,7 @@ elif sys.argv[1:] == ['subprocess']: # pragma: no cover
         try:
             line = raw_input()
         except NameError:
-            line = input()
+            line = input() # pylint:disable=bad-builtin
         print('%s chars.' % len(line))
         sys.stdout.flush()
 

--- a/src/gevent/tests/test__monkey_select.py
+++ b/src/gevent/tests/test__monkey_select.py
@@ -22,7 +22,7 @@ class TestSelect(greentest.TestCase):
             'kevent',
             'devpoll',
     ):
-        _make_test(name, locals())
+        _make_test(name, locals()) # pylint:disable=too-many-function-args
 
     del name
     del _make_test

--- a/src/gevent/tests/test__selectors.py
+++ b/src/gevent/tests/test__selectors.py
@@ -32,6 +32,7 @@ class SelectorTestMixin(object):
 
     def _check_selector(self, sel):
         server, client = socket.socketpair()
+        glet = None
         try:
             sel.register(server, selectors.EVENT_READ, self.read_from_ready_socket_and_reply)
             glet = gevent.spawn(self.run_selector_once, sel)
@@ -43,8 +44,9 @@ class SelectorTestMixin(object):
             sel.close()
             server.close()
             client.close()
-            glet.join(10)
-        self.assertTrue(glet.ready())
+            if glet is not None:
+                glet.join(10)
+        self.assertTrue(glet is not None and glet.ready())
 
 
 class GeventSelectorTest(SelectorTestMixin,

--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -198,9 +198,9 @@ class TestTCP(greentest.TestCase):
                     # from generating ``ConnectionResetError`` on AppVeyor.
                     try:
                         client = client.unwrap()
-                    except (ValueError, OSError):
-                        # PyPy 3.7 started raising _cffi_ssl._stdssl.error.SSLSyscallError,
-                        # which is an OSError
+                    except (ValueError, IOError, OSError):
+                        # PyPy raises _cffi_ssl._stdssl.error.SSLSyscallError,
+                        # which is an IOError in 2.7 and OSError in 3.7
                         pass
 
                 try:


### PR DESCRIPTION
While working on #1864, I noticed that CI probably won't pass even on the master branch. This PR will hopefully fix all the issues.

* An alpha version of greenlet's next major version has been released. The step that installs greenlet in CI didn't specify an upper limit, and since the alpha version isn't backwards compatible, [builds were failing](https://github.com/ento/gevent/runs/8282988158?check_suite_focus=true)
* Newer versions of pylint has been released, which include things like new checks and changes to extensions that are enabled by default
* PyPy's class hierarchy around SSL-related errors may have changed
* setuptools' new implementation of editable installs broke Appveyor builds it seems

[Appveyor builds were failing](https://ci.appveyor.com/project/ento/gevent/builds/44745934/job/70myi721h3dd98px) from

>  Creating library C:\Users\appveyor\AppData\Local\Temp\1\tmpucf7nr76.build-temp\Release\deps/c-ares/src/lib\cares.cp310-win_amd64.lib and object C:\Users\appveyor\AppData\Local\Temp\1\tmpucf7nr76.build-temp\Release\deps/c-ares/src/lib\cares.cp310-win_amd64.exp
>  ares__addrinfo_localhost.obj : error LNK2001: unresolved external symbol __imp_FreeMibTable
>  ares__addrinfo_localhost.obj : error LNK2001: unresolved external symbol __imp_GetUnicastIpAddressTable
>  cares.obj : error LNK2001: unresolved external symbol hstrerror

Previously released wheels for Windows don't include any DLL for `cares`, so it seems like it was trying to build `c-ares` when it didn't need to. The first two errors went away when I added `iphlpapi` to `LIBRARIES` in `_setuputils.py`, but it seems like `hstrerror` ([invoked here](https://github.com/gevent/gevent/blob/5858d226045f701deb8e4b49c03db4cab63053d6/src/gevent/resolver/cares.pyx#L211)) is something unix-only and a [Windows-specific API needs to be used](https://stackoverflow.com/a/57137600/20226).