### PR TITLE
Attempt to support 3.11 x86_64 via manylinux2014

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,11 +102,11 @@ distributed as binary `wheels`_.
    You need Pip 8.0 or later, or buildout 2.10.0 to install the binary
    wheels on Windows or macOS. On Linux, you'll need `pip 19
    <https://github.com/pypa/pip/pull/5008>`_ to install the
-   manylinux2010 wheels.
+   manylinux2014 wheels.
 
 .. tip::
 
-   Binary wheels cannot be installed on non-manylinux2010 compatible
+   Binary wheels cannot be installed on non-manylinux2014 compatible
    Linux systems, such as those that use `musl
    <https://musl.libc.org>`_, including `Alpine Linux
    <https://alpinelinux.org>`_. Those systems must install from source.

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Initially based on a snippet from the greenlet project.
 # This needs to be run from the root of the project.
-# To update: docker pull quay.io/pypa/manylinux2010_x86_64
+# To update: docker pull quay.io/pypa/manylinux2014_x86_64
 set -e
 export PYTHONUNBUFFERED=1
 export PYTHONDONTWRITEBYTECODE=1
@@ -174,5 +174,5 @@ fi
 # Travis CI and locally we want `-ti`, but github actions doesn't have a TTY, so one
 # or the other of the arguments causes this to fail with 'input device is not a TTY'
 # Pas through whether we're running on github or not to help with caching.
-docker run --rm -e GEVENT_MANYLINUX_NAME -e GEVENTSETUP_DISABLE_ARES -e GITHUB_ACTIONS -e GEVENTTEST_SKIP_ALL -e DOCKER_IMAGE -v "$(pwd):/gevent" -v "$LCACHE:/cache" -v "$HOME/.ccache:/ccache" ${DOCKER_IMAGE:-quay.io/pypa/manylinux2010_x86_64} /gevent/scripts/releases/$(basename $0)
+docker run --rm -e GEVENT_MANYLINUX_NAME -e GEVENTSETUP_DISABLE_ARES -e GITHUB_ACTIONS -e GEVENTTEST_SKIP_ALL -e DOCKER_IMAGE -v "$(pwd):/gevent" -v "$LCACHE:/cache" -v "$HOME/.ccache:/ccache" ${DOCKER_IMAGE:-quay.io/pypa/manylinux2014_x86_64} /gevent/scripts/releases/$(basename $0)
 ls -l wheelhouse


### PR DESCRIPTION
I'm not familiar with manylinux, but I'm using my context clues to presume that these changes might enable Python 3.11 wheels for x86_64.

Disclaimer:
- I don't have a local x86_64 environment to confirm myself before posting this PR.
- I have no insight into the potential known or unknown issues introduced by bumping manylinux2010 to manylinux2014.

Facts:
- I can pip install gevent on python:3.11slim-bullseye without any issues on my M1 Mac
- Github actions fail to build gevent on python:3.11-slim-bullseye with the error described in #1917
- manylinux2010 is used to build x86_64 wheels
- The manylinux project has documented EOL for manylinux2010 in August 2022 ([link](https://github.com/pypa/manylinux/issues/1281))
- CPython 3.11.0 is available in manylinux2014 ([link](https://github.com/pypa/manylinux/issues/1317))