### PR TITLE
gevent/threading.py: cancel the parent's queued greenlet switches in a forked child

### DIFF
--- a/docs/changes/2202.bugfix.rst
+++ b/docs/changes/2202.bugfix.rst
@@ -1,0 +1,11 @@
+Stop a forked child from running copies of the parent's greenlets.
+
+``_ForkHooks`` already made the copies appear stopped to :mod:`threading`, but
+every entry on the loop's callback queue was still a pending switch into one of
+them, and ``os.register_at_fork(after_in_child=)`` handlers yield under
+monkey-patching from inside ``fork()`` itself. A child that did nothing but
+``os._exit()`` ran four of the parent's greenlets on every one of 20 forks.
+
+Those switches are now cancelled. A greenlet parked on a timer or an ``io``
+watcher is resumed by the loop rather than by that queue, and this change does
+not reach it.

--- a/src/gevent/tests/test__fork_child_greenlets.py
+++ b/src/gevent/tests/test__fork_child_greenlets.py
@@ -1,0 +1,77 @@
+"""
+A forked child must not run copies of the parent's greenlets.
+
+Only the greenlet that forked survives a fork; everything else in the child's
+hub is a copy. ``os.register_at_fork(after_in_child=)`` handlers run inside
+``fork()`` before it returns, and under monkey-patching they yield, which hands
+the child's hub whatever the parent had queued.
+
+See :issue:`2202`.
+"""
+from gevent import monkey; monkey.patch_all() # pragma: testrunner-no-monkey-combine
+
+import os
+import tempfile
+
+import gevent
+
+from gevent import testing as greentest
+
+if hasattr(os, 'register_at_fork'):
+    # The least a handler can do and still yield.
+    os.register_at_fork(after_in_child=lambda: gevent.sleep(0))
+
+
+class Test(greentest.TestCase):
+
+    WORKERS = 4
+    FORKS = 10
+
+    @greentest.skipOnWindows("Uses fork")
+    def test_child_runs_none_of_the_parents_greenlets(self):
+        # A file with O_APPEND, not a list: the writer we are trying to catch
+        # is a different process, so its testimony cannot come back in the
+        # heap, and it would not survive an exec if it did.
+        fileno, path = tempfile.mkstemp(prefix='gevent-fork-child-greenlets-')
+        os.close(fileno)
+        fileno = os.open(path, os.O_WRONLY | os.O_APPEND)
+        parent = os.getpid()
+        stop = []
+
+        def worker(n):
+            while not stop:
+                # Stands in for the application's side effect.
+                os.write(fileno, b'worker=%d pid=%d\n' % (n, os.getpid()))
+                gevent.sleep(0)
+
+        workers = [gevent.spawn(worker, n) for n in range(self.WORKERS)]
+        try:
+            gevent.sleep(0.05)
+            for _ in range(self.FORKS):
+                pid = os.fork()
+                if pid == 0:
+                    # Do nothing whatsoever, and leave. Anything written by
+                    # this pid was written by a copy of somebody else's
+                    # greenlet, inside os.fork(), before it returned.
+                    os._exit(0)
+                os.waitpid(pid, 0)
+                gevent.sleep(0.01)
+        finally:
+            stop.append(1)
+            gevent.joinall(workers, timeout=10)
+            os.close(fileno)
+
+        try:
+            with open(path, encoding='ascii') as f:
+                strangers = sorted({
+                    int(line.rsplit('pid=', 1)[1])
+                    for line in f
+                } - {parent})
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(strangers, [])
+
+
+if __name__ == '__main__':
+    greentest.main()

--- a/src/gevent/threading.py
+++ b/src/gevent/threading.py
@@ -67,6 +67,7 @@ from gevent.thread import _make_thread_handle
 from gevent.thread import allocate_lock as _allocate_lock
 from gevent.thread import get_ident as _get_ident
 from gevent.hub import sleep as _sleep, getcurrent
+from gevent.hub import _get_hub as _get_hub_if_exists
 from gevent.lock import RLock
 
 
@@ -434,6 +435,29 @@ class _ForkHooks:
                 # over what gets to run.
                 handle._set_done(enter_hub=False)
 
+    @staticmethod
+    def _cancel_pending_switches_in_child():
+        # ``_stop_running_greenlets_in_child`` above only makes the copies
+        # look stopped. Every entry on the loop's callback queue is still a
+        # pending switch into one of them. Nothing in that queue can belong to
+        # the greenlet that forked: that one is running, not waiting to be
+        # switched to.
+        #
+        # Stop each callback rather than discarding the queue. A callback holds
+        # a reference the loop took in run_callback and hands back in
+        # _run_callbacks, so dropping the queue leaks one per entry and the
+        # child's loop never becomes unreferenced, so it hangs instead of
+        # exiting. A stopped callback is still popped and unref'd, just not run.
+        #
+        # See issue #2202.
+        hub = _get_hub_if_exists()
+        loop = getattr(hub, 'loop', None)
+        queue = getattr(loop, '_callbacks', None)
+        if queue is None:
+            return
+        # list(): we are mutating the entries as we go.
+        for cb in list(queue):
+            cb.stop()
 
     def after_fork_in_child(self):
         # We've already imported threading, which installed its "after" hook,
@@ -445,6 +469,7 @@ class _ForkHooks:
         assert get_ident() == self._before_fork_ident
 
         self._stop_running_greenlets_in_child()
+        self._cancel_pending_switches_in_child()
 
         main = __threading__._MainThread()
         main._ident = get_ident() # 3.13: reset to the greenlet version.


### PR DESCRIPTION
Fixes #2202