### PR TITLE
Fix #2100

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ env:
   PYTHONDONTWRITEBYTECODE: 1
   PIP_UPGRADE_STRATEGY: eager
   PIP_NO_WARN_SCRIPT_LOCATION: 1
+  # Higher values like 2 definitely cause test breakage, as we
+  # can't stop a libev watcher if the FD has been closed (which is
+  # a silly design decision)
   GEVENTSETUP_EV_VERIFY: 1
   # Disable some warnings produced by libev especially and also some Cython generated code.
   # These are shared between GCC and clang so it must be a minimal set.
@@ -505,6 +508,9 @@ jobs:
           # 2014 is EOL as of June 2024. But
           # it is "still widely used" and has extended (for-pay)
           # support hrough 2028...
+          # CAUTION: Some of these strings are coded in the `make-manylinux` script
+          # for test configurations, so
+          # be sure to keep them matching.
           - manylinux2014_aarch64
           - manylinux2014_ppc64le
           - manylinux2014_s390x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,10 @@ jobs:
         # XXX: We could probably make this easier on ourself by adding a specific
         # key to the matrix in the version we care about and checking for that matrix key.
         python-version: ["3.14.0-rc.1", "3.12", "pypy-3.10-v7.3.17", '3.9', '3.10.18', '3.11.13', "3.13.5"]
-        os: [macos-latest, ubuntu-latest]
+        # XXX: August 2025: ``macos-latest`` switched from macOS 14 to macOS 15.5;
+        # at that time, we started getting timeouts performing DNS lookups. I can't
+        # replicate those locally on my own macOS 15 machine.
+        os: [macos-14, ubuntu-latest]
         exclude:
           # The bulk of the testing is on Linux and Windows (appveyor).
           # Experience shows that it's sufficient to only test the latest
@@ -113,21 +116,21 @@ jobs:
           #
           # XXX: Automate this part with another job.
           #
-          # - os: macos-latest
+          # - os: macos-14
           #   python-version: 3.8
-          # - os: macos-latest
+          # - os: macos-14
           #   python-version: 3.9
-          # - os: macos-latest
+          # - os: macos-14
           #   python-version: 3.10
-          - os: macos-latest
+          - os: macos-14
             python-version: "pypy-3.10-v7.3.15"
             # On Arm, the only version of 3.9 available is 3.9.13, which is too
             # ancient to run the tests we need.
-          - os: macos-latest
+          - os: macos-14
             python-version: "3.9"
-          - os: macos-latest # Likewise.
+          - os: macos-14 # Likewise.
             python-version: "3.11.13"
-          - os: macos-latest # Same again
+          - os: macos-14 # Same again
             python-version: "3.10.18"
 
     steps:

--- a/_setuplibev.py
+++ b/_setuplibev.py
@@ -107,6 +107,10 @@ def build_extension():
         ]
         CORE.configure = configure_libev
         if os.environ.get('GEVENTSETUP_EV_VERIFY') is not None:
+            # Numeric values from 0 to 3. 2 and above enable some pedantic
+            # checks that can very easily cause undesired failures;
+            # for example, it will abort the process if you try to close a
+            # watcher whose FD is now invalid.
             CORE.define_macros.append(
                 ('EV_VERIFY', os.environ['GEVENTSETUP_EV_VERIFY']))
             # EV_VERIFY is implemented using assert(), which only works if

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,13 +73,16 @@ environment:
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
 
+    # 3.9 is security fix only, goes unsupported in October 2025.
+    # Disable tests for that.
     - PYTHON: "C:\\Python39-x64"
       PYTHON_VERSION: "3.9.x"
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
+      GWHEEL_ONLY: true
 
-
-    # 32-bit, wheel only (no testing)
+    # Tests were already disabled here before 3.9 went EOL because
+    # we stopped testing or providing 32-bit builds.
     - PYTHON: "C:\\Python39"
       PYTHON_VERSION: "3.9.x"
       PYTHON_ARCH: "32"

--- a/docs/changes/2100.bugfix.rst
+++ b/docs/changes/2100.bugfix.rst
@@ -5,7 +5,9 @@ open files while they are still in use by other components.
 For example, :meth:`selectors.BaseSelector.unregister` says "A file
 object shall be unregistered prior to being closed." Failure to do so
 is implementation dependent; in gevent, with libev compiled with
-debugging enabled, this would crash the process.
+debugging enabled, this would crash the process, and with libuv,
+an unexpected, uncatchable exception would be raised. Now, more common
+failure scenarios are handled gracefully.
 
-This also means that gevent now monkey-patches :func:`os.close` to
-help handle these cases.
+This also means that gevent now monkey-patches :func:`os.close` (on
+POSIX) to help handle these cases.

--- a/docs/changes/2100.bugfix.rst
+++ b/docs/changes/2100.bugfix.rst
@@ -1,0 +1,11 @@
+Fix several possible interpreter crashes when there are race
+conditions or programmers don't follow the documented rules and close
+open files while they are still in use by other components.
+
+For example, :meth:`selectors.BaseSelector.unregister` says "A file
+object shall be unregistered prior to being closed." Failure to do so
+is implementation dependent; in gevent, with libev compiled with
+debugging enabled, this would crash the process.
+
+This also means that gevent now monkey-patches :func:`os.close` to
+help handle these cases.

