### PR TITLE
Fix bare except in _addresses.py: use except struct.error

### DIFF
--- a/src/gevent/resolver/_addresses.py
+++ b/src/gevent/resolver/_addresses.py
@@ -60,7 +60,7 @@ def _ipv4_inet_aton(text):
     try:
         ints = [int(part) for part in parts]
         return struct.pack('BBBB', *ints)
-    except:
+    except struct.error:
         raise AddressSyntaxError(text)
 
 


### PR DESCRIPTION
The bare `except:` clause in `_ipv4_inet_aton()` catches `BaseException`, including `SystemExit` and `KeyboardInterrupt`. The only exception that can realistically be raised here is `struct.error` (when an integer part exceeds the 0–255 byte range for `struct.pack('BBBB', ...)`), since `int(part)` on valid digit bytes succeeds normally.

Changing `except:` to `except struct.error:` makes the intent explicit and prevents accidentally silencing signals or shutdown exceptions.