### PR TITLE
Stop Popen.__exit__ raising 'reentrant call' on a pipe a greenlet is reading

### DIFF
--- a/docs/changes/2194.bugfix.rst
+++ b/docs/changes/2194.bugfix.rst
@@ -1,0 +1,8 @@
+Stop the greenlets that ``communicate()`` spawned before
+``gevent.subprocess.Popen.__exit__`` closes the child's pipes. Leaving the
+``with`` block while one of them was still parked in a pipe, because an
+exception was propagating or because the greenlet running the block was
+killed, raised ``RuntimeError: reentrant call`` out of ``__exit__``. That
+replaced the exception that was really unwinding, and skipped the ``wait()``
+that reaps the child. A pipe some other greenlet is reading is now left alone
+rather than raising, which is what ``communicate()`` already did.

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -75,7 +75,7 @@ from gevent._compat import PathLike
 from gevent._util import _NONE
 from gevent._util import copy_globals
 
-from gevent.greenlet import Greenlet, joinall
+from gevent.greenlet import Greenlet, joinall, killall
 spawn = Greenlet.spawn
 import subprocess as __subprocess__
 # We need our sockets (at least those involved in launching children)
@@ -1001,10 +1001,35 @@ class Popen(object):
         return self
 
     def __exit__(self, t, v, tb):
-        if self.stdout:
-            self.stdout.close()
-        if self.stderr:
-            self.stderr.close()
+        # gevent: If we're leaving the block early, because an exception is
+        # propagating or because the greenlet running it was killed, the
+        # greenlets ``communicate`` spawned can still be parked in the pipes.
+        # Closing one out from under a parked greenlet raises ``RuntimeError:
+        # reentrant call``: it shares our thread, so the buffered object's
+        # lock is held by the thread doing the close. Stop them first, and
+        # each one closes its own pipe as it unwinds. ``communicate`` avoids
+        # the same hazard by waiting for them to finish.
+        if self._communicating_greenlets is not None:
+            still_running = [
+                glet for glet in self._communicating_greenlets
+                if not glet.dead
+            ]
+            if still_running:
+                killall(still_running)
+
+        # Some other greenlet, reading ``popen.stdout`` directly, can be
+        # parked in there too, and we have no handle on that one. Its
+        # ``RuntimeError`` must not replace the exception already unwinding
+        # this block, nor skip the ``self.wait()`` below that reaps the child.
+        # The pipe closes once that reader finishes and drops its last
+        # reference to it.
+        for pipe in (self.stdout, self.stderr):
+            if pipe:
+                try:
+                    pipe.close()
+                except RuntimeError:
+                    pass
+
         try:  # Flushing a BufferedWriter may raise an error
             if self.stdin:
                 self.stdin.close()

--- a/src/gevent/tests/test__subprocess.py
+++ b/src/gevent/tests/test__subprocess.py
@@ -311,6 +311,59 @@ class TestPopen(greentest.TestCase):
         # https://github.com/gevent/gevent/pull/939
         self.__test_no_output({}, bytes)
 
+    def __popen_never_exits(self):
+        # A child that neither writes nor exits, so a greenlet reading it
+        # stays parked in the pipe until we do something about it.
+        return subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(3600)'],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+    @greentest.skipOnWindows("Windows uses FileObjectThread, with different close semantics")
+    def test_exit_stops_communicating_greenlets_before_closing(self):
+        # Leaving the block while the greenlets communicate() spawned are
+        # still parked in the pipes must not raise ``RuntimeError: reentrant
+        # call``. They share our thread, so they hold the buffered object's
+        # lock while we close it.
+        with self.__popen_never_exits() as popen:
+            communicator = gevent.spawn(popen.communicate)
+            gevent.sleep(0.1) # let the readers park inside the pipes
+            readers = list(popen._communicating_greenlets)
+            self.assertEqual(len(readers), 2)
+            for reader in readers:
+                self.assertFalse(reader.dead)
+
+            communicator.kill() # abandon the read, as a cancelled task would
+            for reader in readers:
+                self.assertFalse(reader.dead)
+            popen.kill() # so that __exit__'s wait() has a child to reap
+
+        # __exit__ ran, without raising.
+        for reader in readers:
+            self.assertTrue(reader.dead)
+        self.assertTrue(popen.stdout.closed)
+        self.assertTrue(popen.stderr.closed)
+        self.assertIsNotNone(popen.poll())
+
+    @greentest.skipOnWindows("Windows uses FileObjectThread, with different close semantics")
+    def test_exit_ignores_reentrant_call_from_foreign_greenlet(self):
+        # The same hazard, but the greenlet parked in the pipe is not one of
+        # ours, so __exit__ has no handle on it. The RuntimeError still must
+        # not escape, and the child still has to be reaped.
+        popen = self.__popen_never_exits()
+        reader = gevent.spawn(popen.stdout.read)
+        gevent.sleep(0.1)
+        self.assertFalse(reader.dead)
+        self.assertIsNone(popen._communicating_greenlets)
+
+        popen.kill()
+        try:
+            popen.__exit__(None, None, None)
+        finally:
+            reader.kill()
+
+        self.assertTrue(popen.stdout.closed)
+        self.assertIsNotNone(popen.poll())
+
 @greentest.skipOnWindows("Testing POSIX fd closing")
 class TestFDs(unittest.TestCase):
 


### PR DESCRIPTION
fixes #2194 

See failing tests:

https://github.com/ddorian/gevent/pull/1

https://github.com/ddorian/gevent/pull/2