--- a/docs/development/installing_from_source.rst
+++ b/docs/development/installing_from_source.rst
@@ -156,10 +156,11 @@ yes/no.
 ``GEVENTSETUP_EV_VERIFY``
   If set, the value is passed through as the value of the
   ``EV_VERIFY`` C compiler macro when libev is embedded. This should
-  be an integer between 0 and 3; values larger than 2 are likely
+  be an integer between 0 and 3; values larger than 1 are likely
   to cause problems with gevent applications. Also if set,
   this makes sure that the ``NDEBUG`` preprocessor symbol isn't
-  defined so that the C ``assert`` function works.
+  defined so that the C ``assert`` function works (failed assertions
+  crash the process).
 
   .. important::
 
@@ -190,8 +191,9 @@ individual libraries.
 .. important::
 
    This is not a suggested or recommended configuration. It can break
-   gevent in unexpected ways. If you're a downstream packager,
-   please let gevent use its embedded libraries.
+   gevent in unexpected ways, and usually carries a performance cost.
+   Downstream packagers are strongly encouraged to allow gevent to use
+   its embedded libraries.
 
 When embedding a library is disabled, the library must already be
 installed on the system in a way the compiler can access and link

--- a/docs/development/installing_from_source.rst
+++ b/docs/development/installing_from_source.rst
@@ -140,6 +140,13 @@ yes/no.
 ``CPPFLAGS``
   A standard variable used when building the C extensions. gevent may
   make slight modifications to this variable.
+
+  An important symbol is ``NDEBUG``. Unless this is defined, C-level
+  assertions are enabled. libev and libuv are very aggressive about
+  their assertions, and some of their choices do not fit the way
+  gevent is intended to be used. It's best to make sure this is
+  defined, e.g., ``CPPFLAGS=-DNDEBUG``.
+
 ``CFLAGS``
   A standard variable used when building the C extensions. gevent may
   make slight modifications to this variable.
@@ -148,7 +155,18 @@ yes/no.
   make slight modifications to this variable.
 ``GEVENTSETUP_EV_VERIFY``
   If set, the value is passed through as the value of the
-  ``EV_VERIFY`` C compiler macro when libev is embedded.
+  ``EV_VERIFY`` C compiler macro when libev is embedded. This should
+  be an integer between 0 and 3; values larger than 2 are likely
+  to cause problems with gevent applications. Also if set,
+  this makes sure that the ``NDEBUG`` preprocessor symbol isn't
+  defined so that the C ``assert`` function works.
+
+  .. important::
+
+     This note is for downstream packagers, such as Linux
+     distributions. Please do not distribute gevent built with this
+     setting enabled, as it is only for development and testing, not
+     production usage.
 
   In general, setting ``CPPFLAGS`` is more general and can contain
   other macros recognized by libev.
@@ -168,6 +186,12 @@ libraries or runtimes.
 
 However, this can be disabled, either for all libraries at once or for
 individual libraries.
+
+.. important::
+
+   This is not a suggested or recommended configuration. It can break
+   gevent in unexpected ways. If you're a downstream packager,
+   please let gevent use its embedded libraries.
 
 When embedding a library is disabled, the library must already be
 installed on the system in a way the compiler can access and link

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -23,7 +23,8 @@ export PIP_NO_WARN_SCRIPT_LOCATION=1
 export CC="ccache `which gcc`"
 export LDSHARED="$CC -shared"
 export LDCCSHARED="$LDSHARED"
-export LDCXXSHARED="$LDSHARED"
+# greenlet is C++, won't build with this enabled:
+# export LDCXXSHARED="$LDSHARED"
 export CCACHE_NOCPP2=true
 export CCACHE_SLOPPINESS=file_macro,time_macros,include_file_ctime,include_file_mtime
 export CCACHE_NOHASHDIR=true

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -37,9 +37,13 @@ export CCACHE_DIR="/ccache"
 GEVENT_WARNFLAGS="-Wno-strict-aliasing -Wno-comment -Wno-unused-value -Wno-unused-but-set-variable -Wno-sign-compare -Wno-parentheses -Wno-unused-function -Wno-tautological-compare -Wno-strict-prototypes -Wno-return-type -Wno-misleading-indentation"
 OPTIMIZATION_FLAGS="-O3 -pipe"
 if [ -n "$GITHUB_ACTIONS" ]; then
-    if [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_aarch64" ] || [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_ppc64le" ] || [ "$DOCKER_IMAGE" == "quay.io/pypa/manylinux2014_s390x" ] ||  [ "$DOCKER_IMAGE" == "quay.io/pypa/musllinux_1_2_aarch64" ] ; then
+    # Our runners are x86_64, so anything else is emulated and slow.
+    if [[ "$DOCKER_IMAGE" == *x86_64 ]]; then
+        echo "Non-emulated build"
+    else
         # Compiling with -Ofast is a no-go because of the regression it causes (#1864).
         # The default settings have -O3, and adding -Os doesn't help much. So maybe -O1 will.
+        echo "Expecting slow build; lowering optimization and disabling c-ares"
         echo "Compiling with -O1"
         OPTIMIZATION_FLAGS="-pipe -O1"
         SLOW_BUILD=1
