### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,83 @@ jobs:
         with:
           parallel-finished: true
 
+  test_win_arm64:
+    runs-on: windows-11-arm
+    name: test(${{ matrix.python-version }}, windows-11-arm)
+    env:
+      # Reuse APPVEYOR flag to share the same known_failures logic
+      # originally written for AppVeyor Windows builds.
+      APPVEYOR: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: setup.py
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install -U pip setuptools wheel twine
+          python -m pip install -q -U 'cffi;platform_python_implementation=="CPython"'
+          python -m pip install -q -U 'cython>=3.2.1'
+          python -m pip install -U 'greenlet>=3.2.0;platform_python_implementation=="CPython"'
+
+      - name: Build gevent
+        shell: pwsh
+        run: |
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+
+      - name: Check gevent build
+        shell: pwsh
+        run: |
+          Get-ChildItem dist
+          twine check dist/*whl
+
+      - name: Upload gevent wheel
+        uses: actions/upload-artifact@v6
+        with:
+          name: gevent-windows-arm64-${{ matrix.python-version }}.whl
+          path: dist/*whl
+
+      - name: Install gevent
+        shell: pwsh
+        run: |
+          $whl = (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+          python -m pip install -U "$whl[test]"
+
+      - name: Report environment details
+        shell: pwsh
+        run: |
+          python --version
+          python -c "import greenlet; print(greenlet, greenlet.__version__)"
+          python -c "import gevent.core; print(gevent.core.loop)"
+          python -c "import gevent.resolver.cares; print(gevent.resolver.cares)"
+          python -c "from gevent._compat import get_clock_info; print(get_clock_info('perf_counter'))"
+
+      - name: "Tests: Basic"
+        shell: pwsh
+        env:
+          GEVENTTEST_USE_RESOURCES: "-network"
+        run: |
+          python -m gevent.tests --second-chance --config known_failures.py
+
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        shell: pwsh
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: |
+          twine upload --skip-existing dist/*
 
   test_no_embed:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           pip install -U pip
           pip install -U -q setuptools wheel twine
           pip install -q -U 'cffi;platform_python_implementation=="CPython"'
-          pip install -q -U 'cython>=3.2.1'
+          pip install -q -U 'cython>=3.2.4'
           # Use a debug version of greenlet to help catch any errors earlier.
           CFLAGS="$CFLAGS -Og -g -UNDEBUG" pip install -v --no-binary :all: 'greenlet>=3.2.0;platform_python_implementation=="CPython" '
 
@@ -402,7 +402,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -419,7 +423,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel twine
           python -m pip install -q -U 'cffi;platform_python_implementation=="CPython"'
-          python -m pip install -q -U 'cython>=3.2.1'
+          python -m pip install -q -U 'cython>=3.2.4'
           python -m pip install -U 'greenlet>=3.2.0;platform_python_implementation=="CPython"'
 
       - name: Build gevent

--- a/docs/changes/2172.feature.rst
+++ b/docs/changes/2172.feature.rst
@@ -1,0 +1,1 @@
+Build and publish Windows 11 ARM wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 requires = [
      "setuptools >= 40.8.0",
 
-     "Cython >= 3.2.1",
+     "Cython >= 3.2.4",
      # See version requirements in setup.py
      "cffi >= 1.17.1 ; platform_python_implementation == 'CPython'",
      # Python 3.7 requires at least 0.4.14, which is ABI incompatible with earlier

--- a/src/gevent/testing/sysinfo.py
+++ b/src/gevent/testing/sysinfo.py
@@ -102,6 +102,7 @@ RUNNING_ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS')
 RUNNING_ON_TRAVIS = os.environ.get('TRAVIS') or RUNNING_ON_GITHUB_ACTIONS
 RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
 RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
+RUNNING_ON_GITHUB_ACTIONS_WINDOWS = RUNNING_ON_GITHUB_ACTIONS and WIN
 RUNNING_ON_MANYLINUX = os.environ.get('GEVENT_MANYLINUX')
 # I'm not sure how to reliably auto-detect this, without
 # importing platform, something we don't want to do.

--- a/src/gevent/testing/sysinfo.py
+++ b/src/gevent/testing/sysinfo.py
@@ -65,6 +65,7 @@ PY311 = None
 PY312 = None
 PY313 = None
 PY314 = None
+PY315 = None
 
 NON_APPLICABLE_SUFFIXES = ()
 if sys.version_info[0] == 3:
@@ -82,6 +83,8 @@ if sys.version_info[0] == 3:
         PY313 = True
     if sys.version_info[1] >= 14:
         PY314 = True
+    if sys.version_info[1] >= 15:
+        PY315 = True
 
 else: # pragma: no cover
     # Python 4?

--- a/src/gevent/tests/known_failures.py
+++ b/src/gevent/tests/known_failures.py
@@ -83,6 +83,7 @@ PY3 = _AttrCondition('PY3')
 OSX = _AttrCondition('OSX')
 LIBUV = _AttrCondition('LIBUV')
 WIN = _AttrCondition('WIN')
+WIN_GHA = _AttrCondition('RUNNING_ON_GITHUB_ACTIONS_WINDOWS')
 APPVEYOR = _AttrCondition('RUNNING_ON_APPVEYOR')
 TRAVIS = _AttrCondition('RUNNING_ON_TRAVIS')
 CI = _AttrCondition('RUNNING_ON_CI')
@@ -361,8 +362,10 @@ class Definitions(metaclass=DefinitionsMeta):
         But it also takes nearly that long in 3.7. 3.6 and earlier are much faster.
 
         It also takes just over 100s on PyPy 3.7.
+
+        On Windows GitHub Actions, this consistently times out beyond the default 100s limit.
         """,
-        when=(PYPY & TRAVIS & LIBUV) | PY380_EXACTLY,
+        when=(PYPY & TRAVIS & LIBUV) | PY380_EXACTLY | WIN_GHA,
         # https://bitbucket.org/pypy/pypy/issues/2769/systemerror-unexpected-internal-exception
         run_alone=(CI & LEAKTEST & PY3) | (PYPY & LIBUV),
         # This often takes much longer on PyPy on CI.

--- a/src/gevent/thread.py
+++ b/src/gevent/thread.py
@@ -78,7 +78,22 @@ if hasattr(__thread__, 'set_name'):
 
 def get_ident(gr=None):
     if gr is None:
-        gr = getcurrent()
+        try:
+            gr = getcurrent()
+        except RuntimeError:
+            # greenlet is being finalized, being called very late during
+            # interpreter shutdown. Some earlier versions returned
+            # potentially broken objects at that phase, then it switched to
+            # returning None (but the C API we use from Cython code raised
+            # an exception), then this API also started raising an
+            # exception. We have one test failure,
+            # test__lock:TestLockReinitAfterFork.test_it which complains
+            # because the RuntimeError gets printed to stderr when we're
+            # not expecting it. In that case, this API is used to determine
+            # if threading.Lock objects are owned by the current "thread"
+            # (greenlet), so there's not a good value to return here. Reverting to the
+            # previous behaviour of returning id(None) fixes that test.
+            gr = None
     return id(gr)
 
 


### PR DESCRIPTION
This PR adds Windows ARM64 support to the gevent CI

- Adds a new `test_win_arm64` job running on `windows-11-arm` for Python 3.11, 3.12, 3.13, and 3.14.
- Reuses the `APPVEYOR=1` flag to share the existing `known_failures.py` logic originally written for AppVeyor Windows builds.
- Builds, tests, and uploads the ARM64 wheel as a separate artifact.
- Publishes the wheel to PyPI on tag pushes, consistent with other platform jobs.
- Adds `RUNNING_ON_GITHUB_ACTIONS_WINDOWS` detection in `sysinfo.py` to identify Windows GitHub Actions runners.
- Adds a `WIN_GHA` condition in `known_failures.py` using the new flag, and extends the PyPy/TRAVIS/LIBUV timeout failure to also apply on `WIN_GHA` where it consistently exceeds the 100s limit.

Note: PyPy and Python versions older than 3.11 are not supported on Windows ARM64 and are excluded.