### PR TITLE
Switch to the non-legacy setuptools backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-# Our setup.py imports other things from this directory, meaning
-# in needs to be on sys.path. That's not guaranteed in a PEP517 world;
-# the __legacy__ build module makes that true. Ultimately we need to do that
-# ourself (and/or continue to simplify our build system).
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 # Build dependencies. Remember to change these in make-manylinux and appveyor.yml
 # if you add/remove/change them.
 requires = [

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ from setuptools import Extension, setup
 from setuptools import find_packages
 
 
+sys.path.insert(0, os.path.dirname(__file__))
+
 from _setuputils import read
 from _setuputils import read_version
 from _setuputils import PYPY, WIN


### PR DESCRIPTION
Use the non-legacy `setuptools.build_meta` backend.  Prepend the setup directory to `sys.path` prior to importing modules relative to it.

Fixes #1910