### PR TITLE
Remove useless shebang from testrunner.py

### DIFF
--- a/src/gevent/testing/testrunner.py
+++ b/src/gevent/testing/testrunner.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function, absolute_import, division
 
 import re


### PR DESCRIPTION
The `testrunner.py` file have Python shebang, but it is not possible to run the file:
```
$ src/gevent/testing/testrunner.py
Traceback (most recent call last):
  File "/tmp/gevent/src/gevent/testing/testrunner.py", line 19, in <module>
    from . import util
ImportError: attempted relative import with no known parent package
$
```
This change simply removes the useless shebang.