### PR TITLE
Fix 2139 by typing the ivar correctly.

### DIFF
--- a/docs/changes/2139.bugfix.rst
+++ b/docs/changes/2139.bugfix.rst
@@ -1,0 +1,6 @@
+Fix a ``TypeError`` in the C extensions when attempting to put items
+into a full ``SimpleQueue.``
+
+It is believed this problem started in version 25.4.1. On older
+versions, using the environment variable ``PURE_PYTHON`` or
+``GEVENT_PURE_PYTHON`` works around

--- a/src/gevent/_gevent_cqueue.pxd
+++ b/src/gevent/_gevent_cqueue.pxd
@@ -94,7 +94,7 @@ cdef class Queue(SimpleQueue):
 @cython.internal
 cdef class ItemWaiter(Waiter):
     cdef readonly item
-    cdef readonly Queue queue
+    cdef readonly SimpleQueue queue
 
 
 cdef class UnboundQueue(Queue):

--- a/src/gevent/_util.py
+++ b/src/gevent/_util.py
@@ -130,8 +130,8 @@ def import_c_accel(globs, cname):
         return
 
 
-    from gevent._compat import PURE_PYTHON
-    if PURE_PYTHON:
+    from gevent._compat import pure_python_module
+    if pure_python_module(name):
         return
 
     import importlib

--- a/src/gevent/tests/test__queue.py
+++ b/src/gevent/tests/test__queue.py
@@ -134,10 +134,10 @@ class SubscriptMixin:
             self.assertIsInstance(kind[int], type(stdlib_kind[int]))
 
 
-class TestQueue(SubscriptMixin, UsesOnlyOneItemMixin, TestCase):
+class TestSimpleQueue(SubscriptMixin, UsesOnlyOneItemMixin, TestCase):
 
     def _getFUT(self):
-        return queue.Queue
+        return queue.SimpleQueue
 
     def test_get_nowait_simple(self):
         result = []
@@ -447,11 +447,11 @@ class TestChannel(SubscriptMixin, UsesOnlyOneItemMixin, TestCase):
         self.assertEqual(r, [])
 
 
-class TestJoinableQueue(TestQueue):
+class TestQueue(TestSimpleQueue):
     queue = queue
 
     def _getFUT(self):
-        return queue.JoinableQueue
+        return queue.Queue
 
     def test_task_done(self):
         channel = self._makeOne()
@@ -534,7 +534,7 @@ class TestGetInterrupt(AbstractTestWeakRefMixin, AbstractGenericGetTestCase):
 
     Timeout = Empty
 
-    kind = queue.Queue
+    kind = queue.SimpleQueue
 
     def wait(self, timeout):
         return self._makeOne().get(timeout=timeout)
@@ -543,7 +543,7 @@ class TestGetInterrupt(AbstractTestWeakRefMixin, AbstractGenericGetTestCase):
         return self.kind()
 
 class TestGetInterruptJoinableQueue(TestGetInterrupt):
-    kind = queue.JoinableQueue
+    kind = queue.Queue
 
 class TestGetInterruptLifoQueue(TestGetInterrupt):
     kind = queue.LifoQueue
@@ -556,7 +556,7 @@ class TestGetInterruptChannel(TestGetInterrupt):
 
 
 class TestPutInterrupt(AbstractGenericGetTestCase):
-    kind = queue.Queue
+    kind = queue.SimpleQueue
     Timeout = Full
 
     def setUp(self):
@@ -573,7 +573,7 @@ class TestPutInterrupt(AbstractGenericGetTestCase):
 
 
 class TestPutInterruptJoinableQueue(TestPutInterrupt):
-    kind = queue.JoinableQueue
+    kind = queue.Queue
 
 class TestPutInterruptLifoQueue(TestPutInterrupt):
     kind = queue.LifoQueue


### PR DESCRIPTION
Update the tests; because JoinableQueue and Queue became the same thing, we weren't actually testing the SimpleQueue anymore.

Also update the handling of GEVENT_PURE_PYTHON to allow disabling specific modules.