### PR TITLE
Fix AsyncResult accumulating traceback frames on repeated get()

### DIFF
--- a/docs/changes/1946.bugfix.rst
+++ b/docs/changes/1946.bugfix.rst
@@ -1,0 +1,5 @@
+Fix :class:`gevent.event.AsyncResult` re-raising an exception with a
+traceback that kept growing by the frames of every previous
+:meth:`~gevent.event.AsyncResult.get` call, instead of starting fresh
+from the traceback captured when :meth:`~gevent.event.AsyncResult.set_exception`
+was called.

--- a/src/gevent/_compat.py
+++ b/src/gevent/_compat.py
@@ -84,7 +84,7 @@ from abc import ABC # pylint:disable=unused-import
 ## Exceptions
 
 def reraise(t, value, tb=None): # pylint:disable=unused-argument
-    if value.__traceback__ is not tb and tb is not None:
+    if value.__traceback__ is not tb:
         raise value.with_traceback(tb)
     raise value
 def exc_clear():

--- a/src/gevent/tests/test__event.py
+++ b/src/gevent/tests/test__event.py
@@ -1,3 +1,4 @@
+import traceback
 import weakref
 
 import gevent
@@ -105,6 +106,28 @@ class TestAsyncResult(greentest.TestCase):
         e.set_exception(obj)
         gevent.sleep(0)
         self.assertEqual(log, [('caught', obj)])
+
+    def test_get_repeated_does_not_accumulate_traceback(self):
+        # https://github.com/gevent/gevent/issues/1946
+        # Getting an AsyncResult that holds an exception, repeatedly,
+        # used to keep extending the exception's traceback with the
+        # frames of every previous ``get()`` call instead of starting
+        # fresh from the traceback captured at ``set_exception`` time.
+        ar = AsyncResult()
+        ar.set_exception(MyException())
+
+        tb_lengths = []
+        for _ in range(3):
+            try:
+                ar.get()
+            except MyException as exc:
+                # Read the traceback length here, inside the ``except``
+                # clause: ``self.assertRaises`` strips ``__traceback__``
+                # from the exception it stores to avoid a reference
+                # cycle, which would hide this regression.
+                tb_lengths.append(len(traceback.extract_tb(exc.__traceback__)))
+
+        self.assertEqual(tb_lengths, [tb_lengths[0]] * len(tb_lengths))
 
     def test_set(self):
         event1 = AsyncResult()


### PR DESCRIPTION
Fixes #1946

`reraise()` only reset an exception's `__traceback__` when a traceback was available to reset it to (`tb is not None`). When `AsyncResult.set_exception()` is called without an original traceback (`exc_info[2]` is `None`, e.g. `set_exception(Exception())`), `reraise()` fell through to a bare `raise value`, which does not clear a stale `__traceback__` left over from a previous raise of the same exception instance. Each subsequent `get()` therefore kept appending frames from every previous call instead of starting fresh — matching the accumulating traceback shown in the issue.

`gevent.testing.six.reraise` already has the correct, unconditional check (`if value.__traceback__ is not tb:`); this ports the same fix to `gevent._compat.reraise`, which is what `AsyncResult` actually uses.

Added a regression test (`test_get_repeated_does_not_accumulate_traceback`) and a `docs/changes/1946.bugfix.rst` towncrier fragment. Verified against the real compiled package (26.8.0, cp312/win_amd64) by overlaying the patched files: `gevent.tests.test__event` passes 46/46, and reverting the fix reproduces the reported growth (5, 10, 15, 20 frames) while the fix keeps it constant.