### PR TITLE
docs only: 25.8.1 changelog has duped 2111 ref - probably 2119 (or at least that is one useful choice)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,9 +91,9 @@ Bugfixes
   See :issue:`2100`.
 - Fix some ignored AssertionErrors after forking on older versions of
   Python.
-
-  See also :issue:`2119`.
   See :issue:`2111`.
+- Fix ``AttributeError`` for ``_handle`` on v3.13.5+.
+  See :issue:`2119`.
 - Make the classes in ``gevent.queue`` more compatible with classes that
   expect to subclass the standard library queue classes.
   See :issue:`2114`.


### PR DESCRIPTION
Changelog for released version 25.8.1 should reference #2119 because from the towncrier snippet for 2111 it is not clear that the release *also* is the first to resolve the following error, which people on stable distros are only starting to encounter recently:
> AttributeError: '_DummyThread' object has no attribute '_handle'