### PR TITLE
Fix #1895 by tweaking the assertion.

### DIFF
--- a/docs/changes/1895.bugfix.rst
+++ b/docs/changes/1895.bugfix.rst
@@ -1,0 +1,5 @@
+Prevent an ``AssertionError`` (from ``AbstractLinkable``, such as
+locks, events, etc) from being printed after ``os.fork`` under certain
+conditions.
+
+See also :issue:`2058`.

--- a/src/gevent/event.py
+++ b/src/gevent/event.py
@@ -83,9 +83,10 @@ class Event(AbstractLinkable): # pylint:disable=undefined-variable
         self._flag = False
 
     def __str__(self):
-        return '<%s.%s %s _links[%s]>' % (
+        return '<%s.%s at 0x%x %s _links[%s]>' % (
             self.__class__.__module__,
             self.__class__.__name__,
+            id(self),
             'set' if self._flag else 'clear',
             self.linkcount()
         )

--- a/src/gevent/exceptions.py
+++ b/src/gevent/exceptions.py
@@ -6,9 +6,6 @@ Exceptions.
 .. versionadded:: 1.3b1
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from greenlet import GreenletExit
 

--- a/src/gevent/monkey/_patch_thread_common.py
+++ b/src/gevent/monkey/_patch_thread_common.py
@@ -7,11 +7,13 @@ Internal use only.
 """
 import sys
 
-from ._util import _patch_module
-from ._util import _queue_warning
-from ._util import _notify_patch
+from gevent.exceptions import LoopExit
 
 from ._state import is_object_patched
+from ._util import _notify_patch
+from ._util import _patch_module
+from ._util import _queue_warning
+
 
 def _patch_existing_locks(threading):
     if len(list(threading.enumerate())) != 1:
@@ -191,8 +193,9 @@ class BasePatcher:
             self.patch_logging()
 
     def patch_event(self):
-        from .api import patch_item
         from gevent.event import Event
+
+        from .api import patch_item
         patch_item(self.threading_mod, 'Event', Event)
         # Python 2 had `Event` as a function returning
         # the private class `_Event`. Some code may be relying
@@ -215,8 +218,9 @@ class BasePatcher:
 
     def patch__threading_local(self):
         _threading_local = __import__('_threading_local')
-        from .api import patch_item
         from gevent.local import local
+
+        from .api import patch_item
         patch_item(_threading_local, 'local', local)
 
     def patch_active_threads(self):
@@ -266,14 +270,19 @@ class BasePatcher:
             # XXX: There's probably a better way to do this. Probably need to take a
             # step back and look at the whole picture.
             main_thread._ident = get_ident()
-            orig_shutdown()
+            try:
+                orig_shutdown()
+            except LoopExit: # pragma: no cover
+                pass
             patch_item(threading_mod, '_shutdown', orig_shutdown)
         patch_item(threading_mod, '_shutdown', _shutdown)
 
     @staticmethod # Static to be sure we don't accidentally capture `self` and keep it alive
     def _make_existing_non_main_thread_join_func(thread, thread_greenlet, threading_mod):
-        from gevent.hub import sleep
         from time import time
+
+        from gevent.hub import sleep
+
         # TODO: This is almost the algorithm that the 3.13 _ThreadHandle class
         # employs. UNIFY them.
         def join(timeout=None):

--- a/src/gevent/monkey/_patch_thread_lt313.py
+++ b/src/gevent/monkey/_patch_thread_lt313.py
@@ -6,7 +6,7 @@ prior to 3.13.
 Internal use only.
 """
 import sys
-
+from gevent.exceptions import LoopExit
 
 from ._patch_thread_common import BasePatcher
 
@@ -72,7 +72,10 @@ class Patcher(BasePatcher):
             # acquire should be our own (hopefully), and the call to
             # _stop that orig_shutdown makes will discard it.
 
-            orig_shutdown()
+            try:
+                orig_shutdown()
+            except LoopExit: # pragma: no cover
+                pass
             patch_item(threading_mod, '_shutdown', orig_shutdown)
 
         patch_item(threading_mod, '_shutdown', _shutdown)


### PR DESCRIPTION
Careful examination of the circumstances strongly suggest that this state is not a problem in the only scenario I have found that leads to it.

Add a test for this.

Also make our thread patches ignore LoopExit when calling threading._shutdown; that's happening at process death anyway.