### PR TITLE
Remove the (not thread.is_alive()) assertion

### DIFF
--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -395,7 +395,6 @@ class _ForkHooks:
                     handle = getattr(thread, h)
                 except AttributeError:
                     assert sys.version_info[:2] < (3, 13)
-                    assert not thread.is_alive()
                 else:
                     # We DO NOT want to bounce to the hub. We're running
                     # at a very sensitive time and it's best to keep tight control


### PR DESCRIPTION
This assertion apparently has a small chance of failing, possibly by a race condition. It was already skipped on Python 3.13+.

Fixes https://github.com/gevent/gevent/issues/2111