### PR TITLE
Initial compatibility with Cython 3.1a1 by removing legacy Py2 code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,10 +19,10 @@ Bugfixes
 - Distribute manylinux2014 wheels for x86_64.
   See :issue:`2068`.
 - Stop switching to the hub in the after fork hook in a child process. This could lead to strange behaviour, and is different than what all other versions of Python do.
-  
 
 
-----24.10.2 (2024-10-11)
+
+24.10.2 (2024-10-11)
 ====================
 
 
@@ -33,7 +33,7 @@ Bugfixes
   See :issue:`2049`.
 
 
-----24.10.1 (2024-10-09)
+24.10.1 (2024-10-09)
 ====================
 
 

--- a/docs/changes/2076.bugfix.rst
+++ b/docs/changes/2076.bugfix.rst
@@ -1,0 +1,2 @@
+Remove some legacy code that supported Python 2 for compatibility with
+the upcoming releases of Cython 3.1.

--- a/docs/changes/2076.bugfix.rst
+++ b/docs/changes/2076.bugfix.rst
@@ -1,2 +1,8 @@
 Remove some legacy code that supported Python 2 for compatibility with
 the upcoming releases of Cython 3.1.
+
+Also, the ``PeriodicMonitorThreadStartedEvent`` now properly
+implements the ``IPeriodicMonitorThreadStartedEvent`` interface.
+The ``EventLoopBlocked`` event includes the hub which was blocked,
+and it is notified before the report is printed so that event
+listeners can modify the report.

--- a/src/gevent/events.py
+++ b/src/gevent/events.py
@@ -172,9 +172,13 @@ class IPeriodicMonitorThreadStartedEvent(Interface):
 
     monitor = Attribute("The instance of `IPeriodicMonitorThread` that was started.")
 
+@implementer(IPeriodicMonitorThreadStartedEvent)
 class PeriodicMonitorThreadStartedEvent(object):
     """
     The implementation of :class:`IPeriodicMonitorThreadStartedEvent`.
+
+    .. versionchanged:: NEXT
+       Now actually implements the promised interface.
     """
 
     #: The name of the setuptools entry point that is called when this
@@ -189,11 +193,15 @@ class IEventLoopBlocked(Interface):
     The event emitted when the event loop is blocked.
 
     This event is emitted in the monitor thread.
+
+    .. versionchanged:: NEXT
+       Add the *hub* attribute.
     """
 
     greenlet = Attribute("The greenlet that appeared to be blocking the loop.")
     blocking_time = Attribute("The approximate time in seconds the loop has been blocked.")
-    info = Attribute("A sequence of string lines providing extra info.")
+    info = Attribute("A list of string lines providing extra info. You may modify this list.")
+    hub = Attribute("""If not None, the hub being blocked.""")
 
 @implementer(IEventLoopBlocked)
 class EventLoopBlocked(object):
@@ -203,10 +211,11 @@ class EventLoopBlocked(object):
     Implements `IEventLoopBlocked`.
     """
 
-    def __init__(self, greenlet, blocking_time, info):
+    def __init__(self, greenlet, blocking_time, info, *, hub=None):
         self.greenlet = greenlet
         self.blocking_time = blocking_time
         self.info = info
