### PR TITLE
appveyor.yml: Test on Python 3.13 release candidate

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,14 @@ environment:
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
 
+    - PYTHON: "C:\\Python313-x64"
+      PYTHON_VERSION: "3.13.0rc1"
+      PYTHON_ARCH: "64"
+      PYTHON_EXE: python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+
     - PYTHON: "C:\\Python312-x64"
-      PYTHON_VERSION: "3.12.0b4"
+      PYTHON_VERSION: "3.12.0"
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ build:
   parallel: true
   verbosity: minimal
 # The VS 2019 image doesn't have
-# the MSVC needed for Python 2.7.
+# the MSVC needed for Python 2.7. 
 image: Visual Studio 2015
 
 environment:


### PR DESCRIPTION
* https://www.python.org/download/pre-releases
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases

> Building wheel for greenlet (pyproject.toml): finished with status 'error'

Blocked by:
* #2037
* python-greenlet/greenlet#396