### PR TITLE
gevent/subprocess.py: give the pre-exec child a hub of its own

### DIFF
--- a/docs/changes/2196.bugfix.rst
+++ b/docs/changes/2196.bugfix.rst
@@ -1,0 +1,29 @@
+Give the child of :mod:`gevent.subprocess` a hub of its own, so that it runs
+none of the parent's greenlets before it ``exec``s.
+
+The POSIX ``_execute_child`` forks and execs in Python, so for that window the
+child is a whole interpreter holding a copy of the parent's greenlets, open
+file descriptors and in-memory TLS sessions. gevent's own child branch never
+switches, but ``os.register_at_fork(after_in_child=)`` handlers run inside
+``fork()`` before it begins; applications register them (OpenTelemetry, Sentry,
+``filelock``, ``coverage``), and under monkey-patching the ordinary contents of
+such a handler yield. The child's copy of the hub then resumed the copies,
+which carried on doing the application's work in a process that only existed to
+``exec``: writing on a pooled TLS connection until the peer answered
+``bad_record_mac``, or taking bytes off a pipe the parent was capturing, which
+has no MAC to notice it and so showed up only as a short or empty capture.
+
+The child now gets a fresh hub, which puts the parent's watchers, its queued
+callbacks and its hub greenlet out of reach. A fork handler that yields still
+works. One that waits for something only the parent could provide no longer
+runs application greenlets while it waits; it fails with
+:exc:`~gevent.exceptions.LoopExit` instead, unless it left work on the new loop
+first, in which case the child stays, with the parent blocked reading its error
+pipe inside ``Popen.__init__``.
+
+This also fixes the reproducer in :issue:`2023`, where a fork handler that used
+``gevent.get_hub().threadpool`` deadlocked the spawn.
+
+It applies only to the child of :mod:`gevent.subprocess`, which exists to
+``exec`` and nothing else. A child of a plain ``os.fork()`` may legitimately
+keep using the gevent objects it inherited, so it keeps the hub it was given.

--- a/src/gevent/subprocess.py
+++ b/src/gevent/subprocess.py
@@ -302,6 +302,103 @@ else:
     fork = monkey.get_original('os', 'fork')
     from gevent.os import fork_and_watch
 
+    from gevent.hub import Hub
+    from gevent.hub import set_hub
+    from gevent.hub import set_loop
+    from gevent.hub import _get_hub as _get_hub_if_exists
+
+    #: The pid of the process currently between ``fork()`` and ``exec()``, or
+    #: `None`. The child inherits the *parent's* pid here, which is how it
+    #: recognizes itself: its own ``getpid()`` no longer matches.
+    _forking_for_exec_in = None
+
+    def _in_pre_exec_child():
+        """
+        Are we a child of :meth:`Popen._execute_child` that has not
+        ``exec``'d yet?
+        """
+        return (_forking_for_exec_in is not None
+                and _forking_for_exec_in != os.getpid())
+
+    def _fork_marking_the_pre_exec_window():
+        """
+        ``fork()``, recording that the child it produces has not ``exec``'d
+        yet.
+
+        A module global rather than greenlet state, because a copy left
+        runnable in the child is a different greenlet and has to be able to ask
+        the same question. Keyed on pid rather than a bare flag, so that a
+        greenlet parked inside ``fork()`` in the *parent* (:issue:`1865`) does
+        not mark the parent too.
+
+        .. versionadded:: NEXT
+        """
+        global _forking_for_exec_in
+        _forking_for_exec_in = os.getpid()
+        pid = -1
+        try:
+            # Deliberately a global lookup: instrumentation replaces this.
+            pid = fork()
+        finally:
+            if pid != 0:
+                # Parent, or the fork failed. The child keeps the inherited
+                # value until exec() or os._exit() disposes of it.
+                _forking_for_exec_in = None
+        return pid
+
+    def _detach_inherited_hub_in_pre_exec_child():
+        """
+        Give a child between ``fork()`` and ``exec()`` a hub of its own, so
+        that it cannot run the parent's greenlets.
+
+        The child holds a copy of every greenlet the parent had, each stopped
+        wherever it happened to be; only the one that forked may continue. Our
+        own child branch below never switches, but handlers registered with
+        ``os.register_at_fork(after_in_child=)`` run inside ``fork()`` before
+        it returns to us, applications register them (OpenTelemetry, Sentry,
+        ``filelock``, ``coverage``), and under monkey-patching the ordinary
+        contents of such a handler yield. That yield reaches the child's copy
+        of the hub, and the copies run: writing on the parent's TLS sessions
+        until the peer answers ``bad_record_mac``, reading bytes off the pipes
+        it was capturing.
+
+        Cancelling the queued switches does not reach them, because a copy
+        parked on a timer or an ``io`` watcher is resumed by the loop itself.
+        Taking the loop away puts the parent's watchers, callbacks and hub
+        greenlet out of reach in one go, and a handler that yields still works
+        on the new empty loop.
+
+        A handler that instead waits for something only the parent could
+        provide gets :exc:`~gevent.exceptions.LoopExit` at once, reported as
+        unraisable, and the child gets on with ``exec``. If it left work on
+        the new loop first the loop does not raise, and the child stays ---
+        with the parent blocked reading its error pipe inside
+        ``Popen.__init__``, before any ``timeout=`` has begun counting.
+        Bounding that is a separate change.
+
+        Short of that, the child is discarded microseconds later by ``exec``
+        or ``_exit``, so this hub never has to be tidied up.
+
+        .. versionadded:: NEXT
+        """
+        if not _in_pre_exec_child():
+            return
+        if _get_hub_if_exists() is None:
+            # Nothing was ever scheduled in this thread, so there are no
+            # copies to run.
+            return
+        # ``default=False`` matters: libev's default loop is a process-wide
+        # singleton, so asking for the default again would hand back the
+        # parent's loop, watchers and all.
+        set_loop(None)
+        set_hub(Hub(default=False))
+
+    if hasattr(os, 'register_at_fork'):
+        # Handlers run in registration order, so this must be registered
+        # before any of the application's --- which it is, because importing
+        # this module is part of ``monkey.patch_all()``.
+        os.register_at_fork(after_in_child=_detach_inherited_hub_in_pre_exec_child)
+
 # Some explicit imports for static analysis
 STDOUT = __subprocess__.STDOUT
 TimeoutExpired = __subprocess__.TimeoutExpired