@@ -161,12 +165,10 @@ if [ -d /gevent -a -d /opt/python ]; then
 
     # Start echoing commands (doing it earlier is too much)
     set -x
-    for variant in /opt/python/cp{313,312,39,310,311}*; do
+    for variant in /opt/python/cp{314,313,312,39,310,311}*; do
         echo $SEP
-        if [ "$variant" = "/opt/python/cp313-cp313t" ]; then
-            # It appears that Cython 3.0.11 cannot produce code that
-            # works here. Lots of compiler errors.
-            echo "Unable to build without gil"
+        if [[ "$variant" == *t ]]; then
+            echo "Skipping no-gil build. The GIL is required."
             continue
         fi
         export PATH="$variant/bin:$OPATH"

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -469,13 +469,18 @@ class IoMixin(object):
     def __init__(self, loop, fd, events, ref=True, priority=None, _args=None):
         # Win32 only works with sockets, and only when we use libuv, because
         # we don't use _open_osfhandle. See libuv/watchers.py:io for a description.
-        if fd < 0:
-            raise ValueError('fd must be non-negative: %r' % fd)
+        self._validate_fd(fd)
+
         if events & ~self.EVENT_MASK:
             raise ValueError('illegal event mask: %r' % events)
         self._fd = fd
         super(IoMixin, self).__init__(loop, ref=ref, priority=priority,
                                       args=_args or (fd, events))
+
+    @classmethod
+    def _validate_fd(cls, fd):
+        if fd < 0:
+            raise ValueError('fd must be non-negative: %r' % fd)
 
     def start(self, callback, *args, **kwargs):
         args = args or _NOARGS

--- a/src/gevent/_ffi/watcher.py
+++ b/src/gevent/_ffi/watcher.py
@@ -202,7 +202,7 @@ class AbstractWatcherType(type):
     def new(cls, kind):
         return cls._FFI.new(kind)
 
-class watcher(object):
+class watcher(metaclass=AbstractWatcherType):
 
     _callback = None
     _args = None
@@ -460,7 +460,7 @@ class watcher(object):
     def pending(self):
         return False
 
-watcher = AbstractWatcherType('watcher', (object,), dict(watcher.__dict__))
+
 
 class IoMixin(object):
 

--- a/src/gevent/_fileobjectposix.py
+++ b/src/gevent/_fileobjectposix.py
@@ -19,6 +19,7 @@ from gevent._hub_primitives import wait_on_watcher
 from gevent.hub import get_hub
 from gevent.os import _read
 from gevent.os import _write
+from gevent.os import _close
 from gevent.os import ignored_errors
 from gevent.os import make_nonblocking
 
@@ -136,7 +137,7 @@ class GreenFileDescriptorIO(RawIOBase):
     def __finish_close(closefd, fileno, keep_alive):
         try:
             if closefd:
-                os.close(fileno)
+                _close(fileno)
         finally:
             if hasattr(keep_alive, 'close'):
                 keep_alive.close()

--- a/src/gevent/_interfaces.py
+++ b/src/gevent/_interfaces.py
@@ -136,6 +136,9 @@ class ILoop(Interface):
 
         *events* is a bitmask specifying which events to watch
         for. 1 means read, and 2 means write.
+
+        *fd* should be valid. If it is not, this method _should_
+        throw an OSError EBADF.
         """
 
     def closing_fd(fd):
@@ -148,7 +151,9 @@ class ILoop(Interface):
 
         :return: A boolean value that's true if active IO watchers were
            queued to run. Closing the FD should be deferred until the next
-           run of the eventloop with a callback.
+           run of the eventloop with a check watcher (callbacks may be
+           run immediately if we were already running callbacks when this was
+           added, and it needs to come after the loop).
         """
 
     def timer(after, repeat=0.0, ref=True, priority=None):

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -287,6 +287,8 @@ class socket(_socketcommon.SocketMixin):
             def cb(s):
                 try:
                     s.close()
+                except OSError:
+                    pass
                 finally:
                     check.stop()
                     check.close()

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -280,9 +280,9 @@ class socket(_socketcommon.SocketMixin):
         should_defer = self.hub.loop.closing_fd(sock.fileno())
         # Schedule the actual close to happen after that, but only if needed.
         # (If we always defer, we wind up closing things much later than expected.)
-        # Note that if we're in the middle of running callbacks, this can be
+        # Note that if we're in the middle of running callbacks, simply scheduling
+        # a callback with ``run_callback`` could result in the callback being
         # called IMMEDIATELY, which completely defeats the point.
-
         if should_defer:
             check = self.hub.loop.check()
             def cb(s):

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -277,12 +277,13 @@ class socket(_socketcommon.SocketMixin):
         # so that (hopefully) they can be closed before we destroy
         # the FD and invalidate them. We may be in the hub running pending
         # callbacks now, or this may take until the next iteration.
-        scheduled_new = self.hub.loop.closing_fd(sock.fileno())
+        should_defer = self.hub.loop.closing_fd(sock.fileno())
         # Schedule the actual close to happen after that, but only if needed.
         # (If we always defer, we wind up closing things much later than expected.)
         # Note that if we're in the middle of running callbacks, this can be
         # called IMMEDIATELY, which completely defeats the point.
-        if scheduled_new:
+
+        if should_defer:
             check = self.hub.loop.check()
             def cb(s):
                 try:

