### PR TITLE
Deal with BrokenPipeError since openssl 3.4.x.

### DIFF
--- a/src/greentest/3.10/test_ssl.py
+++ b/src/greentest/3.10/test_ssl.py
@@ -2485,7 +2485,6 @@ class ThreadedEchoServer(threading.Thread):
                 # See also http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/
                 if e.errno != errno.EPROTOTYPE and sys.platform != "darwin":
                     self.running = False
-                    self.server.stop()
                     self.close()
                 return False
             else:
@@ -2620,9 +2619,6 @@ class ThreadedEchoServer(threading.Thread):
                     self.close()
                     self.running = False
 
-                    # normally, we'd just stop here, but for the test
-                    # harness, we want to stop the server
-                    self.server.stop()
 
     def __init__(self, certificate=None, ssl_version=None,
                  certreqs=None, cacerts=None,
@@ -2657,21 +2653,33 @@ class ThreadedEchoServer(threading.Thread):
         self.conn_errors = []
         threading.Thread.__init__(self)
         self.daemon = True
+        self._in_context = False
 
     def __enter__(self):
+        if self._in_context:
+            raise ValueError('Re-entering ThreadedEchoServer context')
+        self._in_context = True
         self.start(threading.Event())
         self.flag.wait()
         return self
 
     def __exit__(self, *args):
+        assert self._in_context
+        self._in_context = False
         self.stop()
         self.join()
 
     def start(self, flag=None):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.flag = flag
         threading.Thread.start(self)
 
     def run(self):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.sock.settimeout(1.0)
         self.sock.listen(5)
         self.active = True

--- a/src/greentest/3.11/test_ssl.py
+++ b/src/greentest/3.11/test_ssl.py
@@ -2492,7 +2492,6 @@ class ThreadedEchoServer(threading.Thread):
                 # See also http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/
                 if e.errno != errno.EPROTOTYPE and sys.platform != "darwin":
                     self.running = False
-                    self.server.stop()
                     self.close()
                 return False
             else:
@@ -2627,10 +2626,6 @@ class ThreadedEchoServer(threading.Thread):
                     self.close()
                     self.running = False
 
-                    # normally, we'd just stop here, but for the test
-                    # harness, we want to stop the server
-                    self.server.stop()
-
     def __init__(self, certificate=None, ssl_version=None,
                  certreqs=None, cacerts=None,
                  chatty=True, connectionchatty=False, starttls_server=False,
@@ -2664,21 +2659,33 @@ class ThreadedEchoServer(threading.Thread):
         self.conn_errors = []
         threading.Thread.__init__(self)
         self.daemon = True
+        self._in_context = False
 
     def __enter__(self):
+        if self._in_context:
+            raise ValueError('Re-entering ThreadedEchoServer context')
+        self._in_context = True
         self.start(threading.Event())
         self.flag.wait()
         return self
 
     def __exit__(self, *args):
+        assert self._in_context
+        self._in_context = False
         self.stop()
         self.join()
 
     def start(self, flag=None):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.flag = flag
         threading.Thread.start(self)
 
     def run(self):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.sock.settimeout(1.0)
         self.sock.listen(5)
         self.active = True

--- a/src/greentest/3.12/test_ssl.py
+++ b/src/greentest/3.12/test_ssl.py
@@ -2300,7 +2300,6 @@ class ThreadedEchoServer(threading.Thread):
                 # See also http://erickt.github.io/blog/2014/11/19/adventures-in-debugging-a-potential-osx-kernel-bug/
                 if e.errno != errno.EPROTOTYPE and sys.platform != "darwin":
                     self.running = False
-                    self.server.stop()
                     self.close()
                 return False
             else:
@@ -2435,10 +2434,6 @@ class ThreadedEchoServer(threading.Thread):
                     self.close()
                     self.running = False
 
-                    # normally, we'd just stop here, but for the test
-                    # harness, we want to stop the server
-                    self.server.stop()
-
     def __init__(self, certificate=None, ssl_version=None,
                  certreqs=None, cacerts=None,
                  chatty=True, connectionchatty=False, starttls_server=False,
@@ -2472,21 +2467,33 @@ class ThreadedEchoServer(threading.Thread):
         self.conn_errors = []
         threading.Thread.__init__(self)
         self.daemon = True
+        self._in_context = False
 
     def __enter__(self):
+        if self._in_context:
+            raise ValueError('Re-entering ThreadedEchoServer context')
+        self._in_context = True
         self.start(threading.Event())
         self.flag.wait()
         return self
 
     def __exit__(self, *args):
+        assert self._in_context
+        self._in_context = False
         self.stop()
         self.join()
 
     def start(self, flag=None):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.flag = flag
         threading.Thread.start(self)
 
     def run(self):
+        if not self._in_context:
+            raise ValueError(
+                'ThreadedEchoServer must be used as a context manager')
         self.sock.settimeout(1.0)
         self.sock.listen(5)
         self.active = True


### PR DESCRIPTION
Follows from the changes in gh-127257 and the test adaption in gh-115627.

[gh-127257: ssl: Raise OSError for ERR_LIB_SYS](https://github.com/python/cpython/pull/127361)
[gh-115627: Fix ssl test_pha_required_nocert()](https://github.com/python/cpython/pull/117821)

We are building openSUSE Factory with OpenSSL 3.5 and we can see that gevent fails the test__server.py with BrokenPipeError, here is the error output:

```
[  147s]   ..sTraceback (most recent call last):
[  147s]     File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
[  147s]       result = self._run(*self.args, **self.kwargs)
[  147s]     File "/home/abuild/rpmbuild/BUILD/python-gevent-24.10.3-build/BUILDROOT/usr/lib64/python3.11/site-packages/gevent/baseserver.py", line 34, in _handle_and_close_when_done
[  147s]       return handle(*args_tuple)
[  147s]              ^^^^^^^^^^^^^^^^^^^
[  147s]     File "/home/abuild/rpmbuild/BUILD/python-gevent-24.10.3-build/BUILDROOT/usr/lib64/python3.11/site-packages/gevent/server.py", line 210, in wrap_socket_and_handle
[  147s]       return self.handle(ssl_socket, address)
[  147s]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[  147s]     File "/home/abuild/rpmbuild/BUILD/python-gevent-24.10.3-build/BUILDROOT/usr/lib64/python3.11/site-packages/gevent/tests/test__server.py", line 27, in handle
[  147s]       request_line = fd.readline()
[  147s]                      ^^^^^^^^^^^^^
[  147s]     File "/usr/lib64/python3.11/socket.py", line 718, in readinto
[  147s]       return self._sock.recv_into(b)
[  147s]              ^^^^^^^^^^^^^^^^^^^^^^^
[  147s]     File "/home/abuild/rpmbuild/BUILD/python-gevent-24.10.3-build/BUILDROOT/usr/lib64/python3.11/site-packages/gevent/ssl.py", line 635, in recv_into
[  147s]       return self.read(nbytes, buffer)
[  147s]              ^^^^^^^^^^^^^^^^^^^^^^^^^
[  147s]     File "/home/abuild/rpmbuild/BUILD/python-gevent-24.10.3-build/BUILDROOT/usr/lib64/python3.11/site-packages/gevent/ssl.py", line 437, in read
[  147s]       bytes_read += self._sslobj.read(nbytes, buffer)
[  147s]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[  147s]   BrokenPipeError: [Errno 32] Broken pipe
[  147s]   2025-04-20T23:39:43Z <Greenlet at 0x7f5d518b5d90: _handle_and_close_when_done(<bound method StreamServer.wrap_socket_and_handle , <bound method StreamServer.do_close of <SimpleStre, (<gevent._socket3.socket [closed] at 0x7f5d50cfae5)> failed with BrokenPipeError

```

Please, let me know if you need more info. TIA