### PR TITLE
Fix semaphore notifications from hubless native threads

### DIFF
--- a/docs/changes/2013.bugfix.rst
+++ b/docs/changes/2013.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a semaphore acquired and released by a hubless native thread failing to
+wake greenlets waiting on the semaphore's owning hub.

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -220,11 +220,20 @@ class AbstractLinkable(object):
             try:
                 hub = self._capture_hub(False) # Must create, we need it.
             except InvalidThreadUseError:
-                # The current hub doesn't match self.hub. That's OK,
-                # we still want to start the notifier in the thread running
-                # self.hub (because the links probably contains greenlet.switch
-                # calls valid only in that hub)
-                pass
+                # Links are normally greenlet.switch methods and must be
+                # notified by their owning hub. Wake that hub without first
+                # attempting an unsafe switch from this native thread.
+                hub = self.hub
+                loop = hub.loop
+                if loop is None:
+                    # The owner was destroyed while this thread was using the
+                    # linkable. Its callbacks cannot safely run anywhere else.
+                    raise
+                self._notifier = loop.run_callback_threadsafe(
+                    self._notify_links,
+                    []
+                )
+                return
             if hub is not None:
                 self._notifier = hub.loop.run_callback(self._notify_links, [])
             else:

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -243,6 +243,14 @@ class AbstractLinkable(object):
                     # The owner was destroyed while this thread was using the
                     # linkable. Its callbacks cannot safely run anywhere else.
                     raise
