### PR TITLE
set thread._handle to None for python <= 3.13

### DIFF
--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -151,7 +151,7 @@ class _DummyThread(_DummyThread_):
     _tstate_lock = None
     if _needs_os_thread_handle:
         _os_thread_handle = None
-    elif sys.version_info[:2] == (3, 13):
+    elif sys.version_info[:2] <= (3, 13):
         _handle = None # 3.13
 
     def __init__(self): # pylint:disable=super-init-not-called

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -151,8 +151,10 @@ class _DummyThread(_DummyThread_):
     _tstate_lock = None
     if _needs_os_thread_handle:
         _os_thread_handle = None
-    elif sys.version_info[:2] <= (3, 13):
+    elif PY313:
         _handle = None # 3.13
+    else:
+        _handle = None
 
     def __init__(self): # pylint:disable=super-init-not-called
         #_DummyThread_.__init__(self)


### PR DESCRIPTION
https://github.com/gevent/gevent/commit/8c6f8ebafdc241ae2966b561b2508506a6b92a1c#diff-4c7de3078d9d099e761e20f9ecf89ca7e385ee44f3ef715749c712d1f4dbd3e4L145

In 25.4.1 the `thread._handle` was set to `None` in all cases, but in the 25.5.1 release, `thread._handle` (and `thread._os_thread_handle`) attribute is only defined for `python >= 3.13`, which means line 395 `handle = getattr(thread, h)` raises an attribute error when `python < 3.13`.

To get the same behavior as 25.4.1, this statement in line 154 of `src/gevent/threading.py` (https://github.com/gevent/gevent/commit/8c6f8ebafdc241ae2966b561b2508506a6b92a1c#diff-4c7de3078d9d099e761e20f9ecf89ca7e385ee44f3ef715749c712d1f4dbd3e4R154)

```
elif sys.version_info[:2] == (3, 13):
    _handle = None # 3.13
```

should be changed to

```
elif sys.version_info[:2] <= (3, 13):
    _handle = None # 3.13
```