### PR TITLE
Resolve #2111 and #2120: Allow _DummyThread.is_alive to return False after fork

### DIFF
--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -197,21 +197,6 @@ class _DummyThread(_DummyThread_):
     def _Thread__stop(self):
         pass
 
-    # gh-2111: CPython's _DummyThread expects that `_is_stopped` is never set to True
-    # which leads to some logical inconsistencies if you try to call
-    # _DummyThread.is_alive() after fork.  This is normally not a problem because there
-    # should never be any _DummyThread remaining in the active thread dict after a fork.
-    # However, gevent's after-fork handler still asserts the is_alive status of threads
-    # that existing prior to forking, under the assumption that CPython's
-    # threading._after_fork callback called ._stop() on each of them.  This is fine
-    # for normal threads, but for _DummyThread it triggers this inconsistency.
-    # Instead, allow _DummyThreads to actually return False for is_alive() if it's been
-    # cleaned up after a fork.
-    def isAlive(self):
-        return not self._is_stopped
-
-    is_alive = isAlive  # py3
-
     _stop = _Thread__stop # py3
 
     def _wait_for_tstate_lock(self, *args, **kwargs): # pylint:disable=signature-differs
@@ -412,7 +397,8 @@ class _ForkHooks:
                     handle = getattr(thread, h)
                 except AttributeError:
                     assert sys.version_info[:2] < (3, 13)
-                    assert not thread.is_alive()
+                    # gh-2111: _DummyThread can never not be alive so skip this assertion
+                    assert isinstance(thread, _DummyThread) or not thread.is_alive()
                 else:
                     # We DO NOT want to bounce to the hub. We're running
                     # at a very sensitive time and it's best to keep tight control

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -99,10 +99,12 @@ def _make_cleanup_id(gid):
 _weakref = None
 
 # 3.14 renamed Thread._handle to Thread._os_handle to avoid
-# conflicts with subclasses. This was backported to 3.13.4.
+# conflicts with subclasses. This is proposed to be backported to 3.13.x
+# release branch, but has proven controversial and has *not* yet been
+# backported:
 # https://github.com/python/cpython/issues/132578
 # https://github.com/python/cpython/pull/132696
-_needs_os_thread_handle = sys.version_info[:3] > (3, 13, 4)
+_needs_os_thread_handle = sys.version_info[:2] >= (3, 14)
 
 class _DummyThread(_DummyThread_):
     # We avoid calling the superclass constructor. This makes us about


### PR DESCRIPTION
For me this resolves #2111 on Python 3.11.x

While we're at it also resolve #2120 

Supersedes #2117 