### PR TITLE
Mnkey-patching the ``queue`` module (done by default in ``patch_all``) now patches ``Queue``, ``PriorityQueue``, and ``LifoQueue`

### DIFF
--- a/docs/changes/1957.bugfix.rst
+++ b/docs/changes/1957.bugfix.rst
@@ -1,0 +1,5 @@
+Monkey-patching the ``queue`` module (done by default in
+``patch_all``) now patches ``Queue``, ``PriorityQueue``, and
+``LifoQueue``. In addition to the general benefits of making all those
+classes cooperative, this is known to solve a non-deterministic
+deadlock with ``urllib3``.

--- a/docs/changes/1957.bugfix.rst
+++ b/docs/changes/1957.bugfix.rst
@@ -3,3 +3,12 @@ Monkey-patching the ``queue`` module (done by default in
 ``LifoQueue``. In addition to the general benefits of making all those
 classes cooperative, this is known to solve a non-deterministic
 deadlock with ``urllib3``.
+
+In addition, ``Queue`` was renamed to ``SimpleQueue``; previously
+``SimpleQueue`` was an alias for the undocumented
+``queue._PySimpleQueue``. This makes ``SimpleQueue`` cooperative even
+without monkey-patching.
+
+Likewise, ``JoinableQueue`` was renamed to ``Queue``, providing the
+``join`` method to all ``Queue`` objects, thus matching the standard
+library. The old name remains for backwards compatibility.

--- a/src/gevent/_gevent_cqueue.pxd
+++ b/src/gevent/_gevent_cqueue.pxd
@@ -36,7 +36,7 @@ cdef inline void greenlet_init():
 @cython.final
 cdef _safe_remove(deq, item)
 
-cdef class Queue:
+cdef class SimpleQueue:
     cdef __weakref__
     cdef readonly hub
     cdef readonly queue
@@ -66,9 +66,18 @@ cdef class Queue:
     cpdef get_nowait(self)
     cpdef peek(self, block=*, timeout=*)
     cpdef peek_nowait(self)
-    cpdef shutdown(self, immediate=*)
+
 
     cdef _schedule_unlock(self)
+
+
+cdef class Queue(SimpleQueue):
+    cdef Event _cond
+    cdef readonly int unfinished_tasks
+    cdef _did_put_task(self)
+
+
+    cpdef shutdown(self, immediate=*)
     cdef _drain_for_immediate_shutdown(self)
 
 
@@ -78,27 +87,14 @@ cdef class ItemWaiter(Waiter):
     cdef readonly item
     cdef readonly Queue queue
 
-###
-# XXX: Disabling Cython.final here pending a release > Cython 3.0.11
-# because it breaks on GCC. See https://github.com/gevent/gevent/issues/2049#issuecomment-2404700280
-# Restore when new cython is released.
-#
-# @cython.final
-###
+
 cdef class UnboundQueue(Queue):
     pass
 
 cdef class PriorityQueue(Queue):
     pass
 
-
-cdef class JoinableQueue(Queue):
-    cdef Event _cond
-    cdef readonly int unfinished_tasks
-    cdef _did_put_task(self)
-
-
-cdef class LifoQueue(JoinableQueue):
+cdef class LifoQueue(Queue):
     pass
 
 cdef class Channel:

--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -265,14 +265,20 @@ def patch_queue():
     """
     Patch objects in :mod:`queue`.
 
-
-    Currently, this just replaces :class:`queue.SimpleQueue` (implemented
-    in C) with its Python counterpart, but the details may change at any time.
+    This replaces ``SimpleQueue``, ``PriorityQueue``, ``Queue``
+    and ``LifoQueue`` with their gevent equivalents.
 
     .. versionadded:: 1.3.5
+
+    .. versionchanged:: NEXT
+       In addition to ``SimpleQueue``, now also patches
+       ``Queue``, ``PriorityQueue`` and ``LifoQueue``.`
     """
     _patch_module('queue', items=[
         'SimpleQueue',
+        'PriorityQueue',
+        'LifoQueue',
+        'Queue',
     ])
 
 

--- a/src/gevent/queue.py
+++ b/src/gevent/queue.py
@@ -574,8 +574,8 @@ class JoinableQueue(Queue):
 
     def task_done(self):
         '''Indicate that a formerly enqueued task is complete. Used by queue consumer threads.
-        For each :meth:`get <Queue.get>` used to fetch a task, a subsequent call to :meth:`task_done` tells the queue
-        that the processing on the task is complete.
+        For each :meth:`get <Queue.get>` used to fetch a task, a subsequent call to
+        :meth:`task_done` tells the queue that the processing on the task is complete.
 
         If a :meth:`join` is currently blocking, it will resume when all items have been processed
         (meaning that a :meth:`task_done` call was received for every item that had been

--- a/src/gevent/tests/test__monkey.py
+++ b/src/gevent/tests/test__monkey.py
@@ -152,17 +152,14 @@ class TestMonkey(SubscriberCleanupMixin, unittest.TestCase):
                              and e.module_name == 'ssl')
 
     def test_patch_queue(self):
-        try:
-            import queue
-        except ImportError:
-            # Python 2 called this Queue. Note that having
-            # python-future installed gives us a queue module on
-            # Python 2 as well.
-            queue = None
-        if not hasattr(queue, 'SimpleQueue'):
-            raise unittest.SkipTest("Needs SimpleQueue")
+        import queue
+        import gevent.queue as gq
+
         # pylint:disable=no-member
-        self.assertIs(queue.SimpleQueue, queue._PySimpleQueue)
+        self.assertIs(queue.SimpleQueue, gq.SimpleQueue)
+        self.assertIs(queue.LifoQueue, gq.LifoQueue)
+        self.assertIs(queue.Queue, gq.Queue)
+        self.assertIs(queue.PriorityQueue, gq.PriorityQueue)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In addition to the general benefits of making all those classes cooperative, this is known to solve a non-deterministic deadlock with ``urllib3``.

In addition, ``Queue`` was renamed to ``SimpleQueue``; previously ``SimpleQueue`` was an alias for the undocumented ``queue._PySimpleQueue``. This makes ``SimpleQueue`` cooperative even without monkey-patching.

Likewise, ``JoinableQueue`` was renamed to ``Queue``, providing the ``join`` method to all ``Queue`` objects, thus matching the standard library. The old name remains for backwards compatibility.

Fixes #1957. Closes #2095.