--- a/src/gevent/_socket3.py
+++ b/src/gevent/_socket3.py
@@ -280,9 +280,21 @@ class socket(_socketcommon.SocketMixin):
         scheduled_new = self.hub.loop.closing_fd(sock.fileno())
         # Schedule the actual close to happen after that, but only if needed.
         # (If we always defer, we wind up closing things much later than expected.)
+        # Note that if we're in the middle of running callbacks, this can be
+        # called IMMEDIATELY, which completely defeats the point.
         if scheduled_new:
-            self.hub.loop.run_callback(sock.close)
+            check = self.hub.loop.check()
+            def cb(s):
+                try:
+                    s.close()
+                finally:
+                    check.stop()
+                    check.close()
+            check.start(cb, sock)
         else:
+            # Note that if the file descriptor got closed (``os.close``)
+            # closing the socket will now raise OSError: EBADF. The
+            # stdlib does the same.
             sock.close()
 
 

--- a/src/gevent/libev/_corecffi_cdef.c
+++ b/src/gevent/libev/_corecffi_cdef.c
@@ -247,3 +247,4 @@ static void gevent_zero_check(struct ev_check* handle);
 static void gevent_zero_timer(struct ev_timer* handle);
 static void gevent_zero_prepare(struct ev_prepare* handle);
 static void gevent_set_ev_alloc();
+static int gevent_check_fd_valid(int fd);

--- a/src/gevent/libev/_corecffi_source.c
+++ b/src/gevent/libev/_corecffi_source.c
@@ -81,6 +81,10 @@ static void gevent_set_ev_alloc()
     ev_set_allocator(ptr);
 }
 
+#define GEVENT_CFFI 1
+#include "check_valid_fd.c"
+#undef GEVENT_CFFI
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"

--- a/src/gevent/libev/check_valid_fd.c
+++ b/src/gevent/libev/check_valid_fd.c
@@ -1,0 +1,49 @@
+#ifndef G_CHECK_VALID_FD
+#define G_CHECK_VALID_FD
+
+
+#ifndef _WIN32
+#include <fcntl.h>
+#endif
+
+/**
+   Raises an exception if *fd* is not a valid open file handle.
+   *fd* is the platform specific version; we will call vfd_open if
+   needed.
+
+   Ignore the return value for Cython; for CFFI, when GEVENT_CFFI is defined,
+   returns -1 on error.
+*/
+int gevent_check_fd_valid(int fd)
+{
+// TODO: libuv uses syscalls like poll(), epoll(), and kqueue.
+// the poll one we could do because it doesn't require an
+// extra file descriptor like the rest do, and which is buried in the
+// loop. Why is stat not sufficient? I *think* libuv wants to detect
+// non-selectable types and error out on those. But all we're
+// concerned about right now is whether the file descriptor is valid
+// or not.
+//
+// fstat() would seem to be a way to do that, but libev implements the
+// same function using this method:
+    int was_valid;
+#ifdef _WIN32
+    was_valid = vfd_open_(fd, 1); // raise python exception
+    if (was_valid != -1) {
+        vfd_free(fd);
+    }
+#else
+    was_valid = fcntl(fd, F_GETFD);
+    if (was_valid == -1) {
+#ifndef GEVENT_CFFI
+        // recall you can't use the Python API from CFFI,
+        // because these functions don't hold the GIL
+        PyErr_SetFromErrno(PyExc_OSError);
+#endif
+    }
+#endif
+    return was_valid;
+}
+
+
+#endif