+        self.hub = hub
 
 class IMemoryUsageThresholdExceeded(Interface):
     """

--- a/src/gevent/greenlet.py
+++ b/src/gevent/greenlet.py
@@ -378,14 +378,8 @@ class Greenlet(greenlet):
         hub = get_my_hub(self) # pylint:disable=undefined-variable
         return hub.loop
 
-    def __nonzero__(self): # pylint:disable=bad-dunder-name
+    def __bool__(self): # pylint:disable=bad-dunder-name
         return self._start_event is not None and self._exc_info is None
-    try:
-        __bool__ = __nonzero__ # Python 3
-    except NameError: # pragma: no cover
-        # When we're compiled with Cython, the __nonzero__ function
-        # goes directly into the slot and can't be accessed by name.
-        pass
 
     ### Lifecycle
 

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -162,7 +162,11 @@ _flags = tuple([
 ])
 
 
-_flags_str2int = dict((string, flag) for (flag, string) in _flags)
+_flags_str2int = {
+    string: flag
+    for flag, string
+    in _flags
+}
 
 
 _events = tuple([
@@ -198,22 +202,26 @@ cpdef _flags_to_list(unsigned int flags):
     return result
 
 
-cpdef unsigned int _flags_to_int(object flags) except? -1:
+cpdef unsigned int _flags_to_int(object flags) except *:
     # Note, that order does not matter, libev has its own predefined order
     if not flags:
         return 0
     if isinstance(flags, int):
         return flags
     cdef unsigned int result = 0
+
+    if isinstance(flags, str):
+        flags = flags.split(',')
     try:
-        if isinstance(flags, str):
-            flags = flags.split(',')
         for value in flags:
             value = value.strip().lower()
             if value:
                 result |= _flags_str2int[value]
     except KeyError as ex:
-        raise ValueError('Invalid backend or flag: %s\nPossible values: %s' % (ex, ', '.join(sorted(_flags_str2int.keys()))))
+        # XXX: Cython 3.1a1 crashes on handling exceptions. It's trying to
+        # decref a value it previously set to NULL.
+        raise ValueError('Invalid backend or flag: %s\nPossible values: %s' % (
+            ex, ', '.join(sorted(_flags_str2int.keys()))))
     return result
 
 

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -61,13 +61,6 @@ __all__ = ['get_version',
            'time',
            'loop']
 
-cdef tuple integer_types
-
-if sys.version_info[0] >= 3:
-    integer_types = int,
-else:
-    integer_types = (int, long)
-
 
 cdef extern from "callbacks.h":
     void gevent_callback_io(libev.ev_loop, void*, int)
@@ -151,7 +144,7 @@ def get_header_version():
 
 # This list backends in the order they are actually tried by libev,
 # as defined in loop_init. The names must be lower case.
-_flags = [
+_flags = tuple([
     # IOCP
     (libev.EVBACKEND_PORT, 'port'),
     (libev.EVBACKEND_KQUEUE, 'kqueue'),
@@ -166,28 +159,30 @@ _flags = [
     (libev.EVFLAG_NOINOTIFY, 'noinotify'),
     (libev.EVFLAG_SIGNALFD, 'signalfd'),
     (libev.EVFLAG_NOSIGMASK, 'nosigmask')
-]
+])
 
 
 _flags_str2int = dict((string, flag) for (flag, string) in _flags)
 
 
-_events = [(libev.EV_READ,     'READ'),
-           (libev.EV_WRITE,    'WRITE'),
-           (libev.EV__IOFDSET, '_IOFDSET'),
-           (libev.EV_PERIODIC, 'PERIODIC'),
-           (libev.EV_SIGNAL,   'SIGNAL'),
-           (libev.EV_CHILD,    'CHILD'),
-           (libev.EV_STAT,     'STAT'),
-           (libev.EV_IDLE,     'IDLE'),
-           (libev.EV_PREPARE,  'PREPARE'),
-           (libev.EV_CHECK,    'CHECK'),
-           (libev.EV_EMBED,    'EMBED'),
-           (libev.EV_FORK,     'FORK'),
-           (libev.EV_CLEANUP,  'CLEANUP'),
-           (libev.EV_ASYNC,    'ASYNC'),
-           (libev.EV_CUSTOM,   'CUSTOM'),
-           (libev.EV_ERROR,    'ERROR')]
+_events = tuple([
+    (libev.EV_READ,     'READ'),
+    (libev.EV_WRITE,    'WRITE'),
+    (libev.EV__IOFDSET, '_IOFDSET'),
+    (libev.EV_PERIODIC, 'PERIODIC'),
+    (libev.EV_SIGNAL,   'SIGNAL'),
+    (libev.EV_CHILD,    'CHILD'),
+    (libev.EV_STAT,     'STAT'),
+    (libev.EV_IDLE,     'IDLE'),
+    (libev.EV_PREPARE,  'PREPARE'),
+    (libev.EV_CHECK,    'CHECK'),
+    (libev.EV_EMBED,    'EMBED'),
+    (libev.EV_FORK,     'FORK'),
+    (libev.EV_CLEANUP,  'CLEANUP'),
+    (libev.EV_ASYNC,    'ASYNC'),
+    (libev.EV_CUSTOM,   'CUSTOM'),
+    (libev.EV_ERROR,    'ERROR')
+])
 
 
 cpdef _flags_to_list(unsigned int flags):
@@ -203,20 +198,15 @@ cpdef _flags_to_list(unsigned int flags):
     return result
 
 
-
-basestring = (bytes, str)
-
-
-
 cpdef unsigned int _flags_to_int(object flags) except? -1:
     # Note, that order does not matter, libev has its own predefined order
     if not flags:
         return 0
-    if isinstance(flags, integer_types):
+    if isinstance(flags, int):
         return flags
     cdef unsigned int result = 0
     try:
-        if isinstance(flags, basestring):
+        if isinstance(flags, str):
             flags = flags.split(',')
         for value in flags:
             value = value.strip().lower()
@@ -228,7 +218,7 @@ cpdef unsigned int _flags_to_int(object flags) except? -1:
 
 
 cdef str _str_hex(object flag):
-    if isinstance(flag, integer_types):
+    if isinstance(flag, int):
         return hex(flag)
     return str(flag)
 
@@ -297,13 +287,13 @@ cdef public class callback [object PyGeventCallbackObject, type PyGeventCallback
 
     close = stop
 
-    # Note, that __nonzero__ and pending are different
-    # nonzero is used in contexts where we need to know whether to schedule another callback,
+    # Note, that __bool__ and pending are different
+    # bool is used in contexts where we need to know whether to schedule another callback,
     # so it's true if it's pending or currently running
     # 'pending' has the same meaning as libev watchers: it is cleared before entering callback
 
-    def __nonzero__(self):
-        # it's nonzero if it's pending or currently executing
+    def __bool__(self):
+        # it's bool if it's pending or currently executing
         return self.args is not None
 
     @property
@@ -376,7 +366,7 @@ cdef class CallbackFIFO(object):
         old_tail.next = new_tail
         self.tail = new_tail
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.head is not None
 
     def __len__(self):

--- a/src/gevent/libev/stathelper.c
+++ b/src/gevent/libev/stathelper.c
@@ -1,4 +1,8 @@
 /* copied from Python-2.7.2/Modules/posixmodule.c */
+/* XXX: So obviously this is very outdated.
+   See if CPython itself now has
+   the support we need, or update this to a current copy. */
+#include "Python.h"
 #include "structseq.h"
 
 #define STRUCT_STAT struct stat
@@ -74,7 +78,7 @@ fill_time(PyObject *v, int index, time_t sec, unsigned long nsec)
 #if SIZEOF_TIME_T > SIZEOF_LONG
     ival = PyLong_FromLongLong((PY_LONG_LONG)sec);
 #else
-    ival = PyInt_FromLong((long)sec);
+    ival = PyLong_FromLong((long)sec);
 #endif
     if (!ival)
         return;
@@ -100,27 +104,27 @@ _pystat_fromstructstat(STRUCT_STAT *st)
     if (v == NULL)
         return NULL;
 
-    PyStructSequence_SET_ITEM(v, 0, PyInt_FromLong((long)st->st_mode));
+    PyStructSequence_SET_ITEM(v, 0, PyLong_FromLong((long)st->st_mode));
 #ifdef HAVE_LARGEFILE_SUPPORT
     PyStructSequence_SET_ITEM(v, 1,
                               PyLong_FromLongLong((PY_LONG_LONG)st->st_ino));
 #else
-    PyStructSequence_SET_ITEM(v, 1, PyInt_FromLong((long)st->st_ino));
+    PyStructSequence_SET_ITEM(v, 1, PyLong_FromLong((long)st->st_ino));
 #endif
 #if defined(HAVE_LONG_LONG) && !defined(MS_WINDOWS)
     PyStructSequence_SET_ITEM(v, 2,
                               PyLong_FromLongLong((PY_LONG_LONG)st->st_dev));
 #else
-    PyStructSequence_SET_ITEM(v, 2, PyInt_FromLong((long)st->st_dev));
+    PyStructSequence_SET_ITEM(v, 2, PyLong_FromLong((long)st->st_dev));
 #endif
-    PyStructSequence_SET_ITEM(v, 3, PyInt_FromLong((long)st->st_nlink));
-    PyStructSequence_SET_ITEM(v, 4, PyInt_FromLong((long)st->st_uid));
-    PyStructSequence_SET_ITEM(v, 5, PyInt_FromLong((long)st->st_gid));
+    PyStructSequence_SET_ITEM(v, 3, PyLong_FromLong((long)st->st_nlink));
+    PyStructSequence_SET_ITEM(v, 4, PyLong_FromLong((long)st->st_uid));
+    PyStructSequence_SET_ITEM(v, 5, PyLong_FromLong((long)st->st_gid));
 #ifdef HAVE_LARGEFILE_SUPPORT
     PyStructSequence_SET_ITEM(v, 6,
                               PyLong_FromLongLong((PY_LONG_LONG)st->st_size));
 #else
-    PyStructSequence_SET_ITEM(v, 6, PyInt_FromLong(st->st_size));
+    PyStructSequence_SET_ITEM(v, 6, PyLong_FromLong(st->st_size));
 #endif
 
 #if defined(HAVE_STAT_TV_NSEC)
@@ -144,19 +148,19 @@ _pystat_fromstructstat(STRUCT_STAT *st)
 
 #ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
     PyStructSequence_SET_ITEM(v, ST_BLKSIZE_IDX,
-                              PyInt_FromLong((long)st->st_blksize));
+                              PyLong_FromLong((long)st->st_blksize));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_BLOCKS
     PyStructSequence_SET_ITEM(v, ST_BLOCKS_IDX,
-                              PyInt_FromLong((long)st->st_blocks));
+                              PyLong_FromLong((long)st->st_blocks));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_RDEV
     PyStructSequence_SET_ITEM(v, ST_RDEV_IDX,
-                              PyInt_FromLong((long)st->st_rdev));
+                              PyLong_FromLong((long)st->st_rdev));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_GEN
     PyStructSequence_SET_ITEM(v, ST_GEN_IDX,
-                              PyInt_FromLong((long)st->st_gen));
+                              PyLong_FromLong((long)st->st_gen));
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_BIRTHTIME
     {
@@ -175,7 +179,7 @@ _pystat_fromstructstat(STRUCT_STAT *st)
 #endif
 #ifdef HAVE_STRUCT_STAT_ST_FLAGS
     PyStructSequence_SET_ITEM(v, ST_FLAGS_IDX,
-                              PyInt_FromLong((long)st->st_flags));
+                              PyLong_FromLong((long)st->st_flags));
 #endif
 
     if (PyErr_Occurred()) {

--- a/src/gevent/queue.py
+++ b/src/gevent/queue.py
@@ -243,12 +243,6 @@ class Queue(object):
         """
         return True
 
-    def __nonzero__(self): # pylint:disable=bad-dunder-name
-        # Py2.
-        # For Cython; __bool__ becomes a special method that we can't
-        # get by name.
-        return True
-
     def empty(self):
         """Return ``True`` if the queue is empty, ``False`` otherwise."""
         return not self.qsize()


### PR DESCRIPTION
Fixes #2076.

@scoder But gevent still won't work, at least on Python 3.12. Cython3.1a1 incorrectly compiles the function `cpdef unsigned int _flags_to_int(object flags) except *:` from `src/gevent/libev/corecext.pyx`. In the case of raising an exception (I've tried a few variations), Cython attempts to do a `Py_DECREF` on a temporary that it already set to NULL. `Py_DECREF` isn't safe to call with a possibly-NULL value, and it crashes.