### PR TITLE
Replace concurrent.futures' _global_shutdown_lock when patching threads

### DIFF
--- a/docs/changes/1865.bugfix.rst
+++ b/docs/changes/1865.bugfix.rst
@@ -1,0 +1,9 @@
+Replace ``concurrent.futures.thread._global_shutdown_lock`` when patching
+threads, importing that module if needed. ``Executor.submit`` holds it across
+``Thread.start()``, so a worker greenlet that forks runs the
+:func:`os.register_at_fork` handlers it is registered with while another
+greenlet holds it: a native lock deadlocked, a cooperative one parked the
+greenlet inside ``os.fork()`` (which ``filelock`` 3.30 rejects).
+
+Like the rest of ``patch_thread(existing_locks=True)``, this needs the process
+to be single threaded when patching.

--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -352,6 +352,9 @@ def patch_thread(threading=True, _threading_local=True, Event=True, logging=True
         best-effort attempt and, on certain implementations, may not detect all
         locks. It is important to monkey-patch extremely early in the startup process.
         Setting this to False is not recommended, especially on Python 2.
+        This also replaces the lock :mod:`concurrent.futures.thread` registers
+        with :func:`os.register_at_fork`, which deadlocks or switches greenlets
+        mid-fork.
 
     .. caution::
         Monkey-patching :mod:`thread` and using
@@ -367,6 +370,9 @@ def patch_thread(threading=True, _threading_local=True, Event=True, logging=True
         Add *logging* and *existing_locks* params.
     .. versionchanged:: 1.3a2
         ``Event`` defaults to True.
+    .. versionchanged:: 26.7.1
+        *existing_locks* imports :mod:`concurrent.futures.thread` and replaces
+        its ``_global_shutdown_lock``.
     """
     if sys.version_info[:2] < (3, 13):
         from ._patch_thread_lt313 import Patcher

--- a/src/gevent/monkey/__init__.py
+++ b/src/gevent/monkey/__init__.py
@@ -370,7 +370,7 @@ def patch_thread(threading=True, _threading_local=True, Event=True, logging=True
         Add *logging* and *existing_locks* params.
     .. versionchanged:: 1.3a2
         ``Event`` defaults to True.
-    .. versionchanged:: 26.7.1
+    .. versionchanged:: NEXT
         *existing_locks* imports :mod:`concurrent.futures.thread` and replaces
         its ``_global_shutdown_lock``.
     """

--- a/src/gevent/monkey/_patch_thread_common.py
+++ b/src/gevent/monkey/_patch_thread_common.py
@@ -15,9 +15,29 @@ from ._util import _patch_module
 from ._util import _queue_warning
 
 
+def _patch_global_shutdown_lock(threading):
+    # ``concurrent.futures.thread`` registers its ``_global_shutdown_lock`` with
+    # ``os.register_at_fork(before=acquire, after_in_parent=release)``, and
+    # ``Executor.submit`` holds it across ``Thread.start()``. So a worker
+    # greenlet that forks runs those handlers while another greenlet holds the
+    # lock: a native one blocks the only OS thread forever, one of ours parks
+    # the greenlet inside ``os.fork()``. See :issue:`1865`.
+    #
+    # We can't unregister, so we hand the handlers a lock nobody else holds;
+    # uncontended, it neither blocks nor switches. Its users re-read the global.
+    # We import the module since applications import it after patching.
+    import concurrent.futures.thread as cf_thread
+    if not hasattr(cf_thread, '_global_shutdown_lock'): # pragma: no cover
+        # Private; it may go away.
+        return
+
+    cf_thread._global_shutdown_lock = threading._allocate_lock()
+
+
 def _patch_existing_locks(threading):
     if len(list(threading.enumerate())) != 1:
         return
+    _patch_global_shutdown_lock(threading)
     # This is used to protect internal data structures for enumerate.
     # It's acquired when threads are started and when they're stopped.
     # Stopping a thread checks a Condition, which on Python 2 wants to test

--- a/src/gevent/tests/test__monkey_fork_atomic.py
+++ b/src/gevent/tests/test__monkey_fork_atomic.py
@@ -1,0 +1,48 @@
+"""
+Nothing may switch greenlets inside ``os.fork()``: :func:`os.register_at_fork`
+handlers assume that window is atomic, and ``filelock`` 3.30 enforces it from
+an audit hook. Importing :mod:`concurrent.futures.thread` after patching used
+to break that. See :issue:`1865`.
+"""
+from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
+
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+from gevent import testing as greentest
+
+# Stands in for filelock. Registered after concurrent.futures, so this runs
+# first: ``before`` handlers run in reverse.
+_forking = []
+
+if hasattr(os, 'register_at_fork'):
+    os.register_at_fork(
+        before=lambda: _forking.append(1),
+        after_in_parent=_forking.pop,
+        after_in_child=_forking.clear)
+
+    def _audit(event, _args):
+        if event == 'os.fork' and _forking:
+            raise RuntimeError("fork began inside another fork")
+
+    sys.addaudithook(_audit)
+
+
+class Test(greentest.TestCase):
+
+    @greentest.skipOnWindows("Uses fork")
+    def test_forks_do_not_overlap(self):
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            statuses = list(pool.map(self._spawn, range(4)))
+        self.assertEqual(statuses, [[0] * 4] * 4)
+
+    @staticmethod
+    def _spawn(_i):
+        return [subprocess.Popen([sys.executable, '-c', 'pass']).wait()
+                for _ in range(4)]
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/tests/test__monkey_futures_thread_fork.py
+++ b/src/gevent/tests/test__monkey_futures_thread_fork.py
@@ -1,0 +1,41 @@
+"""
+:mod:`concurrent.futures.thread` imported before patching leaves a native lock
+registered with :func:`os.register_at_fork`; a greenlet that forks while
+another holds it hangs the process. See :issue:`1865`.
+
+The runner catches that hang at its timeout.
+"""
+import concurrent.futures.thread # MUST come before patch_all(); that's the bug
+
+from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+from gevent import testing as greentest
+
+
+class Test(greentest.TestCase):
+
+    def test_global_shutdown_lock_is_patched(self):
+        from gevent.thread import LockType
+        self.assertIsInstance(
+            concurrent.futures.thread._global_shutdown_lock,
+            LockType)
+
+    @greentest.skipOnWindows("Uses fork")
+    def test_concurrent_fork_while_lock_held(self):
+        # Two workers are needed; a single spawn on the main greenlet never
+        # overlaps with ``submit`` holding the lock.
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            statuses = list(pool.map(self._spawn, range(2)))
+        self.assertEqual(statuses, [0, 0])
+
+    @staticmethod
+    def _spawn(_i):
+        return subprocess.Popen([sys.executable, '-c', 'pass']).wait()
+
+
+if __name__ == '__main__':
+    greentest.main()


### PR DESCRIPTION
Executor.submit holds it across Thread.start(), so a worker greenlet that forks runs the os.register_at_fork handlers it is registered with while another greenlet holds it. A native lock deadlocks the process; a cooperative one parks the forking greenlet inside os.fork(), letting a second greenlet fork before the first has finished.

Fixes #1865.