### PR TITLE
Report the full binary mode string from FileObjectPosix

### DIFF
--- a/src/gevent/_fileobjectposix.py
+++ b/src/gevent/_fileobjectposix.py
@@ -45,7 +45,11 @@ class GreenFileDescriptorIO(RawIOBase):
         self._closefd = closefd
         self._fileno = fileno
         self.name = fileno
-        self.mode = open_descriptor.fileio_mode
+        # Use the full mode (including the 't'/'b' suffix), matching what
+        # io.FileIO itself reports; open_descriptor.fileio_mode is the
+        # stripped-down string meant only for constructing the raw FileIO,
+        # not for user-facing introspection.
+        self.mode = open_descriptor.mode
         make_nonblocking(fileno)
         readable = open_descriptor.can_read
         writable = open_descriptor.can_write

--- a/src/gevent/tests/test__fileobject.py
+++ b/src/gevent/tests/test__fileobject.py
@@ -469,6 +469,19 @@ class TestFileObjectPosix(ConcurrentFileObjectMixin, # pylint:disable=too-many-a
     def _getTargetClass(self):
         return fileobject.FileObjectPosix
 
+    def test_mode_includes_binary_suffix(self):
+        # https://github.com/gevent/gevent/issues/2039
+        # Constructing with an explicit 'wb'/'rb' mode should report
+        # that full mode back, matching what io.FileIO does, instead of
+        # silently dropping the 'b' and reporting just 'w'/'r'.
+        r, w = self._pipe()
+
+        writer = self._makeOne(w, 'wb', close=False)
+        self.assertEqual(writer.mode, 'wb')
+
+        reader = self._makeOne(r, 'rb', close=False)
+        self.assertEqual(reader.mode, 'rb')
+
     def test_seek_raises_ioerror(self):
         # https://github.com/gevent/gevent/issues/1323
 


### PR DESCRIPTION
Fixes #2039

`GreenFileDescriptorIO.mode` was being set from `open_descriptor.fileio_mode`, which is the mode string stripped down to just the read/write/append/create flag, meant for constructing the underlying `io.FileIO` object internally. That's not what should be surfaced to callers, since real `io.FileIO` includes the `b`/`t` suffix in its own `mode` attribute.

Under monkey-patched `subprocess.Popen`, this meant `process.stdin.mode` reported `'w'` even when the pipe was opened binary and only accepted bytes, which is exactly what the linked issue describes, and matches the `TypeError: a bytes-like object is required, not 'str'` from trying to `.write()` a str to it based on trusting `.mode`.

`OpenDescriptor` already computes the correct value (`fileio_mode` plus the `t`/`b` suffix) under its own `mode` attribute, this just uses that instead.

Added `test_mode_includes_binary_suffix` to `TestFileObjectPosix`, checking both the binary and text-mode-off case report `wb`/`rb` correctly. Confirmed it fails with the old `'w'`/`'r'` values by reverting just the source change, and passes with the fix. Ran the full `test__fileobject.py` (79 tests) and `test__subprocess.py` (36 tests) suites afterward with no other failures, and `pylint` on the touched source file scores 10.00/10.