### PR TITLE
Fix #2114 by making our Queue classes more like the stdlib.

### DIFF
--- a/docs/changes/2114.bugfix.rst
+++ b/docs/changes/2114.bugfix.rst
@@ -1,0 +1,2 @@
+Make the classes in ``gevent.queue`` more compatible with classes that
+expect to subclass the standard library queue classes.

--- a/src/gevent/_gevent_cqueue.pxd
+++ b/src/gevent/_gevent_cqueue.pxd
@@ -50,7 +50,16 @@ cdef class SimpleQueue:
 
     cpdef _get(self)
     cpdef _put(self, item)
+    cpdef Py_ssize_t _qsize(self)
+    # But the stdlib signature is
+    # ``_init(maxsize)``; even if we call
+    # it with just one argument, cython will always add
+    # a placeholder argument for the *items*. This means
+    # we can't ``cpdef`` this method.
+    # cpdef _init(self, maxsize, items=*)
+
     cpdef _peek(self)
+
 
     cpdef Py_ssize_t qsize(self)
     cpdef bint empty(self)

--- a/src/gevent/tests/test__queue.py
+++ b/src/gevent/tests/test__queue.py
@@ -83,6 +83,35 @@ class UsesOnlyOneItemMixin:
         assert p.get(timeout=0) == "OK"
 
 
+    def test_init_and_bottleneck_methods(self):
+        if not self.SUPPORTS_PUTTING_WITHOUT_GETTING:
+            self.skipTest('Needs to be able to put and get')
+
+        # subclasses of stdlib queues.
+        class X(self._getFUT()):
+            initted = None
+            get_count = 0
+            put_count = 0
+
+            def _init(self, maxsize):
+                super()._init(maxsize)
+                self.initted = True
+
+            def _get(self):
+                self.get_count += 1
+                return super()._get()
+
+            def _put(self, item):
+                self.put_count += 1
+                return super()._put(item)
+
+        x = X()
+        x.put('hi')
+        self.assertEqual(x.get(), 'hi')
+        self.assertEqual(x.put_count, 1)
+        self.assertEqual(x.get_count, 1)
+        self.assertTrue(x.initted)
+
 
 class SubscriptMixin:
     def _getFUT(self):


### PR DESCRIPTION
While (attempting to) carefully maintaining backwards compatibility if any gevent users were poking at these internals.

Note that none of these are documented, whether stdlib or gevent, so they can change.