### PR TITLE
Added a setter method for the MAX_REQUEST_LINE

### DIFF
--- a/src/gevent/pywsgi.py
+++ b/src/gevent/pywsgi.py
@@ -89,6 +89,9 @@ def format_date_time(timestamp):
     value = value.encode("latin-1")
     return value
 
+def set_max_request_line(value):
+    global MAX_REQUEST_LINE
+    MAX_REQUEST_LINE = value
 
 class _InvalidClientInput(IOError):
     # Internal exception raised by Input indicating that the client


### PR DESCRIPTION
WSGI by default limits the url length limit to 8192.
There are scenarios where the user wants to fire URLs exceeding this length.
By creatung a setter method for the constant we can now allow the users to modify the default limit.