### PR TITLE
Fix asserts in test_attributes

### DIFF
--- a/src/gevent/tests/test__socket.py
+++ b/src/gevent/tests/test__socket.py
@@ -396,13 +396,13 @@ class TestTCP(greentest.TestCase):
 
     def test_attributes(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
-        self.assertEqual(socket.AF_INET, s.type)
-        self.assertEqual(socket.SOCK_DGRAM, s.family)
+        self.assertEqual(socket.AF_INET, s.family)
+        self.assertEqual(socket.SOCK_DGRAM, s.type)
         self.assertEqual(0, s.proto)
 
         if hasattr(socket, 'SOCK_NONBLOCK'):
             s.settimeout(1)
-            self.assertEqual(socket.AF_INET, s.type)
+            self.assertEqual(socket.AF_INET, s.family)
 
             s.setblocking(0)
             std_socket = monkey.get_original('socket', 'socket')(socket.AF_INET, socket.SOCK_DGRAM, 0)


### PR DESCRIPTION
This fixes an obvious typo.  See https://docs.python.org/3/library/socket.html#creating-sockets for reference.