--- a/src/gevent/libev/check_valid_fd.c
+++ b/src/gevent/libev/check_valid_fd.c
@@ -16,6 +16,8 @@
 */
 int gevent_check_fd_valid(int fd)
 {
+// See also gevent.os._check_fd_valid
+
 // TODO: libuv uses syscalls like poll(), epoll(), and kqueue.
 // the poll one we could do because it doesn't require an
 // extra file descriptor like the rest do, and which is buried in the

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -81,8 +81,9 @@ cdef extern from "callbacks.h":
 
 cdef extern from "stathelper.c":
     object _pystat_fromstructstat(void*)
-    int check_fd_valid(int) except -1
 
+cdef extern from "check_valid_fd.c":
+    int gevent_check_fd_valid(int) except -1
 
 UNDEF = libev.EV_UNDEF
 NONE = libev.EV_NONE
@@ -1083,7 +1084,7 @@ cdef public class io(watcher) [object PyGeventIOObject, type PyGeventIO_Type]:
             raise ValueError('fd must be non-negative: %r' % fd)
         if events & ~(libev.EV__IOFDSET | libev.EV_READ | libev.EV_WRITE):
             raise ValueError('illegal event mask: %r' % events)
-        check_fd_valid(fd)
+        gevent_check_fd_valid(fd)
 
         cdef int vfd = libev.vfd_open(fd)
         libev.ev_io_init(&self._watcher, <void *>gevent_callback_io, vfd, events)

--- a/src/gevent/libev/corecext.pyx
+++ b/src/gevent/libev/corecext.pyx
@@ -81,6 +81,7 @@ cdef extern from "callbacks.h":
 
 cdef extern from "stathelper.c":
     object _pystat_fromstructstat(void*)
+    int check_fd_valid(int) except -1
 
 
 UNDEF = libev.EV_UNDEF
@@ -1082,7 +1083,8 @@ cdef public class io(watcher) [object PyGeventIOObject, type PyGeventIO_Type]:
             raise ValueError('fd must be non-negative: %r' % fd)
         if events & ~(libev.EV__IOFDSET | libev.EV_READ | libev.EV_WRITE):
             raise ValueError('illegal event mask: %r' % events)
-        # All the vfd_functions are no-ops on POSIX
+        check_fd_valid(fd)
+
         cdef int vfd = libev.vfd_open(fd)
         libev.ev_io_init(&self._watcher, <void *>gevent_callback_io, vfd, events)
         self._w_watcher = <libev.ev_watcher*>&self._watcher

--- a/src/gevent/libev/libev_vfd.h
+++ b/src/gevent/libev/libev_vfd.h
@@ -95,7 +95,7 @@ static int vfd_open_(vfd_socket_t handle, int pyexc)
 	}
 	if (ioctlsocket(handle, FIONREAD, &arg) != 0) {
 		if (pyexc)
-			PyErr_Format(PyExc_IOError,
+			PyErr_Format(PyExc_OSError,
 #ifdef _WIN64
 				"%lld is not a socket (files are not supported)",
 #else
@@ -130,7 +130,7 @@ static int vfd_open_(vfd_socket_t handle, int pyexc)
 	if (vfd_num >= FD_SETSIZE) {
 		/* libev's select doesn't support more that FD_SETSIZE fds */
 		if (pyexc)
-			PyErr_Format(PyExc_IOError, "cannot watch more than %d sockets", (int)FD_SETSIZE);
+			PyErr_Format(PyExc_OSError, "cannot watch more than %d sockets", (int)FD_SETSIZE);
 		goto done;
 	}
 	/* allocate more space if needed */

--- a/src/gevent/libev/stathelper.c
+++ b/src/gevent/libev/stathelper.c
@@ -189,39 +189,3 @@ _pystat_fromstructstat(STRUCT_STAT *st)
 
     return v;
 }
-
-
-#include <fcntl.h>
-/**
-   Raises an exception if *fd* is not a valid open file handle.
-   *fd* is the platform specific version; we will call vfd_open if
-   needed.
-
-   Ignore the return value.
-*/
-int check_fd_valid(int fd)
-{
-// TODO: libuv uses syscalls like poll(), epoll(), and kqueue.
-// the poll one we could do because it doesn't require an
-// extra file descriptor like the rest do, and which is buried in the
-// loop. Why is stat not sufficient? I *think* libuv wants to detect
-// non-selectable types and error out on those. But all we're
-// concerned about right now is whether the file descriptor is valid
-// or not.
-//
-// fstat() would seem to be a way to do that, but libev implements the
-// same function using this method:
-    int was_valid;
-#ifdef _WIN32
-    was_valid = vfd_open_(fd, 1); // raise python exception
-    if (was_valid != -1) {
-        vfd_free(fd);
-    }
-#else
-    was_valid = fcntl(fd, F_GETFD);
-    if (was_valid == -1) {
-        PyErr_SetFromErrno(PyExc_OSError);
-    }
-#endif
-    return was_valid;
-}

--- a/src/gevent/libev/stathelper.c
+++ b/src/gevent/libev/stathelper.c
@@ -189,3 +189,39 @@ _pystat_fromstructstat(STRUCT_STAT *st)
 
     return v;
 }
+
+
+#include <fcntl.h>
+/**
+   Raises an exception if *fd* is not a valid open file handle.
+   *fd* is the platform specific version; we will call vfd_open if
+   needed.
+
+   Ignore the return value.
+*/
+int check_fd_valid(int fd)
+{
+// TODO: libuv uses syscalls like poll(), epoll(), and kqueue.
+// the poll one we could do because it doesn't require an
+// extra file descriptor like the rest do, and which is buried in the
+// loop. Why is stat not sufficient? I *think* libuv wants to detect
+// non-selectable types and error out on those. But all we're
+// concerned about right now is whether the file descriptor is valid
+// or not.
+//
+// fstat() would seem to be a way to do that, but libev implements the
+// same function using this method:
+    int was_valid;
+#ifdef _WIN32
+    was_valid = vfd_open_(fd, 1); // raise python exception
+    if (was_valid != -1) {
+        vfd_free(fd);
+    }
+#else
+    was_valid = fcntl(fd, F_GETFD);
+    if (was_valid == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+    }
+#endif
+    return was_valid;
+}

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -679,6 +679,12 @@ class loop(AbstractLoop):
 
         return io_watcher.multiplex(events)
 
+    def closing_fd(self, fd): # pylint:disable=unused-argument
+        # XXX: libev feeds an event here. DO THAT
+        if fd in self._io_watchers and self._io_watchers[fd]._multiplex_watchers:
+            return True
+        return False
+
     def prepare(self, ref=True, priority=None):
         # We run arbitrary code in python_prepare_callback. That could switch
         # greenlets. If it does that while also manipulating the active prepare

--- a/src/gevent/libuv/loop.py
+++ b/src/gevent/libuv/loop.py
@@ -1,10 +1,6 @@
 """
 libuv loop implementation
 """
-# pylint: disable=no-member
-from __future__ import absolute_import
-from __future__ import print_function
-
 import errno
 import os
 import signal
@@ -704,8 +700,9 @@ class loop(AbstractLoop):
         # that way, if we try to use this FD again for a new watcher, and
         # it is actually invalid, we get the right exception at construction time.
         # Only do this if we're actually going to be deferring the close; if we close
-        # immediately, open a new socket, and request a watcher, we could get this watcher
-        # object back
+        # immediately, open a new socket, and request a watcher for it, we could get this watcher
+        # object back because FDs get reused and the second socket very likely
+        # has the same FD as the original socket.
         if must_defer:
             # At this point, if the watcher is active, libev feeds a
             # synthetic event to it with ``ev_feed_fd_event``. This doesn't

--- a/src/gevent/libuv/watcher.py
+++ b/src/gevent/libuv/watcher.py
@@ -79,11 +79,15 @@ class libuv_error_wrapper(object):
                 args = args[1:]
             res = libuv_func(*args, **kwargs)
             if res is not None and res < 0:
-                raise UVFuncallError(
+                kind = UVFuncallError
+                if res == libuv.UV_EBADF:
+                    kind = lambda msg: OSError(abs(res), msg)
+                raise kind(
                     str(ffi.string(libuv.uv_err_name(res)).decode('ascii')
                         + ' '
                         + ffi.string(libuv.uv_strerror(res)).decode('ascii'))
                     + " Args: " + repr(args) + " KWARGS: " + repr(kwargs)
+                    + " UVError: " + str(res)
                 )
             return res
 

--- a/src/gevent/libuv/watcher.py
+++ b/src/gevent/libuv/watcher.py
@@ -1,9 +1,9 @@
 # pylint: disable=too-many-lines, protected-access, redefined-outer-name, not-callable
 # pylint: disable=no-member
-from __future__ import absolute_import, print_function
 
 import functools
 import sys
+import os
 
 from gevent.libuv import _corecffi # pylint:disable=no-name-in-module,import-error
 
@@ -400,6 +400,10 @@ class io(_base.IoMixin, watcher):
 
 
     def multiplex(self, events):
+        # libuv validates the FD when a watcher is originally
+        # created, but it may have gone invalid. Re-do the validation
+        # check here so we can raise the proper OSError.
+        os.fstat(self._fd)
         watcher = self._multiplexwatcher(events, self)
         self._multiplex_watchers.append(watcher)
         self._calc_and_update_events()

--- a/src/gevent/libuv/watcher.py
+++ b/src/gevent/libuv/watcher.py
@@ -14,6 +14,7 @@ libuv = _corecffi.lib
 
 from gevent._ffi import watcher as _base
 from gevent._ffi import _dbg
+from gevent.os import _check_fd_valid
 
 # A set of uv_handle_t* CFFI objects. Kept around
 # to keep the memory alive until libuv is done with them.
@@ -56,14 +57,6 @@ def _events_to_str(events): # export
     return _base.events_to_str(events, _events)
 
 
-if sys.platform.startswith('win32'):
-    # fstat doesn't work with sockets on windows.
-    # TODO: Figure out what libuv uses for its open verification and
-    # call that.
-    def _check_fd_valid(_fd):
-        return True
-else:
-    from os import fstat as _check_fd_valid
 
 class UVFuncallError(ValueError):
     pass

--- a/src/gevent/os.py
+++ b/src/gevent/os.py
@@ -79,12 +79,14 @@ _NO_DEFER_REG_FILE = True
 
 if fcntl:
     def _check_fd_valid(fd):
+        # see libev/check_valid_fd.c. This is what libev does;
+        # libuv is much more sophisticated.
         return fcntl.fcntl(fd, fcntl.F_GETFD)
 else:
     def _check_fd_valid(fd): # pylint: disable=unused-argument
         # Windows. Nothing we can reliably use here across
         # all event loops. We need to write some code and make it part
-        # of the
+        # of the event loop interface.
         pass
 
 if fcntl:

--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -10,12 +10,13 @@ import select as __select__
 from gevent.event import Event
 from gevent.hub import _get_hub_noargs as get_hub
 from gevent.hub import sleep as _g_sleep
-from gevent._compat import integer_types
+
 from gevent._compat import iteritems
 from gevent._util import copy_globals
 from gevent._util import _NONE
 
-from errno import EINTR
+from errno import EBADF
+
 _real_original_select = __select__.select
 if sys.platform.startswith('win32'):
     def _original_select(r, w, x, t):
@@ -54,6 +55,9 @@ else:
 
 __all__ = ['error'] + __implements__
 
+# This is now a plain OSError, we should never try to
+# recatch and throw these. But the constant needs to
+# remain for BWC.
 error = __select__.error
 
 __imports__ = copy_globals(__select__, globals(),
@@ -63,14 +67,18 @@ __imports__ = copy_globals(__select__, globals(),
 _EV_READ = 1
 _EV_WRITE = 2
 
-def get_fileno(obj):
-    try:
-        fileno_f = obj.fileno
-    except AttributeError:
-        if not isinstance(obj, integer_types):
-            raise TypeError('argument must be an int, or have a fileno() method: %r' % (obj,))
-        return obj
-    return fileno_f()
+def get_fileno(fileobj):
+    if isinstance(fileobj, int):
+        fd = fileobj
+    else:
+        try:
+            fd = int(fileobj.fileno())
+        except (AttributeError, TypeError, ValueError):
+            raise ValueError("Invalid file object: "
+                             "{!r}".format(fileobj)) from None
+    if fd < 0:
+        raise ValueError("Invalid file descriptor: {}".format(fd))
+    return fd
 
 
 class SelectResult(object):
@@ -92,14 +100,11 @@ class SelectResult(object):
         MAXPRI = loop.MAXPRI
 
         for fdlist, callback in fd_cb:
-            try:
-                for fd in fdlist:
-                    watcher = io(get_fileno(fd), callback.mask)
-                    watcher.priority = MAXPRI
-                    watchers.append(watcher)
-                    watcher.start(callback, fd, watcher)
-            except IOError as ex:
-                raise error(*ex.args)
+            for fd in fdlist:
+                watcher = io(get_fileno(fd), callback.mask)
+                watcher.priority = MAXPRI
+                watchers.append(watcher)
+                watcher.start(callback, fd, watcher)
 
     @staticmethod
     def _closeall(watchers):
@@ -176,14 +181,8 @@ def select(rlist, wlist, xlist, timeout=None): # pylint:disable=unused-argument
     #
     # We accept the *xlist* here even though we can't
     # below because this is all about error handling.
-    sel_results = ((), (), ())
-    try:
-        sel_results = _original_select(rlist, wlist, xlist, 0)
-    except error as e:
-        enumber = getattr(e, 'errno', None) or e.args[0]
-        if enumber != EINTR:
-            # Ignore interrupted syscalls
-            raise
+    # Since Python 3.5, we don't need to worry about EINTR handling.
+    sel_results = _original_select(rlist, wlist, xlist, 0)
 
     if sel_results[0] or sel_results[1] or sel_results[2] or (timeout is not None and timeout == 0):
         # If we actually had stuff ready, go ahead and return it. No need
@@ -225,6 +224,10 @@ class PollResult(object):
 
         self.events.add((fd, result_flags))
         self.event.set()
+
+    def add_error_before_io(self, fd):
+        # This is before we do any IO, don't set the event
+        self.events.add((fd, POLLNVAL))
 
 class poll(object):
     """
@@ -283,14 +286,21 @@ class poll(object):
         """
         self.register(fd, eventmask)
 
-    def _get_started_watchers(self, watcher_cb):
+    def _get_started_watchers(self, poll_result):
         watchers = []
         io = self.loop.io
         MAXPRI = self.loop.MAXPRI
-
+        watcher_cb = poll_result.add_event
         try:
             for fd, flags in iteritems(self.fds):
-                watcher = io(fd, flags)
+                try:
+                    watcher = io(fd, flags)
+                except OSError as ex:
+                    if ex.errno != EBADF:
+                        raise
+                    poll_result.add_error_before_io(fd)
+                    continue
+
                 watchers.append(watcher)
                 watcher.priority = MAXPRI
                 watcher.start(watcher_cb, fd, pass_events=True)
@@ -314,7 +324,7 @@ class poll(object):
            i.e., block. This was always the case with libev.
         """
         result = PollResult()
-        watchers = self._get_started_watchers(result.add_event)
+        watchers = self._get_started_watchers(result)
         try:
             if timeout is not None:
                 if timeout < 0:

--- a/src/gevent/select.py
+++ b/src/gevent/select.py
@@ -11,7 +11,6 @@ from gevent.event import Event
 from gevent.hub import _get_hub_noargs as get_hub
 from gevent.hub import sleep as _g_sleep
 
-from gevent._compat import iteritems
 from gevent._util import copy_globals
 from gevent._util import _NONE
 
@@ -292,7 +291,7 @@ class poll(object):
         MAXPRI = self.loop.MAXPRI
         watcher_cb = poll_result.add_event
         try:
-            for fd, flags in iteritems(self.fds):
+            for fd, flags in self.fds.items():
                 try:
                     watcher = io(fd, flags)
                 except OSError as ex:

--- a/src/gevent/testing/monkey_test.py
+++ b/src/gevent/testing/monkey_test.py
@@ -75,7 +75,7 @@ support.wait_threads_exit = wait_threads_exit
 try:
     from test import support as ts
 except ImportError:
-    pass
+    ts = None
 else:
     ts.threading_setup = threading_setup
     ts.threading_cleanup = threading_cleanup
@@ -145,6 +145,13 @@ temp_handle, temp_path = tempfile.mkstemp(prefix=test_name, suffix='.py', text=T
 os.write(temp_handle, module_source.encode('utf-8'))
 os.close(temp_handle)
 remove_file = not os.environ.get('GEVENT_DEBUG')
+if remove_file and ts is not None:
+    # Some of the stdlib tests spew a lot of data to stdout. This
+    # makes it hard to read results of a whole run of all the monkey
+    # stdlib tests. The main CPython regression runner, the equivalent
+    # of ``gevent.tests`` sets this to false and that stops some of it.
+    ts.verbose = 0
+    print('Disabling verbose stdlib tests')
 try:
     module_code = compile(module_source,
                           temp_path,

--- a/src/gevent/tests/test__select.py
+++ b/src/gevent/tests/test__select.py
@@ -120,6 +120,7 @@ class TestPossibleCrashes(greentest.TestCase):
     loop implementation) a IO watcher for a closed/invalid file descriptor.
 
     See https://github.com/gevent/gevent/issues/2100
+    See test__selectors.py
     """
 
     def test_closing_object_while_selecting(self):
@@ -148,7 +149,7 @@ class TestPossibleCrashes(greentest.TestCase):
         #     can run immediately. Which it did, and closed the FD, breaking the loops.
         #     The fix is to use a check watcher instead.
         # (2) libuv doesn't implement the function that lets us determine that we
-        #     need to defer the check.
+        #     need to defer the check. (fixing this involved rolling our own.)
         sock = socket.socket()
         self.addCleanup(sock.close)
         gevent.spawn(sock.close)

--- a/src/gevent/tests/test__select.py
+++ b/src/gevent/tests/test__select.py
@@ -112,7 +112,7 @@ class TestSelectTypes(greentest.TestCase):
         self.assertRaises(TypeError, select.select, ['hello'], [], [], 0.001)
 
 
-
+@greentest.skipOnWindows("Things like os.close don't work on Windows")
 class TestPossibleCrashes(greentest.TestCase):
     """
     Tests for the crashes and unexpected exceptions

--- a/src/gevent/tests/test__selectors.py
+++ b/src/gevent/tests/test__selectors.py
@@ -6,6 +6,7 @@ from gevent import socket
 from gevent import selectors
 
 import gevent.testing as greentest
+from gevent.testing import timing
 
 class SelectorTestMixin(object):
 
@@ -104,6 +105,65 @@ class GeventSelectorTest(SelectorTestMixin,
             for pair in pairs:
                 for s in pair:
                     s.close()
+
+
+
+class TestPossibleCrashes(greentest.TestCase):
+    """
+    Tests for the crashes and unexpected exceptions
+    that happen when we try to use or create (depending on
+    loop implementation) a IO watcher for a closed/invalid file descriptor.
+
+    See https://github.com/gevent/gevent/issues/2100
+    See test__select.py
+    """
+
+    def test_closing_object_while_selecting(self):
+        sock = socket.socket()
+        self.addCleanup(sock.close)
+        gevent.spawn(sock.close)
+
+        sel = selectors.GeventSelector()
+        sel.register(sock, selectors.EVENT_READ)
+        # This call needs to be blocking so we get all the way
+        # to having an open, started IO watcher when the
+        # socket gets closed.
+        with sel:
+            sel.select(timeout=timing.SMALLEST_RELIABLE_DELAY)
+
+
+    def _close_invalid_sock(self, sock):
+        # Because we closed the FD already (which raises EBADF when done again), but we
+        # still need to take care of the gevent-resources
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    def test_closing_fd_while_selecting(self):
+        # using regular os.close will
+        # crash under libuv
+        from gevent import os
+
+        sock = socket.socket()
+        self.addCleanup(self._close_invalid_sock, sock)
+        gevent.spawn(os.close, sock.fileno())
+
+        sel = selectors.GeventSelector()
+        sel.register(sock, selectors.EVENT_READ)
+
+        with sel:
+            sel.select(timeout=timing.SMALLEST_RELIABLE_DELAY)
+
+    def test_closing_fd_before_selecting(self):
+        import os
+        sock = socket.socket()
+        self.addCleanup(self._close_invalid_sock, sock)
+        os.close(sock.fileno())
+
+        sel = selectors.GeventSelector()
+        with self.assertRaisesRegex(ValueError, 'Invalid file'):
+            sel.register(sock, selectors.EVENT_READ)
 
 
 

--- a/src/gevent/tests/test__selectors.py
+++ b/src/gevent/tests/test__selectors.py
@@ -107,7 +107,7 @@ class GeventSelectorTest(SelectorTestMixin,
                     s.close()
 
 
-
+@greentest.skipOnWindows("Things like os.close don't work on Windows")
 class TestPossibleCrashes(greentest.TestCase):
     """
     Tests for the crashes and unexpected exceptions

--- a/src/gevent/tests/test__subprocess.py
+++ b/src/gevent/tests/test__subprocess.py
@@ -316,7 +316,7 @@ class TestFDs(unittest.TestCase):
 
     @mock.patch('os.closerange')
     @mock.patch('gevent.subprocess._set_inheritable')
-    @mock.patch('os.close')
+    @mock.patch('gevent.subprocess.os_close')
     def test_close_fds_brute_force(self, close, set_inheritable, closerange):
         keep = (
             4, 5,
@@ -349,7 +349,7 @@ class TestFDs(unittest.TestCase):
     @mock.patch('os.listdir')
     @mock.patch('os.closerange')
     @mock.patch('gevent.subprocess._set_inheritable')
-    @mock.patch('os.close')
+    @mock.patch('gevent.subprocess.os_close')
     def test_close_fds_from_path(self, close, set_inheritable, closerange, listdir):
         keep = (
             4, 5,


### PR DESCRIPTION
And more. Writing tests for 2100, I discovered several other ways to crash the interpreter, so those are all fixed now too. 

Lots of good info in the commit messages and the comments in the code. I still have some finishing touches, but this should be the bulk of it. 

- [ ] Can/should libuv feed an event like libev does?
- [ ] I need to integrate the libev changes into libev-cffi
- [ ] I need to write similar crashing tests for GeventSelector.