@@ -1628,7 +1725,8 @@ class Popen(object):
                     # write to stderr -> hang.  http://bugs.python.org/issue1336
                     gc.disable()
                     try:
-                        self.pid = fork_and_watch(self._on_child, self._loop, True, fork)
+                        self.pid = fork_and_watch(self._on_child, self._loop, True,
+                                                  _fork_marking_the_pre_exec_window)
                     except:
                         if gc_was_enabled:
                             gc.enable()

--- a/src/gevent/tests/test__subprocess_fork_child_hub.py
+++ b/src/gevent/tests/test__subprocess_fork_child_hub.py
@@ -1,0 +1,81 @@
+"""
+A child of :mod:`gevent.subprocess` must run none of the parent's greenlets
+before it ``exec``s.
+
+The POSIX ``_execute_child`` forks and execs in Python, so for that window the
+child is a whole interpreter holding a copy of the parent's greenlets, file
+descriptors and TLS sessions. Our own child branch never switches, but
+``os.register_at_fork(after_in_child=)`` handlers run inside ``fork()`` before
+it begins, and under monkey-patching they yield.
+
+The workers here are parked on a timer rather than merely runnable, so emptying
+the loop's callback queue does not account for them: the loop resumes them
+itself. The child must not be running the parent's loop at all.
+"""
+from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import gevent
+
+from gevent import testing as greentest
+
+if hasattr(os, 'register_at_fork'):
+    # The least a handler can do and still yield.
+    os.register_at_fork(after_in_child=lambda: gevent.sleep(0))
+
+
+class Test(greentest.TestCase):
+
+    # Well under a second here, but a Python-level fork/exec ten times over is
+    # slow enough under coverage on a busy CI runner to reach the 15 second
+    # default, which it did.
+    __timeout__ = 60
+
+    WORKERS = 4
+    SPAWNS = 10
+
+    @greentest.skipOnWindows("Uses the POSIX fork/exec path")
+    def test_child_runs_none_of_the_parents_greenlets(self):
+        fileno, path = tempfile.mkstemp(prefix='gevent-subprocess-fork-child-')
+        os.close(fileno)
+        fileno = os.open(path, os.O_WRONLY | os.O_APPEND)
+        parent = os.getpid()
+        stop = []
+
+        def worker(n):
+            while not stop:
+                # Parked on a timer, not sitting in the callback queue.
+                gevent.sleep(0.002)
+                # Stands in for the application's side effect: in the process
+                # this came from, it was a write on a pooled TLS connection.
+                os.write(fileno, b'worker=%d pid=%d\n' % (n, os.getpid()))
+
+        workers = [gevent.spawn(worker, n) for n in range(self.WORKERS)]
+        try:
+            gevent.sleep(0.05)
+            for _ in range(self.SPAWNS):
+                subprocess.run([sys.executable, '-c', 'pass'], check=False)
+                gevent.sleep(0.01)
+        finally:
+            stop.append(1)
+            gevent.joinall(workers, timeout=10)
+            os.close(fileno)
+
+        try:
+            with open(path, encoding='ascii') as f:
+                strangers = sorted({
+                    int(line.rsplit('pid=', 1)[1])
+                    for line in f
+                } - {parent})
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(strangers, [])
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/tests/test__subprocess_fork_child_pipe.py
+++ b/src/gevent/tests/test__subprocess_fork_child_pipe.py
@@ -1,0 +1,96 @@
+"""
+A child of :mod:`gevent.subprocess` must not read another subprocess's pipe.
+
+The sibling of :mod:`gevent.tests.test__subprocess_fork_child_hub` with the
+theft running the other way: a copy of a parent greenlet resumed in the
+pre-exec child *reads*, and those bytes never reach the parent that was
+capturing them. On a TLS socket that is loud (``bad_record_mac``); a pipe has
+no MAC, so it is silent, and the capture is simply short --- in the worst case
+empty, which is how it was first seen in production.
+
+Every line the producers write is numbered and fixed-width, so a short read is
+arithmetic rather than judgement.
+"""
+from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
+
+import os
+import subprocess
+import sys
+
+import gevent
+
+from gevent import testing as greentest
+
+if hasattr(os, 'register_at_fork'):
+    # The least a handler can do and still yield.
+    os.register_at_fork(after_in_child=lambda: gevent.sleep(0))
+
+#: Lines per producer. Each is exactly ``LINE_LEN`` bytes with its newline.
+LINES = 1500
+LINE_LEN = 64
+EXPECTED = LINES * LINE_LEN
+
+#: Concurrent producers. One is enough to see the defect on about half the
+#: runs; every extra pipe is another chance for a fork window to land while a
+#: reader is parked on it, and at this many it showed up on every attempt.
+PRODUCERS = 16
+SPAWNS = 120
+
+PRODUCER = (
+    'import sys, time\n'
+    'for i in range(%d):\n'
+    '    sys.stdout.write("%%063d\\n" %% i)\n'
+    '    sys.stdout.flush()\n'
+    '    time.sleep(0.0005)\n'
+) % LINES
+
+
+class Test(greentest.TestCase):
+
+    # The producers alone take a couple of seconds, well past the default.
+    __timeout__ = 120
+
+    @greentest.skipOnWindows("Uses the POSIX fork/exec path")
+    def test_spawning_does_not_consume_another_pipe(self):
+        # Not `with`: all of them have to stay open together, for the whole
+        # length of the spawn storm. They are waited on and closed below.
+        victims = [
+            subprocess.Popen([sys.executable, '-c', PRODUCER], # pylint:disable=consider-using-with
+                             stdout=subprocess.PIPE)
+            for _ in range(PRODUCERS)
+        ]
+        chunks = [[] for _ in victims]
+
+        def consume(n):
+            read = victims[n].stdout.read
+            while True:
+                buf = read(4096)
+                if not buf:
+                    return
+                chunks[n].append(buf)
+
+        def spawn_storm():
+            for _ in range(SPAWNS):
+                subprocess.run([sys.executable, '-c', 'pass'], check=False)
+                gevent.sleep(0.005)
+
+        readers = [gevent.spawn(consume, n) for n in range(PRODUCERS)]
+        storm = gevent.spawn(spawn_storm)
+        try:
+            gevent.joinall([storm], timeout=180)
+            gevent.joinall(readers, timeout=180)
+        finally:
+            for victim in victims:
+                victim.wait()
+                victim.stdout.close()
+
+        short = [
+            (n, victims[n].returncode, EXPECTED - len(b''.join(chunks[n])))
+            for n in range(PRODUCERS)
+            if len(b''.join(chunks[n])) != EXPECTED or victims[n].returncode != 0
+        ]
+        self.assertEqual(short, [])
+
+
+if __name__ == '__main__':
+    greentest.main()


### PR DESCRIPTION
See failing tests:

https://github.com/ddorian/gevent/pull/3
https://github.com/ddorian/gevent/pull/4

Fixes #2196.


