### PR TITLE
Monkey-patch queue.LifoQueue to be gevent.queue.LifoQueue.

### DIFF
--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -271,9 +271,12 @@ def patch_queue():
     implementation, but the details may change at any time.
 
     .. versionadded:: 1.3.5
+
+    .. versionchanged:: NEXT
+       Patch :class:`queue.LifoQueue` to work around https://github.com/gevent/gevent/issues/1957
     """
     _patch_module('queue', items=[
-        'LifoQueue',  # https://github.com/gevent/gevent/issues/1957
+        'LifoQueue',
         'SimpleQueue',
     ])
 

--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -265,12 +265,15 @@ def patch_queue():
     Patch objects in :mod:`queue`.
 
 
-    Currently, this just replaces :class:`queue.SimpleQueue` (implemented
-    in C) with its Python counterpart, but the details may change at any time.
+    Currently, this replaces :class:`queue.SimpleQueue` (implemented
+    in C) with its Python counterpart as well as :class:`queue.LifoQueue`
+    (which triggers deadlocks in some cases) with a gevent-specific
+    implementation, but the details may change at any time.
 
     .. versionadded:: 1.3.5
     """
     _patch_module('queue', items=[
+        'LifoQueue',  # https://github.com/gevent/gevent/issues/1957
         'SimpleQueue',
     ])
 


### PR DESCRIPTION
Works around https://github.com/gevent/gevent/issues/1957

This issue has been opened for almost two years. Until it is resolved, everybody hitting it has to spend time diagnosing it, implementing the workaround and deploying it. With this change, we relieve users from having to rediscover, implement and maintain that kludge and make it easy to remove once the issue is resolved.