### PR TITLE
Make gevent.os.close not init the hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,14 @@ jobs:
       - name: Install ccache (ubuntu)
         if: startsWith(runner.os, 'Linux')
         run: |
-          sudo apt-get install -y ccache sed gcc
+          sudo apt-get install -y ccache sed gcc libffi-dev
           echo CCACHE_DIR=$HOME/.ccache >>$GITHUB_ENV
           mkdir -p $HOME/.ccache
       - name: Install ccache (macos)
         if: startsWith(runner.os, 'macOS')
         run: |
           brew install ccache
+          brew install libffi
           echo CFLAGS=$CFLAGS -Wno-parentheses-equality >>$GITHUB_ENV
           echo CCACHE_DIR=$HOME/.ccache >>$GITHUB_ENV
           mkdir -p $HOME/.ccache
@@ -213,7 +214,10 @@ jobs:
         run: |
           pip install -U pip
           pip install -U -q setuptools wheel twine
-          pip install -q -U 'cffi;platform_python_implementation=="CPython"'
+          # The --no-binary are because these projects have uploaded
+          # 3.15 wheels that don't work right on 3.15b4, so we need to disable
+          # them.
+          pip install -q -U --no-binary=:all: 'cffi;platform_python_implementation=="CPython"'
           pip install -q -U --no-binary=:all: 'cython>=3.2.4'
           # Use a debug version of greenlet to help catch any errors earlier.
           CFLAGS="$CFLAGS -Og -g -UNDEBUG" pip install -v --no-binary :all: 'greenlet>=3.2.0;platform_python_implementation=="CPython" '
@@ -443,7 +447,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel twine
           python -m pip install -q -U 'cffi;platform_python_implementation=="CPython"'
-          python -m pip install -q -U --no-binary=:all: 'cython>=3.2.4'
+          python -m pip install -q -U 'cython>=3.2.4'
           python -m pip install -U --no-binary=:all: 'greenlet>=3.2.0;platform_python_implementation=="CPython"'
 
       - name: Build gevent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           pip install -U pip
           pip install -U -q setuptools wheel twine
           pip install -q -U 'cffi;platform_python_implementation=="CPython"'
-          pip install -q -U 'cython>=3.2.4'
+          pip install -q -U --no-binary=:all: 'cython>=3.2.4'
           # Use a debug version of greenlet to help catch any errors earlier.
           CFLAGS="$CFLAGS -Og -g -UNDEBUG" pip install -v --no-binary :all: 'greenlet>=3.2.0;platform_python_implementation=="CPython" '
 
@@ -406,7 +406,7 @@ jobs:
 
   test_win:
     runs-on:  ${{ matrix.os }}
-    name: test(${{ matrix.python-version }}, ${{ matrix.os }})
+    name: test (${{ matrix.python-version }}, ${{ matrix.os }})
     env:
       # Reuse APPVEYOR flag to share the same known_failures logic
       # originally written for AppVeyor Windows builds.
@@ -443,8 +443,8 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel twine
           python -m pip install -q -U 'cffi;platform_python_implementation=="CPython"'
-          python -m pip install -q -U 'cython>=3.2.4'
-          python -m pip install -U 'greenlet>=3.2.0;platform_python_implementation=="CPython"'
+          python -m pip install -q -U --no-binary=:all: 'cython>=3.2.4'
+          python -m pip install -U --no-binary=:all: 'greenlet>=3.2.0;platform_python_implementation=="CPython"'
 
       - name: Build gevent
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,13 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14.5"
-          - "3.15-dev"
+          # 3.15b4 seems completely incompatible with the
+          # binary wheels for CFFI, which at this writing, are
+          # from the first of July, long before B4. Most tests fail
+          # with segfaults immediately on x86 and arm both. So disabling for now
+          # (I don't know how we'd go about building our own wheel; building our own
+          # cython wheel failed with several different errors)
+          # - "3.15-dev"
         exclude:
           - os: windows-11-arm
             python-version: "3.10"

--- a/docs/changes/+d6cf4032.removal.rst
+++ b/docs/changes/+d6cf4032.removal.rst
@@ -1,0 +1,4 @@
+In a future version (early 2027), ``gevent.monkey.patch_all`` will ONLY accept
+keyword arguments. Currently, you could be calling it with positional
+arguments, although that has never been the intent or documented way
+to call it.

--- a/docs/changes/+e07b546a.bugfix.rst
+++ b/docs/changes/+e07b546a.bugfix.rst
@@ -1,0 +1,2 @@
+Make ``gevent.os.close`` not initialize a hub if one wasn't already present.
+In that case, it can just directly close the file descriptor.

