### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ build-backend = "setuptools.build_meta:__legacy__"
 # if you add/remove/change them.
 requires = [
      "setuptools >= 40.8.0",
-     "wheel",
 
      # Python 3.7 requires at least Cython 0.27.3.
      # 0.28 is faster, and (important!) lets us specify the target module


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a