### PR TITLE
Fixes gevent.select.select not handling all iterable inputs correctly

### DIFF
--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -159,6 +159,13 @@ def select(rlist, wlist, xlist, timeout=None): # pylint:disable=unused-argument
         # forward compatible
         raise ValueError("timeout must be non-negative")
 
+    # since rlist and wlist can be any iterable we will have to first
+    # copy them into a list, so we can use them in both _original_select
+    # and in SelectResult.select. We don't need to do it for xlist, since
+    # that one will only be passed into _original_select
+    rlist = rlist if isinstance(rlist, (list, tuple)) else list(rlist)
+    wlist = wlist if isinstance(wlist, (list, tuple)) else list(wlist)
+
     # First, do a poll with the original select system call. This is
     # the most efficient way to check to see if any of the file
     # descriptors have previously been closed and raise the correct

--- a/src/gevent/tests/test__select.py
+++ b/src/gevent/tests/test__select.py
@@ -106,6 +106,17 @@ class TestSelectTypes(greentest.TestCase):
             finally:
                 sock.close()
 
+    def test_iterable(self):
+        sock = socket.socket()
+
+        def fileno_iter():
+            yield int(sock.fileno())
+
+        try:
+            select.select(fileno_iter, [], [], 0.001)
+        finally:
+            sock.close()
+
     def test_string(self):
         self.switch_expected = False
         self.assertRaises(TypeError, select.select, ['hello'], [], [], 0.001)

--- a/src/gevent/tests/test__select.py
+++ b/src/gevent/tests/test__select.py
@@ -113,7 +113,7 @@ class TestSelectTypes(greentest.TestCase):
             yield int(sock.fileno())
 
         try:
-            select.select(fileno_iter, [], [], 0.001)
+            select.select(fileno_iter(), [], [], 0.001)
         finally:
             sock.close()
 


### PR DESCRIPTION
This fixes #1979 