### PR TITLE
Fix basepython for py311-cffi testenv in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:py311-cffi]
 basepython =
-    python2.7
+    python3.11
 setenv =
 	GEVENT_LOOP=libev-cffi
 


### PR DESCRIPTION
Fixes #1995.