### PR TITLE
Run leakchecks on Python 3.11; make them more comprehensive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,11 +350,10 @@ jobs:
         run: |
           python -mgevent.tests --second-chance $G_USE_COV --ignore tests_that_dont_use_resolver.txt
       - name: "Tests: leakchecks"
-        # Run the leaktests; this seems to be extremely slow on Python 3.7
-        # XXX: Figure out why. Can we reproduce locally?
+        # Run the leaktests;
         # This is incredibly important and we MUST have an environment that successfully passes
         # these tests.
-        if: matrix.python-version == 2.7 && startsWith(runner.os, 'Linux')
+        if: (matrix.python-version == 2.7 || startsWith(matrix.python-version, '3.11')) && startsWith(runner.os, 'Linux')
         env:
           GEVENTTEST_LEAKCHECK: 1
         run: |

--- a/src/gevent/resolver/__init__.py
+++ b/src/gevent/resolver/__init__.py
@@ -135,6 +135,15 @@ class AbstractResolver(object):
         and k not in ('SOCK_CLOEXEC', 'SOCK_MAX_SIZE')
     }
 
+    def close(self):
+        """
+        Release resources held by this object.
+
+        Subclasses that define resources should override.
+
+        .. versionadded:: NEXT
+        """
+
     @staticmethod
     def fixup_gaierror(func):
         import functools

--- a/src/gevent/resolver/cares.pyx
+++ b/src/gevent/resolver/cares.pyx
@@ -412,6 +412,9 @@ cdef class channel:
         return '<%s at 0x%x _timer=%r _watchers[%s]>' % args
 
     def destroy(self):
+        self.__destroy()
+
+    cdef __destroy(self):
         if self.channel:
             # XXX ares_library_cleanup?
             cares.ares_destroy(self.channel)
@@ -421,10 +424,7 @@ cdef class channel:
             self.loop = None
 
     def __dealloc__(self):
-        if self.channel:
-            # XXX ares_library_cleanup?
-            cares.ares_destroy(self.channel)
-            self.channel = NULL
+        self.__destroy()
 
     cpdef set_servers(self, servers=None):
         if not self.channel:

--- a/src/gevent/testing/leakcheck.py
+++ b/src/gevent/testing/leakcheck.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 
 import sys
 import gc
-import types
 from functools import wraps
 import unittest
 
@@ -52,8 +51,10 @@ def ignores_leakcheck(func):
 
 class _RefCountChecker(object):
 
-    # Some builtin things that we ignore
-    IGNORED_TYPES = (tuple, dict, types.FrameType, types.TracebackType)
+    # Some builtin things that we ignore.
+    # For awhile, we also ignored types.FrameType and types.TracebackType,
+    # but those are important and often involved in leaks.
+    IGNORED_TYPES = (tuple, dict,)
     try:
         CALLBACK_KIND = gevent.core.callback
     except AttributeError:

--- a/src/gevent/tests/test__ares_timeout.py
+++ b/src/gevent/tests/test__ares_timeout.py
@@ -34,6 +34,7 @@ class TestTimeout(greentest.TestCase):
 
         r = Resolver(servers=[address[0]], timeout=0.001, tries=1,
                      udp_port=address[-1])
+        self._close_on_teardown(r)
 
         with self.assertRaisesRegex(socket.herror, "ARES_ETIMEOUT"):
             r.gethostbyname('www.google.com')

--- a/src/gevent/tests/test__environ.py
+++ b/src/gevent/tests/test__environ.py
@@ -4,7 +4,7 @@ import gevent
 import gevent.core
 import subprocess
 
-if sys.argv[1:] == []:
+if not sys.argv[1:]:
     os.environ['GEVENT_BACKEND'] = 'select'
     # (not in Py2) pylint:disable=consider-using-with
     popen = subprocess.Popen([sys.executable, __file__, '1'])


### PR DESCRIPTION
Previously, we didn't run explicit leak checks on any version of Python 3; now we do.

Previously, we excluded leaks of frame and traceback objects; now we check for those too.

This is in the context of https://github.com/python/cpython/issues/98110 and https://github.com/gevent/gevent/issues/1909, helping determine where the bug actually is. We seem to be heading towards a consensus that it's not gevent or greenlet leaking/corrupting memory.