+                # The check on self._notifier above and this assignment are
+                # not atomic: another thread could install its own notifier
+                # in between, and one of the two would be lost. That's safe
+                # per the class comment above (2a/2b) when this is compiled
+                # with Cython (the GIL is held for the whole method) or the
+                # subclass holds a native lock (only Semaphore does). In
+                # pure-Python mode without such a lock (Event, AsyncResult),
+                # this is a real, currently-unclosed race.
                 notifier = _FakeNotifier()
                 self._notifier = notifier
                 try:

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -37,13 +37,24 @@ __all__ = [
 _get_thread_ident = __import__(thread_mod_name).get_ident
 _allocate_thread_lock = __import__(thread_mod_name).allocate_lock
 
+# Reserve _notifier before a foreign thread wakes the owner loop. It mirrors
+# the callback attributes used by the wait and unlink paths.
 class _FakeNotifier(object):
     __slots__ = (
+        'args',
         'pending',
     )
 
     def __init__(self):
+        self.args = ([],)
+        self.pending = True
+
+    def stop(self):
+        self.args = None
         self.pending = False
+
+    def __bool__(self):
+        return self.args is not None
 
 def get_roots_and_hubs():
     from gevent.hub import Hub # delay import
@@ -221,18 +232,28 @@ class AbstractLinkable(object):
                 hub = self._capture_hub(False) # Must create, we need it.
             except InvalidThreadUseError:
                 # Links are normally greenlet.switch methods and must be
-                # notified by their owning hub. Wake that hub without first
-                # attempting an unsafe switch from this native thread.
+                # notified by their owning hub. First publish a notifier that
+                # coalesces foreign-thread wakeups, then wake that hub. The
+                # callback returned by run_callback_threadsafe cannot itself
+                # be used as _notifier: the hub may run it before this thread
+                # has received and stored it.
                 hub = self.hub
                 loop = hub.loop
                 if loop is None:
                     # The owner was destroyed while this thread was using the
                     # linkable. Its callbacks cannot safely run anywhere else.
                     raise
-                self._notifier = loop.run_callback_threadsafe(
-                    self._notify_links,
-                    []
-                )
+                notifier = _FakeNotifier()
+                self._notifier = notifier
+                try:
+                    loop.run_callback_threadsafe(
+                        self._notify_links_from_threadsafe,
+                        notifier
+                    )
+                except:
+                    if self._notifier is notifier:
+                        self._notifier = None
+                    raise
                 return
             if hub is not None:
                 self._notifier = hub.loop.run_callback(self._notify_links, [])
@@ -244,6 +265,16 @@ class AbstractLinkable(object):
                     self._notify_links([])
                 finally:
                     self._notifier = None
+
+    def _notify_links_from_threadsafe(self, notifier):
+        # The callback may be stale after cancellation, fork, or a newer
+        # notification. Only the notifier that requested this wakeup may run.
+        if self._notifier is notifier:
+            if notifier:
+                notifier.pending = False
+                self._notify_links(notifier.args[0])
+            else:
+                self._notifier = None
 
     def _notify_link_list(self, links):
         # The core of the _notify_links method to notify

--- a/src/gevent/_abstract_linkable.py
+++ b/src/gevent/_abstract_linkable.py
@@ -275,6 +275,15 @@ class AbstractLinkable(object):
                     self._notifier = None
 
     def _notify_links_from_threadsafe(self, notifier):
+        # notifier.args[0] starts out empty, but it is not necessarily
+        # still empty by the time this runs: if a greenlet calls wait()
+        # (see _wait() below) while we're already ready() and this
+        # notifier is still pending, instead of registering a normal
+        # rawlink it appends its resume callback directly to
+        # notifier.args[0] (see __wait_to_be_notified()), so that it gets
+        # woken up along with everyone else once this callback finally
+        # runs.
+        #
         # The callback may be stale after cancellation, fork, or a newer
         # notification. Only the notifier that requested this wakeup may run.
         if self._notifier is notifier:

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -36,7 +36,8 @@ cdef void _init()
 cdef dict get_roots_and_hubs()
 
 cdef class _FakeNotifier(object):
-    cdef bint pending
+    cdef public object args
+    cdef public bint pending
 
 cdef class AbstractLinkable(object):
    # We declare the __weakref__ here in the base (even though
@@ -57,6 +58,7 @@ cdef class AbstractLinkable(object):
    cpdef unlink(self, callback)
 
    cdef _check_and_notify(self)
+   cpdef _notify_links_from_threadsafe(self, notifier)
    cdef SwitchOutGreenletWithLoop _capture_hub(self, bint create)
    cdef __wait_to_be_notified(self, bint rawlink)
 

--- a/src/gevent/_gevent_c_abstract_linkable.pxd
+++ b/src/gevent/_gevent_c_abstract_linkable.pxd
@@ -58,7 +58,7 @@ cdef class AbstractLinkable(object):
    cpdef unlink(self, callback)
 
    cdef _check_and_notify(self)
-   cpdef _notify_links_from_threadsafe(self, notifier)
+   cdef _notify_links_from_threadsafe(self, notifier)
    cdef SwitchOutGreenletWithLoop _capture_hub(self, bint create)
    cdef __wait_to_be_notified(self, bint rawlink)
 

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -281,9 +281,8 @@ class TestAsyncResultCrossThread(greentest.TestCase):
 
     @greentest.ignores_leakcheck
     def test_cross_thread_callback_can_run_before_scheduling_returns(self):
-        loop = gevent.get_hub().loop
-        if not hasattr(loop, '__dict__'):
-            self.skipTest("The loop's methods cannot be wrapped")
+        hub = gevent.get_hub()
+        real_loop = hub.loop
 
         from threading import Thread as NativeThread
         from threading import Event as NativeEvent
@@ -298,17 +297,27 @@ class TestAsyncResultCrossThread(greentest.TestCase):
         link_started = NativeEvent()
         producer_done = NativeEvent()
 
-        run_callback_threadsafe = loop.run_callback_threadsafe
+        class LoopProxy(object):
+            # We can't always wrap methods directly on ``real_loop``:
+            # depending on the backend, it may be a Cython-compiled
+            # extension type with no instance ``__dict__`` (so we
+            # can't add attributes to it) and its class is immutable
+            # (so we can't patch the class either). Instead, we swap
+            # out ``hub.loop`` itself for a plain Python object that
+            # forwards everything to the real loop except the one
+            # method we need to intercept.
+            def __getattr__(self, name):
+                return getattr(real_loop, name)
 
-        def run_before_return(callback, *args):
-            scheduling.set()
-            if not allow_enqueue.wait(DELAY * 15):
-                raise AssertionError("The owner did not allow the callback")
-            scheduled = run_callback_threadsafe(callback, *args)
-            enqueued.set()
-            if not link_started.wait(DELAY * 15):
-                raise AssertionError("The owner did not start notification")
-            return scheduled
+            def run_callback_threadsafe(self, callback, *args):
+                scheduling.set()
+                if not allow_enqueue.wait(DELAY * 15):
+                    raise AssertionError("The owner did not allow the callback")
+                scheduled = real_loop.run_callback_threadsafe(callback, *args)
+                enqueued.set()
+                if not link_started.wait(DELAY * 15):
+                    raise AssertionError("The owner did not start notification")
+                return scheduled
 
         def set_result():
             try:
@@ -324,7 +333,7 @@ class TestAsyncResultCrossThread(greentest.TestCase):
 
         thread = NativeThread(target=set_result)
         thread.error = None
-        loop.run_callback_threadsafe = run_before_return
+        hub.loop = LoopProxy()
         try:
             thread.start()
             self.assertTrue(scheduling.wait(DELAY * 15))
@@ -343,7 +352,7 @@ class TestAsyncResultCrossThread(greentest.TestCase):
             link_started.set()
             producer_done.set()
             thread.join(DELAY * 15)
-            del loop.run_callback_threadsafe
+            hub.loop = real_loop
 
 class TestEventCrossThread(TestAsyncResultCrossThread):
 

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -279,6 +279,71 @@ class TestAsyncResultCrossThread(greentest.TestCase):
         # Do it again to make sure it works multiple times.
         self.test_cross_thread_use_set_in_bg()
 
+    def test_cross_thread_callback_can_run_before_scheduling_returns(self):
+        loop = gevent.get_hub().loop
+        if not hasattr(loop, '__dict__'):
+            self.skipTest("The loop's methods cannot be wrapped")
+
+        from threading import Thread as NativeThread
+        from threading import Event as NativeEvent
+
+        result = self._makeOne()
+        result.wait(0) # Capture the owner hub.
+        result.rawlink(lambda _: None)
+
+        scheduling = NativeEvent()
+        allow_enqueue = NativeEvent()
+        enqueued = NativeEvent()
+        link_started = NativeEvent()
+        producer_done = NativeEvent()
+
+        run_callback_threadsafe = loop.run_callback_threadsafe
+
+        def run_before_return(callback, *args):
+            scheduling.set()
+            if not allow_enqueue.wait(DELAY * 15):
+                raise AssertionError("The owner did not allow the callback")
+            scheduled = run_callback_threadsafe(callback, *args)
+            enqueued.set()
+            if not link_started.wait(DELAY * 15):
+                raise AssertionError("The owner did not start notification")
+            return scheduled
+
+        def set_result():
+            try:
+                self._setOne(result)
+            except BaseException as ex: # pylint:disable=broad-exception-caught
+                thread.error = ex
+            finally:
+                producer_done.set()
+
+        def link(_):
+            link_started.set()
+            self.assertTrue(producer_done.wait(DELAY * 15))
+
+        thread = NativeThread(target=set_result)
+        thread.error = None
+        loop.run_callback_threadsafe = run_before_return
+        try:
+            thread.start()
+            self.assertTrue(scheduling.wait(DELAY * 15))
+            result.rawlink(link)
+            allow_enqueue.set()
+            self.assertTrue(enqueued.wait(DELAY * 15))
+            with gevent.Timeout(DELAY * 15):
+                while not producer_done.is_set():
+                    gevent.sleep(0)
+            thread.join(DELAY * 15)
+            self.assertFalse(thread.is_alive())
+            if thread.error is not None:
+                raise thread.error
+        finally:
+            allow_enqueue.set()
+            link_started.set()
+            producer_done.set()
+            thread.join(DELAY * 15)
+            del loop.run_callback_threadsafe
+
 class TestEventCrossThread(TestAsyncResultCrossThread):
 
     def _makeOne(self):

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -279,6 +279,7 @@ class TestAsyncResultCrossThread(greentest.TestCase):
         # Do it again to make sure it works multiple times.
         self.test_cross_thread_use_set_in_bg()
 
+    @greentest.ignores_leakcheck
     def test_cross_thread_callback_can_run_before_scheduling_returns(self):
         loop = gevent.get_hub().loop
         if not hasattr(loop, '__dict__'):

--- a/src/gevent/tests/test__issue2013.py
+++ b/src/gevent/tests/test__issue2013.py
@@ -1,0 +1,106 @@
+import _thread
+import time
+
+
+# This module monkey-patches at import time and depends on a fresh native-thread
+# state. It must run in its own subprocess.
+# pragma: testrunner-no-combine
+
+
+# Capture the native APIs before monkey-patching. The producer must not be a
+# gevent-managed thread and must never create a hub of its own.
+native_start_new_thread = _thread.start_new_thread
+native_get_ident = _thread.get_ident
+native_sleep = time.sleep
+
+from gevent import monkey
+monkey.patch_all()
+
+import gevent
+from gevent._hub_local import get_hub_if_exists
+from gevent.lock import BoundedSemaphore
+import gevent.testing as greentest
+
+
+class TestHublessThreadSemaphore(greentest.TestCase):
+
+    __timeout__ = 10
+
+    def _wait_for(self, condition):
+        with gevent.Timeout(2):
+            while not condition():
+                gevent.sleep(0.001)
+
+    def _run_waiters(self, semaphore, count, release):
+        owner_ident = native_get_ident()
+        notified_on = []
+        resumed_on = []
+
+        semaphore.rawlink(
+            lambda _: notified_on.append(native_get_ident())
+        )
+
+        def waiter():
+            semaphore.acquire()
+            resumed_on.append(native_get_ident())
+            semaphore.release()
+
+        waiters = [gevent.spawn(waiter) for _ in range(count)]
+        self._wait_for(lambda: semaphore.linkcount() == count + 1)
+        release()
+        gevent.joinall(waiters, timeout=2)
+
+        self.assertTrue(all(waiter.successful() for waiter in waiters))
+        self.assertEqual(notified_on, [owner_ident])
+        self.assertEqual(resumed_on, [owner_ident] * count)
+
+    def _run_native_round(self, owner_ident):
+        semaphore = BoundedSemaphore(1)
+        acquired = []
+        release_requested = []
+        released = []
+        producer_ident = []
+        producer_hub = []
+
+        def producer():
+            producer_ident.append(native_get_ident())
+            producer_hub.append(get_hub_if_exists())
+            semaphore.acquire()
+            acquired.append(True)
+            while not release_requested:
+                native_sleep(0.001)
+            semaphore.release()
+            released.append(True)
+
+        native_start_new_thread(producer, ())
+        self._wait_for(lambda: acquired)
+        self._run_waiters(
+            semaphore,
+            4,
+            lambda: release_requested.append(True),
+        )
+        self._wait_for(lambda: released)
+
+        self.assertNotEqual(producer_ident, [owner_ident])
+        self.assertEqual(producer_hub, [None])
+
+    def test_hubless_native_thread_release_wakes_waiters(self):
+        owner_ident = native_get_ident()
+        for _ in range(20):
+            self._run_native_round(owner_ident)
+
+    def test_owner_thread_release_wakes_waiters(self):
+        semaphore = BoundedSemaphore(1)
+        semaphore.acquire()
+        self._run_waiters(semaphore, 2, semaphore.release)
+
+    def test_gevent_producer_release_wakes_waiters(self):
+        semaphore = BoundedSemaphore(1)
+        semaphore.acquire()
+        producer = gevent.Greenlet(semaphore.release)
+        self._run_waiters(semaphore, 2, producer.start)
+        producer.get(timeout=2)
+
+
+if __name__ == '__main__':
+    greentest.main()


### PR DESCRIPTION
Fixes #2013.

`dd-trace-py` encountered this through Python logging. After monkey-patching, logging handler locks are backed by gevent semaphores, so a hubless native thread logging alongside greenlets could release a handler lock without waking the waiting greenlets.

A native thread can release a gevent semaphore while a greenlet is waiting for it. The semaphore becomes available, but its notification was attempted on the native thread. Greenlets cannot switch across threads, so the waiter could remain parked indefinitely.

When this happens, schedule the normal notification on the semaphore's existing owning hub with `run_callback_threadsafe`. This avoids the cross-thread switch while preserving the existing notification and acquisition order. The normal same-hub path is unchanged.