--- a/scripts/releases/make-manylinux
+++ b/scripts/releases/make-manylinux
@@ -197,8 +197,10 @@ if [ -d /gevent -a -d /opt/python ]; then
         # The downside is that we must install dependencies manually.
         # NOTE: We can't upgrade ``wheel`` because ``auditwheel`` depends on
         # it, and auditwheel is installed in one of these environments.
-        time python -m pip install  -U 'cython >= 3.2'
-        time python -mpip install -U cffi 'greenlet >= 3.2' setuptools
+        time python -m pip install  -U --no-binary :all: 'cython >= 3.2'
+        # see ci.yml about --no-binary :all:: Incompatible wheels built for
+        # 3.15b3 break on 3.15b4.
+        time python -mpip install -U --no-binary :all: cffi 'greenlet >= 3.2' setuptools
         echo "$variant: Building wheel"
         time (python setup.py bdist_wheel)
         PATH="$OPATH" auditwheel repair dist/gevent*.whl

--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -667,8 +667,16 @@ def patch_all(socket=True, dns=True, time=True, select=True, thread=True, os=Tru
        Add the ``contextvars`` argument.
     .. versionchanged:: 1.5
        Better handling of patching more than once.
+    .. versionchanged:: NEXT
+       A future version (released in early 2027) will make all arguments keyword-only. Users calling
+       this API positionally will need to migrate to keywords.
     """
     # pylint:disable=too-many-locals,too-many-branches
+
+    # See test__threading.py for implications of the order in which
+    # we patch modules. We could rearrange the arguments, but they're not
+    # keyword only; somebody could be calling ``patch_all(True, True, False, True)``
+    # so that would be a breaking change, requiring notification
 
     # Check to see if they're changing the patched list
     _warnings, first_time, modules_to_patch = _check_repatching(**locals())

--- a/src/gevent/os.py
+++ b/src/gevent/os.py
@@ -47,6 +47,7 @@ import os
 from stat import S_ISREG
 
 from gevent.hub import _get_hub_noargs as get_hub
+from gevent.hub import _get_hub
 from gevent.hub import reinit
 from gevent.event import Event
 from gevent._config import config
@@ -133,7 +134,12 @@ if fcntl:
         if S_ISREG(stats.st_mode) and _NO_DEFER_REG_FILE:
             return _close(fd)
 
-        hub = get_hub()
+        # Don't init the hub if not already in use. If not
+        # in use, we can just close regularly, there's no
+        # chance the FD was being used for IO.
+        hub = _get_hub()
+        if hub is None:
+            return _close(fd)
         loop = hub.loop
 
         if fd in _closing_fd_to_event:

--- a/src/gevent/testing/patched_tests_setup.py
+++ b/src/gevent/testing/patched_tests_setup.py
@@ -1158,11 +1158,17 @@ if sys.version_info[:3] < (3, 8, 10):
         'test_httplib.BasicTest.test_dir_with_added_behavior_on_status',
         'test_httplib.TunnelTests.test_tunnel_connect_single_send_connection_setup',
         'test_ssl.TestSSLDebug.test_msg_callback_deadlock_bpo43577',
-        # This one fails with the updated certs
-        'test_ssl.ContextTests.test_load_verify_cadata',
         # This one times out on 3.7.1 on Appveyor
         'test_ftplib.TestTLS_FTPClassMixin.test_retrbinary_rest',
     ]
+
+disabled_tests += [
+    # These are flaky and depend on the exact version of the tests,
+    # the exact version of CA data, the exact version of the stdlib
+    # ssl module, etc. They sometimes break only on musl.
+    'test_ssl.ContextTests.test_load_verify_cadata',
+    'test_ssl.SimpleBackgroundTests.test_connect_cadata',
+]
 
 if RESOLVER_DNSPYTHON:
     disabled_tests += [

--- a/src/gevent/tests/known_failures.py
+++ b/src/gevent/tests/known_failures.py
@@ -98,6 +98,7 @@ PY313LT5 = ConstantCondition(
     sys.version_info[:2] == (3, 13)
     and sys.version_info[2] < 5
 )
+PY315B4_EXACTLY = ConstantCondition(sys.version_info == (3, 15, 0, 'beta', 4))
 
 class _Definition(object):
     __slots__ = (
@@ -312,9 +313,12 @@ class Definitions(metaclass=DefinitionsMeta):
     ).ignored(
         """
         This fails to run a single test. It looks like just importing the module
-        can hang. All I see is the output from patch_all()
+        can hang. All I see is the output from patch_all().
+
+        Currently crashing on Python 3.15b4 on windows. I'm suspicious
+        of problems with old CFFI wheels.
         """,
-        when=APPVEYOR & PYPY3
+        when=(APPVEYOR & PYPY3) | (APPVEYOR & PY315B4_EXACTLY)
     )
 
     test__monkey_sigchld_2 = Ignored(

--- a/src/gevent/tests/known_failures.py
+++ b/src/gevent/tests/known_failures.py
@@ -98,7 +98,7 @@ PY313LT5 = ConstantCondition(
     sys.version_info[:2] == (3, 13)
     and sys.version_info[2] < 5
 )
-PY315B4_EXACTLY = ConstantCondition(sys.version_info == (3, 15, 0, 'beta', 4))
+
 
 class _Definition(object):
     __slots__ = (
@@ -314,11 +314,8 @@ class Definitions(metaclass=DefinitionsMeta):
         """
         This fails to run a single test. It looks like just importing the module
         can hang. All I see is the output from patch_all().
-
-        Currently crashing on Python 3.15b4 on windows. I'm suspicious
-        of problems with old CFFI wheels.
         """,
-        when=(APPVEYOR & PYPY3) | (APPVEYOR & PY315B4_EXACTLY)
+        when=(APPVEYOR & PYPY3)
     )
 
     test__monkey_sigchld_2 = Ignored(

--- a/src/gevent/tests/test__core.py
+++ b/src/gevent/tests/test__core.py
@@ -115,11 +115,13 @@ class LibevTestMixin(WatcherTestMixin):
 class TestLibevCext(LibevTestMixin, unittest.TestCase):
     kind = available_loops['libev-cext']
 
-@unittest.skipIf(not_available('libev-cffi'), "Needs libev-cffi")
+@unittest.skipIf(not_available('libev-cffi') or sys.version_info == (3, 15, 0, 'beta', 4),
+                 "Needs libev-cffi")
 class TestLibevCffi(LibevTestMixin, unittest.TestCase):
     kind = available_loops['libev-cffi']
 
-@unittest.skipIf(not_available('libuv-cffi'), "Needs libuv-cffi")
+@unittest.skipIf(not_available('libuv-cffi') or sys.version_info == (3, 15, 0, 'beta', 4),
+                 "Needs libuv-cffi")
 class TestLibuvCffi(WatcherTestMixin, unittest.TestCase):
     kind = available_loops['libuv-cffi']
 

--- a/src/gevent/tests/test__threading.py
+++ b/src/gevent/tests/test__threading.py
@@ -3,7 +3,7 @@ Tests specifically for the monkey-patched threading module.
 """
 from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
 import gevent.hub
-import sys
+
 # check that the locks initialized by 'threading' did not init the hub.
 
 # Beginning in Python 3.15, on Linux kernels new enough, importing

--- a/src/gevent/tests/test__threading.py
+++ b/src/gevent/tests/test__threading.py
@@ -4,14 +4,21 @@ Tests specifically for the monkey-patched threading module.
 from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
 import gevent.hub
 import sys
-# check that the locks initialized by 'threading' did not init the hub
-# XXX: Python 3.15b1--3.15b3 on ubuntu-latest on github actions fails this assert.
-# I can't reproduce it in the manylinux_2_28 image locally.
-assert gevent.hub._get_hub() is None or sys.version_info in [
-    (3, 15, 0, 'beta', 1),
-    (3, 15, 0, 'beta', 2),
-    (3, 15, 0, 'beta', 3),
-], 'monkey.patch_all() should not init hub'
+# check that the locks initialized by 'threading' did not init the hub.
+
+# Beginning in Python 3.15, on Linux kernels new enough, importing
+# ``subprocess`` attempts to check whether pidfd is available. This leads
+# it to call ``os.close(pidfd)``. If we've already monkey-patched ``os``
+# at that point, the hub gets created. The order of module patching
+# is somewhat undefined: it relies on ``locals()`` and dictionary iteration
+# order, so effectively it's the order of arguments to ``patch_all``, which
+# we cannot currently change. A release early 2027 can do that, so
+# we might be able to fix this problem then by moving os after subprocess,
+# though I'm hesitant to change patch order because we know it works, even if
+# accidentally. In the meantime, we changed ``gevent.os.close`` to not init
+# the hub.
+assert (gevent.hub._get_hub() is None
+), 'monkey.patch_all() should not init hub'
 
 import gevent
 import gevent.testing as greentest


### PR DESCRIPTION
This fixes assertion failures under 3.15.

Also various other build fixes, mostly for 3.15 having to do with incompatible binary wheels. Much of that will be rolled back. 