### PR TITLE
socket._drop_ref_on_close: Check that the hub still has a loop

### DIFF
--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -277,11 +277,15 @@ class socket(_socketcommon.SocketMixin):
         # so that (hopefully) they can be closed before we destroy
         # the FD and invalidate them. We may be in the hub running pending
         # callbacks now, or this may take until the next iteration.
-        scheduled_new = self.hub.loop.closing_fd(sock.fileno())
+        loop = self.hub.loop
+        if loop is None:
+            sock.close()
+            return
+        scheduled_new = loop.closing_fd(sock.fileno())
         # Schedule the actual close to happen after that, but only if needed.
         # (If we always defer, we wind up closing things much later than expected.)
         if scheduled_new:
-            self.hub.loop.run_callback(sock.close)
+            loop.run_callback(sock.close)
         else:
             sock.close()
 


### PR DESCRIPTION
I've applied gevent patching to an httpx web client session. This approach for http2 support on the client side seems to work out, at least for some limited testing with a certain web API. As an alternative for http2 client support, there's also [curl_cffi](https://curl-cffi.readthedocs.io/en/latest/api.html)

Applying httpx at present, the application may be implemented in a way that it may call `close()` on an httpx client session from a callback activated on a concurrent.futures.Future. Ostensibly, this could provide a sort of close-on-exception logic in the client. Perhaps it may be a little abrupt for how it unwinds under the future callback.

With the application's design as at present, then using gevent `patch_all()` with all default patches,  I've seen an exception in `src/gevent/_socket3.py` at `socket._drop_ref_on_close()`. In short, it seems that the hub may not have a loop by the time `_drop_ref_on_close` is called. In one application, this handler was called  while the httpx session was closing, after a  concurrent.futures.Future callback had been activated in a certain thread.

This patch checks that the hub has a loop. If `hub.loop` is None, it calls `close()` directly and returns from the handler function. In this single approach to the item, it seems to prevent that exception when the httpx session is closed like so.
