### PR TITLE
Config option to disable report printing in monitoring thread

### DIFF
--- a/src/gevent/_config.py
+++ b/src/gevent/_config.py
@@ -546,6 +546,19 @@ class MaxBlockingTime(FloatSettingMixin, Setting):
     .. versionadded:: 1.3b1
     """
 
+class PrintReports(BoolSettingMixin, Setting):
+    name = 'print_reports'
+    # This environment key doesn't follow the convention because it's
+    # meant to match a key used by existing projects
+    environment_key = 'GEVENT_PRINT_REPORTS'
+    default = True
+
+    desc = """\
+    If the `monitor_thread` is enabled, this is
+    whether to print reports when the event loop is blocked.
+    .. versionadded:: 24.10.4
+    """
+
 class MonitorMemoryPeriod(FloatSettingMixin, Setting):
     name = 'memory_monitor_period'
 

--- a/src/gevent/_monitor.py
+++ b/src/gevent/_monitor.py
@@ -238,12 +238,13 @@ class PeriodicMonitoringThread(object):
             hub, active_greenlet,
             dict(greenlet_stacks=False, current_thread_ident=self.monitor_thread_ident))
 
-        stream = hub.exception_stream
-        for line in report:
-            # Printing line by line may interleave with other things,
-            # but it should also prevent a "reentrant call to print"
-            # when the report is large.
-            print(line, file=stream)
+        if GEVENT_CONFIG.print_reports:
+            stream = hub.exception_stream
+            for line in report:
+                # Printing line by line may interleave with other things,
+                # but it should also prevent a "reentrant call to print"
+                # when the report is large.
+                print(line, file=stream)
 
         notify(EventLoopBlocked(active_greenlet, GEVENT_CONFIG.max_blocking_time, report))
         return (active_greenlet, report)


### PR DESCRIPTION
I do not need the printing and it is generating a lot of spam in my case, but I do need the BlockedEventLoop notification, so I'm proposing a simple config option to disable the printing.

I did not have success with `gevent.get_hub().exception_stream = None`. Maybe it is due to my setup creating multiple hubs/threads beyond my control/awareness. It is hard for me to tell.