### PR TITLE
Fix bug in psycopg2_pool example

### DIFF
--- a/examples/psycopg2_pool.py
+++ b/examples/psycopg2_pool.py
@@ -97,6 +97,8 @@ class AbstractDatabaseConnectionPool(object):
                 if isolation_level is not None:
                     conn.set_isolation_level(isolation_level)
                 self.put(conn)
+            else:
+                self.size -= 1
 
     @contextlib.contextmanager
     def cursor(self, *args, **kwargs):


### PR DESCRIPTION
The example implementation of a connection pool for psycopg2 can enter a problematic state in which all connection objects have been discarded, the `size` is large, and no new connections are created.

**The bug**
When retrieving a connection, the `size` is increased after a new connection is created.
When exiting a context in which a connection was used, that connection is returned to the pool, or discarded. When discarding a connection, the `size` is not changed. Effectively, the `size` of the pool can only grow, even though in reality connections can be lost and the active pool might shrink.

**The fix**
This fix ensures that the `size` is properly decremented when discarding a connection.